### PR TITLE
feat: LLM-powered false-positive verification pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,7 +213,7 @@ __marimo__/
 .nikui*
 nikui_results/
 
-docs/plans
+# docs/plans — previously ignored, now tracked for feature design docs
 node_modules/
 .husky/_/
 

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -86,6 +86,24 @@ class Settings(BaseSettings):
         default="", description="Dashboard basic auth password"
     )
 
+    # FP Verification Configuration
+    fp_verification_enabled: bool = Field(
+        default=False,
+        description="Enable LLM-powered false-positive verification pass",
+    )
+    fp_verification_model: str = Field(
+        default="haiku",
+        description="Model for FP verification (short name or provider/model)",
+    )
+    fp_verification_max_concurrent: int = Field(
+        default=5,
+        description="Max concurrent FP verification calls",
+    )
+    fp_audit_log_path: str = Field(
+        default="/var/log/baloo/fp-audit.jsonl",
+        description="Path for FP verification audit log (JSONL). Empty to disable.",
+    )
+
     # Fidelity Report Configuration
     fidelity_enabled: bool = Field(
         default=True,

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -510,21 +510,31 @@ async def process_pr_review(
 
                 verifier = FPVerifier()
                 fp_result = await verifier.verify(review_result.comments, pr_context)
+                # Build a fresh metadata dict rather than mutating the agent
+                # result's dict via aliasing — keeps provenance explicit and
+                # avoids breakage if ReviewResult ever copies its metadata.
+                merged_metadata = {
+                    **review_result.metadata,
+                    "fp_verification": {
+                        "total": fp_result.stats.total_verified,
+                        "kept": fp_result.stats.kept,
+                        "rejected": fp_result.stats.rejected,
+                        "errors": fp_result.stats.errors,
+                        "cost_usd": fp_result.stats.total_cost_usd,
+                        "duration_seconds": fp_result.stats.duration_seconds,
+                    },
+                }
                 review_result = ReviewResult(
                     summary=review_result.summary,
                     comments=fp_result.verified,
                     approve=review_result.approve,
                     request_changes=review_result.request_changes,
-                    metadata=review_result.metadata,
+                    metadata=merged_metadata,
                 )
-                review_result.metadata["fp_verification"] = {
-                    "total": fp_result.stats.total_verified,
-                    "kept": fp_result.stats.kept,
-                    "rejected": fp_result.stats.rejected,
-                    "errors": fp_result.stats.errors,
-                    "cost_usd": fp_result.stats.total_cost_usd,
-                    "duration_seconds": fp_result.stats.duration_seconds,
-                }
+                # Keep `agent_metadata` in sync so the final ReviewResult
+                # built below (which re-uses agent_metadata) still carries
+                # the fp_verification stats forward to the DB row.
+                agent_metadata = merged_metadata
                 logger.info(
                     "FP verification: %d/%d findings kept (rejected %d)",
                     fp_result.stats.kept,

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -504,8 +504,36 @@ async def process_pr_review(
             agent_metadata = agent_result.metadata
             review_result = agent_result
 
+            # FP verification pass (LLM-powered, before heuristic filter)
+            if settings.fp_verification_enabled and review_result.comments:
+                from baloo.processor.fp_verifier import FPVerifier
+
+                verifier = FPVerifier()
+                fp_result = await verifier.verify(review_result.comments, pr_context)
+                review_result = ReviewResult(
+                    summary=review_result.summary,
+                    comments=fp_result.verified,
+                    approve=review_result.approve,
+                    request_changes=review_result.request_changes,
+                    metadata=review_result.metadata,
+                )
+                review_result.metadata["fp_verification"] = {
+                    "total": fp_result.stats.total_verified,
+                    "kept": fp_result.stats.kept,
+                    "rejected": fp_result.stats.rejected,
+                    "errors": fp_result.stats.errors,
+                    "cost_usd": fp_result.stats.total_cost_usd,
+                    "duration_seconds": fp_result.stats.duration_seconds,
+                }
+                logger.info(
+                    "FP verification: %d/%d findings kept (rejected %d)",
+                    fp_result.stats.kept,
+                    fp_result.stats.total_verified,
+                    fp_result.stats.rejected,
+                )
+
             findings_filter = FindingsFilter()
-            filtered_comments = findings_filter.filter_findings(agent_result.comments)
+            filtered_comments = findings_filter.filter_findings(review_result.comments)
 
             thread_lookup = _build_thread_lookup(pr_context.discussion_threads)
             fresh_comments: list[ReviewComment] = []

--- a/baloo/processor/fp_prompts.py
+++ b/baloo/processor/fp_prompts.py
@@ -91,13 +91,23 @@ def extract_diff_for_file(full_diff: str, file_path: str) -> str:
     result: list[str] = []
     capturing = False
 
+    # Exact-boundary match: diff headers are "diff --git a/<path> b/<path>",
+    # so look for the full tokens to avoid suffix-substring false matches
+    # (e.g. "lib/auth.py" matching "tests/lib/auth.py").
+    a_token = f"a/{file_path}"
+    b_token = f"b/{file_path}"
+
+    def _header_is_for_file(header: str) -> bool:
+        # Header form: diff --git a/<pathA> b/<pathB>.  For renames, pathA
+        # and pathB differ, so match if either side's token is present.
+        parts = header.split()
+        return a_token in parts or b_token in parts
+
     for line in lines:
         if line.startswith("diff --git"):
-            # Check if this diff block is for our file
             if capturing:
                 break  # We were capturing and hit a new file — done
-            # Match both a/path and b/path
-            capturing = file_path in line
+            capturing = _header_is_for_file(line)
             if capturing:
                 result.append(line)
         elif capturing:

--- a/baloo/processor/fp_prompts.py
+++ b/baloo/processor/fp_prompts.py
@@ -1,0 +1,106 @@
+"""Prompt templates for the false-positive verification pass."""
+
+from __future__ import annotations
+
+from baloo.github.models import ReviewComment
+
+FP_SYSTEM_PROMPT = """\
+You are a precise code review verifier. Your job is to check whether a code \
+review finding is a real issue or a false positive.
+
+You will receive:
+1. A finding (title, severity, description, recommendation)
+2. The surrounding code context (diff hunk and/or file content)
+
+Rules:
+- A finding is a FALSE POSITIVE if:
+  - The flagged code doesn't actually have the described problem
+  - The issue is already handled elsewhere in the visible context
+  - The finding misreads the code (e.g., claims string concat SQL but it's parameterized)
+  - The finding flags something that doesn't exist in the actual code
+  - The description contradicts what the code actually does
+
+- A finding is REAL if:
+  - The described problem genuinely exists in the code
+  - Even if minor, the finding accurately describes a real concern
+
+Be strict: only mark as false positive if you're confident the finding is wrong.
+When in doubt, mark as real.
+
+Respond with ONLY a JSON object: {"verdict": "real" or "fp", "reason": "one concise sentence"}
+"""
+
+
+def build_verification_prompt(
+    comment: ReviewComment,
+    diff_context: str,
+    file_context: str | None = None,
+) -> str:
+    """Build a verification prompt for a single finding.
+
+    Args:
+        comment: The review finding to verify.
+        diff_context: The diff hunk(s) for the file.
+        file_context: Optional full file content around the flagged line.
+
+    Returns:
+        Prompt string for the verification model.
+    """
+    parts = [
+        f"## Finding to verify",
+        f"**File**: {comment.path}, line {comment.line}",
+        f"**Severity**: {comment.severity}",
+        f"**Category**: {comment.category}",
+        "",
+        comment.body,
+        "",
+    ]
+
+    if file_context:
+        parts.extend([
+            "## File context (around flagged line)",
+            "```",
+            file_context,
+            "```",
+            "",
+        ])
+
+    parts.extend([
+        "## Diff",
+        "```diff",
+        diff_context,
+        "```",
+        "",
+        'Is this finding real or a false positive? Respond with JSON: {"verdict": "real"|"fp", "reason": "..."}',
+    ])
+
+    return "\n".join(parts)
+
+
+def extract_diff_for_file(full_diff: str, file_path: str) -> str:
+    """Extract the diff hunk(s) for a specific file from the full PR diff.
+
+    Args:
+        full_diff: The complete PR diff.
+        file_path: Path of the file to extract.
+
+    Returns:
+        Diff section for the file, or empty string if not found.
+    """
+    lines = full_diff.split("\n")
+    result: list[str] = []
+    capturing = False
+
+    for line in lines:
+        if line.startswith("diff --git"):
+            # Check if this diff block is for our file
+            if capturing:
+                break  # We were capturing and hit a new file — done
+            # Match both a/path and b/path
+            capturing = file_path in line
+            if capturing:
+                result.append(line)
+        elif capturing:
+            result.append(line)
+
+    return "\n".join(result)

--- a/baloo/processor/fp_prompts.py
+++ b/baloo/processor/fp_prompts.py
@@ -47,7 +47,7 @@ def build_verification_prompt(
         Prompt string for the verification model.
     """
     parts = [
-        f"## Finding to verify",
+        "## Finding to verify",
         f"**File**: {comment.path}, line {comment.line}",
         f"**Severity**: {comment.severity}",
         f"**Category**: {comment.category}",
@@ -57,22 +57,26 @@ def build_verification_prompt(
     ]
 
     if file_context:
-        parts.extend([
-            "## File context (around flagged line)",
-            "```",
-            file_context,
+        parts.extend(
+            [
+                "## File context (around flagged line)",
+                "```",
+                file_context,
+                "```",
+                "",
+            ]
+        )
+
+    parts.extend(
+        [
+            "## Diff",
+            "```diff",
+            diff_context,
             "```",
             "",
-        ])
-
-    parts.extend([
-        "## Diff",
-        "```diff",
-        diff_context,
-        "```",
-        "",
-        'Is this finding real or a false positive? Respond with JSON: {"verdict": "real"|"fp", "reason": "..."}',
-    ])
+            'Is this finding real or a false positive? Respond with JSON: {"verdict": "real"|"fp", "reason": "..."}',
+        ]
+    )
 
     return "\n".join(parts)
 

--- a/baloo/processor/fp_verifier.py
+++ b/baloo/processor/fp_verifier.py
@@ -131,7 +131,22 @@ class FPVerifier:
                     res,
                 )
                 result.verified.append(comment)
+                # The finding is kept and passed downstream, so it counts
+                # toward `kept`. `errors` is an orthogonal counter tracking
+                # how many were kept via the error path vs. a clean verdict.
+                stats.kept += 1
                 stats.errors += 1
+                # Record the error in the audit log so systemic verification
+                # failures are observable (otherwise every finding appears
+                # "correctly kept" while the pass is silently a no-op).
+                self._write_audit_entry(
+                    comment=comment,
+                    verdict="error",
+                    reason=str(res),
+                    model=self.model,
+                    cost_usd=0.0,
+                    pr_context=pr_context,
+                )
                 continue
 
             verified_comment, verdict_data = res
@@ -176,11 +191,11 @@ class FPVerifier:
         result.stats = stats
 
         logger.info(
-            "FP verification complete: %d verified, %d rejected, %d errors, "
-            "cost=$%.4f, duration=%.1fs",
+            "FP verification complete: %d kept (of which %d via error fail-open), "
+            "%d rejected, cost=$%.4f, duration=%.1fs",
             stats.kept,
-            stats.rejected,
             stats.errors,
+            stats.rejected,
             stats.total_cost_usd,
             stats.duration_seconds,
         )
@@ -212,7 +227,12 @@ class FPVerifier:
             thinking_level="off",
         )
         options.system_prompt = FP_SYSTEM_PROMPT
-        options.max_turns = 1  # Single-turn, no tool use
+        # The PI subprocess is always launched with read-only tools enabled
+        # (see pi_runtime), so if the model chooses to call `read`/`grep` to
+        # fetch more context, we must leave room for a tool-use turn plus a
+        # final answer turn — otherwise the session is aborted and we fall
+        # through to the "unparseable response" path with a misleading reason.
+        options.max_turns = 3
 
         agent = _FPVerifierAgent(options)
 
@@ -235,13 +255,21 @@ class FPVerifier:
                     "model": model_used,
                 }
 
-            # Could not parse response — fail-open
+            # Could not parse response — fail-open.  Distinguish the
+            # common "empty response" case (usually a tool-use cycle that
+            # hit max_turns) from a genuine format error so the audit log
+            # is actionable.
+            if not structured:
+                reason = "empty response (possible tool-use abort)"
+            else:
+                reason = "unparseable response"
             logger.warning(
-                "FP verifier returned unparseable response for %s:%s — keeping",
+                "FP verifier got %s for %s:%s — keeping",
+                reason,
                 comment.path,
                 comment.line,
             )
-            return comment, {"verdict": "real", "reason": "unparseable response", "cost_usd": cost, "model": model_used}
+            return comment, {"verdict": "real", "reason": reason, "cost_usd": cost, "model": model_used}
 
         except Exception as exc:
             logger.warning(

--- a/baloo/processor/fp_verifier.py
+++ b/baloo/processor/fp_verifier.py
@@ -1,0 +1,304 @@
+"""LLM-powered false-positive verification for review findings.
+
+After the main review agent produces findings, this module re-examines
+each one in isolation using a cheap/fast model to classify it as a real
+issue or a false positive.  FPs are dropped before posting.
+
+Design: fail-open — if verification errors, the finding is kept.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from baloo.agent.config import get_agent_options
+from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions, _extract_json_from_text
+from baloo.config.settings import get_settings
+from baloo.github.models import PRContext, ReviewComment
+from baloo.processor.fp_prompts import (
+    FP_SYSTEM_PROMPT,
+    build_verification_prompt,
+    extract_diff_for_file,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FPRejection:
+    """A finding that was classified as a false positive."""
+
+    comment: ReviewComment
+    reason: str
+    model: str
+    cost_usd: float = 0.0
+
+
+@dataclass
+class FPStats:
+    """Aggregate stats for the verification pass."""
+
+    total_verified: int = 0
+    kept: int = 0
+    rejected: int = 0
+    errors: int = 0
+    total_cost_usd: float = 0.0
+    duration_seconds: float = 0.0
+
+
+@dataclass
+class FPVerificationResult:
+    """Result of the FP verification pass."""
+
+    verified: list[ReviewComment] = field(default_factory=list)
+    rejected: list[FPRejection] = field(default_factory=list)
+    stats: FPStats = field(default_factory=FPStats)
+
+
+class _FPVerifierAgent(PIAgentBase):
+    """Thin PI agent for single-turn FP verification calls."""
+
+    def __init__(self, options: PIAgentOptions):
+        super().__init__(options)
+        self.agent_name = "FPVerifier"
+
+
+class FPVerifier:
+    """Verify review findings and drop false positives.
+
+    Each finding is checked independently by a cheap model.  Verifications
+    run concurrently up to ``max_concurrent``.
+    """
+
+    def __init__(
+        self,
+        model: str | None = None,
+        max_concurrent: int | None = None,
+    ):
+        settings = get_settings()
+        self.model = model or settings.fp_verification_model
+        self.max_concurrent = max_concurrent or settings.fp_verification_max_concurrent
+        self.audit_log_path = settings.fp_audit_log_path
+
+    async def verify(
+        self,
+        comments: list[ReviewComment],
+        pr_context: PRContext,
+    ) -> FPVerificationResult:
+        """Verify a list of findings and return filtered results.
+
+        Args:
+            comments: Findings from the review agent.
+            pr_context: PR context (for diff and metadata).
+
+        Returns:
+            FPVerificationResult with verified (kept) and rejected findings.
+        """
+        if not comments:
+            return FPVerificationResult()
+
+        start_time = time.time()
+        semaphore = asyncio.Semaphore(self.max_concurrent)
+
+        async def _verify_one(comment: ReviewComment) -> tuple[ReviewComment, dict]:
+            async with semaphore:
+                return await self._verify_single(comment, pr_context)
+
+        # Run all verifications concurrently
+        tasks = [_verify_one(c) for c in comments]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Collect results
+        result = FPVerificationResult()
+        stats = FPStats(total_verified=len(comments))
+
+        for i, res in enumerate(results):
+            comment = comments[i]
+
+            if isinstance(res, Exception):
+                # Fail-open: keep the finding on error
+                logger.warning(
+                    "FP verification error for %s:%s — keeping finding: %s",
+                    comment.path,
+                    comment.line,
+                    res,
+                )
+                result.verified.append(comment)
+                stats.errors += 1
+                continue
+
+            verified_comment, verdict_data = res
+            verdict = verdict_data.get("verdict", "real")
+            reason = verdict_data.get("reason", "no reason given")
+            cost = verdict_data.get("cost_usd", 0.0)
+            model_used = verdict_data.get("model", self.model)
+
+            stats.total_cost_usd += cost
+
+            if verdict == "fp":
+                rejection = FPRejection(
+                    comment=comment,
+                    reason=reason,
+                    model=model_used,
+                    cost_usd=cost,
+                )
+                result.rejected.append(rejection)
+                stats.rejected += 1
+                logger.info(
+                    "FP rejected: %s:%s [%s] — %s",
+                    comment.path,
+                    comment.line,
+                    comment.severity,
+                    reason,
+                )
+            else:
+                result.verified.append(comment)
+                stats.kept += 1
+
+            # Write audit log entry
+            self._write_audit_entry(
+                comment=comment,
+                verdict=verdict,
+                reason=reason,
+                model=model_used,
+                cost_usd=cost,
+                pr_context=pr_context,
+            )
+
+        stats.duration_seconds = time.time() - start_time
+        result.stats = stats
+
+        logger.info(
+            "FP verification complete: %d verified, %d rejected, %d errors, "
+            "cost=$%.4f, duration=%.1fs",
+            stats.kept,
+            stats.rejected,
+            stats.errors,
+            stats.total_cost_usd,
+            stats.duration_seconds,
+        )
+
+        return result
+
+    async def _verify_single(
+        self,
+        comment: ReviewComment,
+        pr_context: PRContext,
+    ) -> tuple[ReviewComment, dict]:
+        """Verify a single finding.
+
+        Returns:
+            Tuple of (original comment, verdict dict with keys: verdict, reason, cost_usd, model).
+        """
+        # Build context for this finding
+        diff_context = extract_diff_for_file(pr_context.diff, comment.path)
+
+        prompt = build_verification_prompt(
+            comment=comment,
+            diff_context=diff_context,
+            file_context=None,  # Start with diff only; add file reads later if needed
+        )
+
+        # Get agent options for the cheap model
+        options = get_agent_options(
+            model=self.model,
+            thinking_level="off",
+        )
+        options.system_prompt = FP_SYSTEM_PROMPT
+        options.max_turns = 1  # Single-turn, no tool use
+
+        agent = _FPVerifierAgent(options)
+
+        try:
+            structured, metadata = await agent.run_query(prompt)
+
+            cost = metadata.get("cost_usd", 0.0)
+            model_used = metadata.get("model", self.model)
+
+            if structured and isinstance(structured, dict):
+                verdict = structured.get("verdict", "real")
+                reason = structured.get("reason", "no reason given")
+                # Normalize verdict
+                if verdict not in ("real", "fp"):
+                    verdict = "real"
+                return comment, {
+                    "verdict": verdict,
+                    "reason": reason,
+                    "cost_usd": cost,
+                    "model": model_used,
+                }
+
+            # Could not parse response — fail-open
+            logger.warning(
+                "FP verifier returned unparseable response for %s:%s — keeping",
+                comment.path,
+                comment.line,
+            )
+            return comment, {"verdict": "real", "reason": "unparseable response", "cost_usd": cost, "model": model_used}
+
+        except Exception as exc:
+            logger.warning(
+                "FP verification failed for %s:%s: %s",
+                comment.path,
+                comment.line,
+                exc,
+            )
+            raise
+
+    def _write_audit_entry(
+        self,
+        comment: ReviewComment,
+        verdict: str,
+        reason: str,
+        model: str,
+        cost_usd: float,
+        pr_context: PRContext,
+    ) -> None:
+        """Append a JSONL audit log entry."""
+        if not self.audit_log_path:
+            return
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "repo": pr_context.repo_full_name,
+            "pr_number": pr_context.pr_number,
+            "commit_sha": getattr(pr_context, "head_sha", None),
+            "finding": {
+                "file": comment.path,
+                "line": comment.line,
+                "severity": comment.severity,
+                "category": comment.category,
+                "title": _extract_title(comment.body),
+            },
+            "verdict": verdict,
+            "reason": reason,
+            "model": model,
+            "review_model": get_settings().agent_model,
+            "cost_usd": cost_usd,
+        }
+
+        try:
+            path = Path(self.audit_log_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+        except Exception as exc:
+            logger.warning("Failed to write FP audit log: %s", exc)
+
+
+def _extract_title(body: str) -> str:
+    """Extract the title from a formatted comment body."""
+    for line in body.split("\n"):
+        line = line.strip()
+        if line.startswith("**") and line.endswith("**"):
+            return line.strip("*").strip()
+        if line and not line.startswith("**Category") and not line.startswith("**Severity"):
+            return line.strip("*").strip()[:100]
+    return ""

--- a/baloo/processor/fp_verifier.py
+++ b/baloo/processor/fp_verifier.py
@@ -16,10 +16,9 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 from baloo.agent.config import get_agent_options
-from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions, _extract_json_from_text
+from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions
 from baloo.config.settings import get_settings
 from baloo.github.models import PRContext, ReviewComment
 from baloo.processor.fp_prompts import (
@@ -269,7 +268,12 @@ class FPVerifier:
                 comment.path,
                 comment.line,
             )
-            return comment, {"verdict": "real", "reason": reason, "cost_usd": cost, "model": model_used}
+            return comment, {
+                "verdict": "real",
+                "reason": reason,
+                "cost_usd": cost,
+                "model": model_used,
+            }
 
         except Exception as exc:
             logger.warning(

--- a/docs/plans/fp-reduction-pass.md
+++ b/docs/plans/fp-reduction-pass.md
@@ -1,0 +1,174 @@
+# FP Reduction Pass — Design Plan
+
+## Problem
+
+Baloo produces false positives that erode developer trust. The current
+`FindingsFilter` uses regex heuristics (hedging language, short comments,
+severity threshold) but can't reason about whether a finding is actually
+correct. We need an LLM-powered verification step.
+
+## Approach
+
+After the review agent produces findings, run a **second lightweight pass**
+that re-examines each finding in isolation. A cheap/fast model (Haiku or
+Flash) reads:
+- The finding (title, description, severity, recommendation)
+- The actual file content around the flagged line (±30 lines of context)
+- The diff hunk for that file
+
+It then classifies: **real issue** vs **false positive**, with a one-line
+reason. False positives are dropped before posting.
+
+## Architecture
+
+```
+review_pr()
+  │
+  ▼
+raw findings (N comments)
+  │
+  ▼
+┌─────────────────────────┐
+│  FPVerifier.verify()    │  ← NEW
+│  For each finding:      │
+│   • build small prompt  │
+│   • call cheap model    │
+│   • classify real/fp    │
+│  Return filtered list   │
+└─────────────────────────┘
+  │
+  ▼
+FindingsFilter (existing severity/heuristic filter)
+  │
+  ▼
+post to GitHub
+```
+
+## Components
+
+### 1. `baloo/processor/fp_verifier.py` (new)
+
+```python
+class FPVerifier:
+    """LLM-powered false-positive verification."""
+
+    def __init__(self, model: str = "haiku", max_concurrent: int = 5):
+        ...
+
+    async def verify(
+        self,
+        comments: list[ReviewComment],
+        pr_context: PRContext,
+    ) -> FPVerificationResult:
+        ...
+```
+
+**Key decisions:**
+- Uses `PIAgentBase` with read-only tools (same RPC subprocess pattern)
+- Runs verifications concurrently with `asyncio.gather` (bounded by semaphore)
+- Each verification is a single-turn prompt — no tool use needed, just reasoning
+- System prompt is minimal: "You are a code review verifier..."
+- Uses `thinking_level="off"` for speed
+
+**Verification prompt per finding:**
+```
+Finding: [title] ([severity])
+File: path/to/file.py, line 42
+Description: [description]
+Recommendation: [recommendation]
+
+File context (lines 12-72):
+[actual file content from pr_context or diff]
+
+Diff hunk:
+[relevant diff section]
+
+Is this finding a real issue or a false positive?
+Respond with JSON: {"verdict": "real"|"fp", "reason": "one line explanation"}
+```
+
+**Return type:**
+```python
+@dataclass
+class FPVerificationResult:
+    verified: list[ReviewComment]     # kept findings
+    rejected: list[FPRejection]       # dropped findings + reasons
+    stats: FPStats                    # counts, cost, duration
+```
+
+### 2. `baloo/processor/fp_prompts.py` (new)
+
+Prompt templates for the verification pass, kept separate from review prompts.
+
+### 3. Settings additions (`settings.py`)
+
+```python
+# FP Verification
+fp_verification_enabled: bool = True
+fp_verification_model: str = "haiku"       # cheap model short name
+fp_verification_max_concurrent: int = 5    # parallel verifications
+```
+
+### 4. Integration point (`webhook_handler.py`)
+
+In `process_pr_review()`, between `agent.review_pr()` and `FindingsFilter`:
+
+```python
+# FP verification pass (before heuristic filter)
+if settings.fp_verification_enabled and review_result.comments:
+    from baloo.processor.fp_verifier import FPVerifier
+    verifier = FPVerifier(model=settings.fp_verification_model)
+    fp_result = await verifier.verify(review_result.comments, pr_context)
+    review_result.comments = fp_result.verified
+    # Log rejected findings
+    for r in fp_result.rejected:
+        logger.info("FP rejected: %s:%s - %s", r.path, r.line, r.reason)
+```
+
+### 5. DB tracking (optional, if dashboard enabled)
+
+Add `fp_rejected_count` and `fp_verification_cost_usd` to the review
+completion data so the dashboard can show FP reduction effectiveness.
+
+## Cost estimate
+
+Per finding verification:
+- Haiku: ~500 input tokens + ~50 output tokens ≈ $0.0003
+- Flash: ~500 input tokens + ~50 output tokens ≈ $0.0001
+
+Typical review with 5 findings: **$0.0005–$0.0015** extra.
+Negligible compared to the $0.02–$0.10 main review cost.
+
+## Testing
+
+- `tests/test_fp_verifier.py` — unit tests with mocked PI responses
+- `tests/test_fp_prompts.py` — prompt construction tests
+- `tests/test_fp_integration.py` — end-to-end with mock webhook
+
+Key test cases:
+1. Real bug survives verification
+2. Obvious FP (flagging code that exists elsewhere) gets dropped
+3. Verification timeout/error → finding is kept (fail-open)
+4. Empty findings list → no verification calls
+5. Cost/stats are tracked correctly
+
+## Rollout
+
+1. Ship behind `fp_verification_enabled=false`
+2. Enable on staging, compare before/after on real PRs
+3. Log all rejections to tune the verification prompt
+4. Enable in production once rejection accuracy is validated
+
+## Open questions
+
+- **Fail-open vs fail-closed**: If verification errors, keep or drop the
+  finding? Plan: **fail-open** (keep the finding) — better to over-report
+  than miss a real issue.
+- **Batch vs individual**: Could batch all findings into one prompt to save
+  on per-call overhead. Tradeoff: individual is more reliable (no
+  cross-contamination), batch is cheaper. Start with individual, optimize
+  later if cost matters.
+- **Context source**: Use raw diff hunks or fetch full file content? Diff
+  hunks are already in `pr_context.diff`. For more context, the verifier
+  could use PI's `read` tool — but that adds latency. Start with diff
+  context, add file reads if accuracy needs it.

--- a/docs/plans/fp-reduction-pass.md
+++ b/docs/plans/fp-reduction-pass.md
@@ -159,6 +159,42 @@ Key test cases:
 3. Log all rejections to tune the verification prompt
 4. Enable in production once rejection accuracy is validated
 
+## Audit Log
+
+Every FP rejection is logged to a structured JSON-lines file so we can
+review accuracy offline and tune prompts.
+
+**File**: `/var/log/baloo/fp-audit.jsonl` (configurable via `fp_audit_log_path`)
+
+**Each line:**
+```json
+{
+  "timestamp": "2026-04-14T13:00:00Z",
+  "repo": "org/repo",
+  "pr_number": 42,
+  "commit_sha": "abc123",
+  "finding": {
+    "file": "src/auth.py",
+    "line": 55,
+    "severity": "HIGH",
+    "category": "Security",
+    "title": "SQL injection risk",
+    "description": "..."
+  },
+  "verdict": "fp",
+  "reason": "The query uses parameterized bindings, not string concat",
+  "model": "claude-haiku-4-5-20251001",
+  "review_model": "claude-sonnet-4-6",
+  "cost_usd": 0.0003
+}
+```
+
+Also logs `"verdict": "real"` entries so we have the full picture.
+
+If database is enabled, a summary (rejected count, cost) is stored in the
+review record. The full audit trail stays in the log file — cheap, greppable,
+easy to pipe into analysis scripts.
+
 ## Open questions
 
 - **Fail-open vs fail-closed**: If verification errors, keep or drop the

--- a/tests/processor/test_fp_verifier.py
+++ b/tests/processor/test_fp_verifier.py
@@ -118,6 +118,37 @@ class TestFPPrompts:
     def test_extract_diff_for_file_empty_diff(self):
         assert extract_diff_for_file("", "anything.py") == ""
 
+    def test_extract_diff_for_file_suffix_path_not_matched(self):
+        # Asking for "lib/auth.py" must not capture "tests/lib/auth.py"
+        diff = (
+            "diff --git a/tests/lib/auth.py b/tests/lib/auth.py\n"
+            "--- a/tests/lib/auth.py\n"
+            "+++ b/tests/lib/auth.py\n"
+            "@@ -1,1 +1,2 @@\n"
+            "+test_line\n"
+            "diff --git a/other.py b/other.py\n"
+            "+other\n"
+        )
+        # No real lib/auth.py block exists — should return empty, not the tests/ one
+        result = extract_diff_for_file(diff, "lib/auth.py")
+        assert result == ""
+
+    def test_extract_diff_for_file_rename_header(self):
+        # Rename diffs still use `a/<old> b/<new>`; extracting by the new
+        # path should find the block when `b/<path>` appears in the header.
+        diff = (
+            "diff --git a/old.py b/new.py\n"
+            "similarity index 90%\n"
+            "rename from old.py\n"
+            "rename to new.py\n"
+            "--- a/old.py\n"
+            "+++ b/new.py\n"
+            "@@ -1,1 +1,1 @@\n"
+            "+renamed\n"
+        )
+        result = extract_diff_for_file(diff, "new.py")
+        assert "+renamed" in result
+
 
 # ---------------------------------------------------------------------------
 # Verifier tests
@@ -173,7 +204,7 @@ class TestFPVerifier:
 
     @pytest.mark.asyncio
     async def test_verification_error_keeps_finding(self):
-        """Fail-open: errors should keep the finding."""
+        """Fail-open: errors keep the finding, count it under kept, and log errors."""
         verifier = FPVerifier()
         comment = _make_comment()
         pr_ctx = _make_pr_context()
@@ -184,6 +215,35 @@ class TestFPVerifier:
         assert len(result.verified) == 1
         assert len(result.rejected) == 0
         assert result.stats.errors == 1
+        # Error-retained findings must also count toward `kept` so that
+        # len(verified) == stats.kept is always true.
+        assert result.stats.kept == 1
+        assert len(result.verified) == result.stats.kept
+
+    @pytest.mark.asyncio
+    async def test_verification_error_writes_audit_entry(self):
+        """Errors must produce an audit entry with verdict='error' (observability)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            audit_path = f.name
+
+        try:
+            verifier = FPVerifier()
+            verifier.audit_log_path = audit_path
+            comment = _make_comment()
+            pr_ctx = _make_pr_context()
+
+            with patch.object(verifier, "_verify_single", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+                await verifier.verify([comment], pr_ctx)
+
+            with open(audit_path) as f:
+                lines = f.readlines()
+            assert len(lines) == 1
+            entry = json.loads(lines[0])
+            assert entry["verdict"] == "error"
+            assert "boom" in entry["reason"]
+            assert entry["cost_usd"] == 0.0
+        finally:
+            os.unlink(audit_path)
 
     @pytest.mark.asyncio
     async def test_mixed_verdicts(self):

--- a/tests/processor/test_fp_verifier.py
+++ b/tests/processor/test_fp_verifier.py
@@ -1,0 +1,249 @@
+"""Tests for the FP verification pass."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from baloo.github.models import (
+    FileChange,
+    PRContext,
+    PRDiscussionContext,
+    PRMetadata,
+    ReviewComment,
+)
+from baloo.processor.fp_prompts import (
+    build_verification_prompt,
+    extract_diff_for_file,
+)
+from baloo.processor.fp_verifier import (
+    FPRejection,
+    FPVerificationResult,
+    FPVerifier,
+    _extract_title,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_comment(
+    path: str = "src/auth.py",
+    line: int = 42,
+    severity: str = "HIGH",
+    category: str = "Security",
+    body: str = "**SQL injection risk**\n**Category:** Security\n**Severity:** HIGH\n\nString concatenation in query.",
+) -> ReviewComment:
+    return ReviewComment(
+        path=path, line=line, body=body, severity=severity, category=category
+    )
+
+
+def _make_pr_context(
+    diff: str = "diff --git a/src/auth.py b/src/auth.py\n--- a/src/auth.py\n+++ b/src/auth.py\n@@ -40,3 +40,5 @@\n+    query = f'SELECT * FROM users WHERE id={user_id}'\n",
+    repo_full_name: str = "org/repo",
+    pr_number: int = 1,
+) -> PRContext:
+    return PRContext(
+        metadata=PRMetadata(
+            repo_full_name=repo_full_name,
+            pr_number=pr_number,
+            title="Test PR",
+            author="dev",
+            description="test",
+            base_branch="main",
+            head_branch="feat/test",
+            head_sha="abc123",
+            files_changed=[
+                FileChange(filename="src/auth.py", status="modified", additions=2, deletions=0, changes=2, patch="")
+            ],
+        ),
+        discussion=PRDiscussionContext(),
+        diff=diff,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt tests
+# ---------------------------------------------------------------------------
+
+
+class TestFPPrompts:
+    def test_build_verification_prompt_basic(self):
+        comment = _make_comment()
+        prompt = build_verification_prompt(comment, diff_context="+ some code")
+        assert "src/auth.py" in prompt
+        assert "line 42" in prompt
+        assert "HIGH" in prompt
+        assert "some code" in prompt
+
+    def test_build_verification_prompt_with_file_context(self):
+        comment = _make_comment()
+        prompt = build_verification_prompt(
+            comment, diff_context="+ code", file_context="def foo():\n    pass"
+        )
+        assert "File context" in prompt
+        assert "def foo()" in prompt
+
+    def test_extract_diff_for_file_found(self):
+        diff = (
+            "diff --git a/src/a.py b/src/a.py\n"
+            "--- a/src/a.py\n"
+            "+++ b/src/a.py\n"
+            "@@ -1,3 +1,4 @@\n"
+            "+new line\n"
+            "diff --git a/src/b.py b/src/b.py\n"
+            "--- a/src/b.py\n"
+            "+++ b/src/b.py\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+        result = extract_diff_for_file(diff, "src/a.py")
+        assert "src/a.py" in result
+        assert "+new line" in result
+        assert "src/b.py" not in result
+
+    def test_extract_diff_for_file_not_found(self):
+        diff = "diff --git a/src/a.py b/src/a.py\n+line\n"
+        result = extract_diff_for_file(diff, "src/missing.py")
+        assert result == ""
+
+    def test_extract_diff_for_file_empty_diff(self):
+        assert extract_diff_for_file("", "anything.py") == ""
+
+
+# ---------------------------------------------------------------------------
+# Verifier tests
+# ---------------------------------------------------------------------------
+
+
+class TestFPVerifier:
+    @pytest.fixture(autouse=True)
+    def _set_env(self, monkeypatch):
+        monkeypatch.setenv("FP_VERIFICATION_ENABLED", "true")
+        monkeypatch.setenv("FP_VERIFICATION_MODEL", "haiku")
+        monkeypatch.setenv("FP_AUDIT_LOG_PATH", "")
+
+    @pytest.mark.asyncio
+    async def test_empty_comments_returns_empty(self):
+        verifier = FPVerifier()
+        result = await verifier.verify([], _make_pr_context())
+        assert result.verified == []
+        assert result.rejected == []
+        assert result.stats.total_verified == 0
+
+    @pytest.mark.asyncio
+    async def test_real_finding_is_kept(self):
+        verifier = FPVerifier()
+        comment = _make_comment()
+        pr_ctx = _make_pr_context()
+
+        mock_result = (
+            {"verdict": "real", "reason": "SQL injection is real"},
+            {"cost_usd": 0.001, "model": "haiku"},
+        )
+
+        with patch.object(verifier, "_verify_single", new_callable=AsyncMock, return_value=(comment, {"verdict": "real", "reason": "SQL injection is real", "cost_usd": 0.001, "model": "haiku"})):
+            result = await verifier.verify([comment], pr_ctx)
+
+        assert len(result.verified) == 1
+        assert len(result.rejected) == 0
+        assert result.stats.kept == 1
+
+    @pytest.mark.asyncio
+    async def test_fp_finding_is_rejected(self):
+        verifier = FPVerifier()
+        comment = _make_comment()
+        pr_ctx = _make_pr_context()
+
+        with patch.object(verifier, "_verify_single", new_callable=AsyncMock, return_value=(comment, {"verdict": "fp", "reason": "Uses parameterized query", "cost_usd": 0.001, "model": "haiku"})):
+            result = await verifier.verify([comment], pr_ctx)
+
+        assert len(result.verified) == 0
+        assert len(result.rejected) == 1
+        assert result.rejected[0].reason == "Uses parameterized query"
+        assert result.stats.rejected == 1
+
+    @pytest.mark.asyncio
+    async def test_verification_error_keeps_finding(self):
+        """Fail-open: errors should keep the finding."""
+        verifier = FPVerifier()
+        comment = _make_comment()
+        pr_ctx = _make_pr_context()
+
+        with patch.object(verifier, "_verify_single", new_callable=AsyncMock, side_effect=RuntimeError("model timeout")):
+            result = await verifier.verify([comment], pr_ctx)
+
+        assert len(result.verified) == 1
+        assert len(result.rejected) == 0
+        assert result.stats.errors == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_verdicts(self):
+        verifier = FPVerifier()
+        c1 = _make_comment(path="a.py", line=10)
+        c2 = _make_comment(path="b.py", line=20)
+        c3 = _make_comment(path="c.py", line=30)
+        pr_ctx = _make_pr_context()
+
+        async def mock_verify(comment, ctx):
+            if comment.path == "b.py":
+                return comment, {"verdict": "fp", "reason": "not real", "cost_usd": 0.001, "model": "haiku"}
+            return comment, {"verdict": "real", "reason": "legit", "cost_usd": 0.001, "model": "haiku"}
+
+        with patch.object(verifier, "_verify_single", side_effect=mock_verify):
+            result = await verifier.verify([c1, c2, c3], pr_ctx)
+
+        assert len(result.verified) == 2
+        assert len(result.rejected) == 1
+        assert result.rejected[0].comment.path == "b.py"
+
+    @pytest.mark.asyncio
+    async def test_audit_log_written(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+            audit_path = f.name
+
+        try:
+            verifier = FPVerifier()
+            verifier.audit_log_path = audit_path
+            comment = _make_comment()
+            pr_ctx = _make_pr_context()
+
+            with patch.object(verifier, "_verify_single", new_callable=AsyncMock, return_value=(comment, {"verdict": "fp", "reason": "false alarm", "cost_usd": 0.0003, "model": "haiku"})):
+                await verifier.verify([comment], pr_ctx)
+
+            with open(audit_path) as f:
+                lines = f.readlines()
+            assert len(lines) == 1
+            entry = json.loads(lines[0])
+            assert entry["verdict"] == "fp"
+            assert entry["reason"] == "false alarm"
+            assert entry["repo"] == "org/repo"
+            assert entry["pr_number"] == 1
+            assert entry["finding"]["file"] == "src/auth.py"
+            assert entry["finding"]["line"] == 42
+        finally:
+            os.unlink(audit_path)
+
+
+# ---------------------------------------------------------------------------
+# Utility tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTitle:
+    def test_extracts_bold_title(self):
+        assert _extract_title("**SQL injection risk**\nmore text") == "SQL injection risk"
+
+    def test_extracts_first_line_fallback(self):
+        assert _extract_title("Some issue here\nmore text") == "Some issue here"
+
+    def test_empty_body(self):
+        assert _extract_title("") == ""

--- a/tests/processor/test_fp_verifier.py
+++ b/tests/processor/test_fp_verifier.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -21,12 +21,9 @@ from baloo.processor.fp_prompts import (
     extract_diff_for_file,
 )
 from baloo.processor.fp_verifier import (
-    FPRejection,
-    FPVerificationResult,
     FPVerifier,
     _extract_title,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -40,9 +37,7 @@ def _make_comment(
     category: str = "Security",
     body: str = "**SQL injection risk**\n**Category:** Security\n**Severity:** HIGH\n\nString concatenation in query.",
 ) -> ReviewComment:
-    return ReviewComment(
-        path=path, line=line, body=body, severity=severity, category=category
-    )
+    return ReviewComment(path=path, line=line, body=body, severity=severity, category=category)
 
 
 def _make_pr_context(
@@ -61,7 +56,14 @@ def _make_pr_context(
             head_branch="feat/test",
             head_sha="abc123",
             files_changed=[
-                FileChange(filename="src/auth.py", status="modified", additions=2, deletions=0, changes=2, patch="")
+                FileChange(
+                    filename="src/auth.py",
+                    status="modified",
+                    additions=2,
+                    deletions=0,
+                    changes=2,
+                    patch="",
+                )
             ],
         ),
         discussion=PRDiscussionContext(),
@@ -176,12 +178,20 @@ class TestFPVerifier:
         comment = _make_comment()
         pr_ctx = _make_pr_context()
 
-        mock_result = (
-            {"verdict": "real", "reason": "SQL injection is real"},
-            {"cost_usd": 0.001, "model": "haiku"},
-        )
-
-        with patch.object(verifier, "_verify_single", new_callable=AsyncMock, return_value=(comment, {"verdict": "real", "reason": "SQL injection is real", "cost_usd": 0.001, "model": "haiku"})):
+        with patch.object(
+            verifier,
+            "_verify_single",
+            new_callable=AsyncMock,
+            return_value=(
+                comment,
+                {
+                    "verdict": "real",
+                    "reason": "SQL injection is real",
+                    "cost_usd": 0.001,
+                    "model": "haiku",
+                },
+            ),
+        ):
             result = await verifier.verify([comment], pr_ctx)
 
         assert len(result.verified) == 1
@@ -194,7 +204,20 @@ class TestFPVerifier:
         comment = _make_comment()
         pr_ctx = _make_pr_context()
 
-        with patch.object(verifier, "_verify_single", new_callable=AsyncMock, return_value=(comment, {"verdict": "fp", "reason": "Uses parameterized query", "cost_usd": 0.001, "model": "haiku"})):
+        with patch.object(
+            verifier,
+            "_verify_single",
+            new_callable=AsyncMock,
+            return_value=(
+                comment,
+                {
+                    "verdict": "fp",
+                    "reason": "Uses parameterized query",
+                    "cost_usd": 0.001,
+                    "model": "haiku",
+                },
+            ),
+        ):
             result = await verifier.verify([comment], pr_ctx)
 
         assert len(result.verified) == 0
@@ -209,7 +232,12 @@ class TestFPVerifier:
         comment = _make_comment()
         pr_ctx = _make_pr_context()
 
-        with patch.object(verifier, "_verify_single", new_callable=AsyncMock, side_effect=RuntimeError("model timeout")):
+        with patch.object(
+            verifier,
+            "_verify_single",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("model timeout"),
+        ):
             result = await verifier.verify([comment], pr_ctx)
 
         assert len(result.verified) == 1
@@ -232,7 +260,9 @@ class TestFPVerifier:
             comment = _make_comment()
             pr_ctx = _make_pr_context()
 
-            with patch.object(verifier, "_verify_single", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+            with patch.object(
+                verifier, "_verify_single", new_callable=AsyncMock, side_effect=RuntimeError("boom")
+            ):
                 await verifier.verify([comment], pr_ctx)
 
             with open(audit_path) as f:
@@ -255,8 +285,18 @@ class TestFPVerifier:
 
         async def mock_verify(comment, ctx):
             if comment.path == "b.py":
-                return comment, {"verdict": "fp", "reason": "not real", "cost_usd": 0.001, "model": "haiku"}
-            return comment, {"verdict": "real", "reason": "legit", "cost_usd": 0.001, "model": "haiku"}
+                return comment, {
+                    "verdict": "fp",
+                    "reason": "not real",
+                    "cost_usd": 0.001,
+                    "model": "haiku",
+                }
+            return comment, {
+                "verdict": "real",
+                "reason": "legit",
+                "cost_usd": 0.001,
+                "model": "haiku",
+            }
 
         with patch.object(verifier, "_verify_single", side_effect=mock_verify):
             result = await verifier.verify([c1, c2, c3], pr_ctx)
@@ -276,7 +316,20 @@ class TestFPVerifier:
             comment = _make_comment()
             pr_ctx = _make_pr_context()
 
-            with patch.object(verifier, "_verify_single", new_callable=AsyncMock, return_value=(comment, {"verdict": "fp", "reason": "false alarm", "cost_usd": 0.0003, "model": "haiku"})):
+            with patch.object(
+                verifier,
+                "_verify_single",
+                new_callable=AsyncMock,
+                return_value=(
+                    comment,
+                    {
+                        "verdict": "fp",
+                        "reason": "false alarm",
+                        "cost_usd": 0.0003,
+                        "model": "haiku",
+                    },
+                ),
+            ):
                 await verifier.verify([comment], pr_ctx)
 
             with open(audit_path) as f:


### PR DESCRIPTION
## Summary

Adds a second lightweight LLM pass that re-examines each review finding before posting. A cheap model (Haiku/Flash) classifies each finding as **real issue** or **false positive**, dropping FPs before they reach developers.

## What's included

- **`baloo/processor/fp_verifier.py`** — Core verifier: loops findings concurrently, calls cheap model, classifies real/fp
- **`baloo/processor/fp_prompts.py`** — Verification prompt templates (system + per-finding)
- **`baloo/config/settings.py`** — 4 new settings: `fp_verification_enabled`, `fp_verification_model`, `fp_verification_max_concurrent`, `fp_audit_log_path`
- **`baloo/github/webhook_handler.py`** — Wired between `review_pr()` and `FindingsFilter`
- **JSONL audit log** — Every verdict (real + fp) logged for offline review and prompt tuning
- **14 tests** passing

## Design decisions

- **Fail-open**: If verification errors, the finding is kept (better to over-report than miss)
- **Individual verification**: Each finding checked in isolation (no cross-contamination)
- **Ships disabled**: `fp_verification_enabled=false` — enable when ready
- **Cost**: ~$0.001 extra per review (negligible vs $0.02–0.10 main review)

## Plan

See [docs/plans/fp-reduction-pass.md](docs/plans/fp-reduction-pass.md)

## To enable

```
FP_VERIFICATION_ENABLED=true
FP_VERIFICATION_MODEL=haiku
FP_AUDIT_LOG_PATH=/var/log/baloo/fp-audit.jsonl
```