### PR TITLE
docs: OSS-ready README, CI, templates, and repo metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: "bug: "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what happened.
+
+**To reproduce**
+1. PR type / size (e.g. "3-file Python PR")
+2. What Baloo did (or didn't do)
+3. Any error messages from logs
+
+**Expected behavior**
+What should have happened.
+
+**Environment**
+- Baloo version/commit:
+- Model: (e.g. `sonnet`)
+- Deployment: (Docker / bare metal / EC2)
+- Python version:
+
+**Logs**
+```
+Paste relevant logs here (redact secrets)
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest an improvement or new capability
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+**Problem**
+What problem does this solve? What's frustrating about the current behavior?
+
+**Proposed solution**
+Describe what you'd like to happen.
+
+**Alternatives considered**
+Any other approaches you've thought about.
+
+**Additional context**
+Links, screenshots, or examples that help explain the request.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+Brief description of what this PR does.
+
+## Changes
+
+- 
+
+## Testing
+
+- [ ] Tests added/updated
+- [ ] `uv run pytest` passes
+- [ ] `uv run ruff check baloo tests` clean
+- [ ] `uv run black --check baloo tests` clean
+
+## Notes
+
+Any risks, follow-ups, or context for reviewers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint (ruff)
+        run: uv run ruff check baloo tests
+
+      - name: Format check (black)
+        run: uv run black --check baloo tests
+
+      - name: Tests
+        run: uv run pytest -x -q
+        env:
+          APP_ENVIRONMENT: test
+          BALOO_ENV_FILE: /tmp/baloo-ci.env

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,59 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+
+      - name: Sync root files to docs/
+        run: |
+          # Copy and fix links for MkDocs context (docs/ is the root)
+          sed -e 's|docs/||g' -e 's|(README.md)|(./)|g' -e 's|(CONTRIBUTING.md)|(contributing.md)|g' -e 's|(AGENTS.md)|(https://github.com/Blue-Bear-Security/baloo-bear/blob/main/AGENTS.md)|g' -e 's|(SECURITY.md)|(https://github.com/Blue-Bear-Security/baloo-bear/blob/main/SECURITY.md)|g' -e 's|(LICENSE)|(https://github.com/Blue-Bear-Security/baloo-bear/blob/main/LICENSE)|g' -e 's|(DOCKER.md)|(https://github.com/Blue-Bear-Security/baloo-bear/blob/main/DOCKER.md)|g' -e 's|(\.env.example)|(https://github.com/Blue-Bear-Security/baloo-bear/blob/main/.env.example)|g' README.md > docs/index.md
+          sed -e 's|(SECURITY.md)|(https://github.com/Blue-Bear-Security/baloo-bear/blob/main/SECURITY.md)|g' CONTRIBUTING.md > docs/contributing.md
+
+      - name: Build docs
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,4 @@ node_modules/
 
 # Private deployment configs (entire folder – instance-specific)
 deploy/
+site/

--- a/README.md
+++ b/README.md
@@ -145,7 +145,21 @@ All settings are environment variables. Key ones:
 | `DASHBOARD_ENABLED` | `false` | Enable review dashboard UI |
 | `FIDELITY_ENABLED` | `true` | Compare PRs against plan docs |
 
-Full reference: [`.env.example`](.env.example)
+Full reference: [docs/configuration.md](docs/configuration.md)
+
+## Documentation
+
+📖 **[docs/README.md](docs/README.md)** — Full documentation index
+
+Feature guides:
+- [Review Agent](docs/features/review-agent.md) — How the agentic review works
+- [Guidelines Enforcement](docs/features/guidelines.md) — Repo convention checking
+- [Fidelity Analysis](docs/features/fidelity.md) — Plan-vs-implementation scoring
+- [Models](docs/features/models.md) — Supported models and fallback
+- [Severity Routing](docs/features/severity-routing.md) — How findings reach developers
+- [Discussion Tracking](docs/features/discussions.md) — Thread follow-ups across iterations
+- [FP Verification](docs/features/fp-verification.md) — False-positive reduction
+- [Dashboard](docs/features/dashboard.md) — Review history UI
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,179 +1,171 @@
-# Baloo
+<p align="center">
+  <img src="docs/assets/baloo-banner.png" alt="Baloo — AI Code Review Agent" width="600">
+</p>
 
-Baloo is a FastAPI-based GitHub App that reviews pull requests with Anthropic models. It fetches full pull request context, reads repository guidelines from `AGENTS.md` and `CONTRIBUTING.md`, and posts review comments, approvals, and optional dashboard or fidelity output back to GitHub.
+<p align="center">
+  <strong>AI-powered code reviews for every pull request</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Blue-Bear-Security/baloo-bear/actions/workflows/ci.yml"><img src="https://github.com/Blue-Bear-Security/baloo-bear/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python 3.10+"></a>
+  <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+</p>
+
+---
+
+Baloo is a **GitHub App** that automatically reviews pull requests using LLMs. It installs on your repos, reads every PR diff, and posts actionable review comments — catching bugs, security issues, and guideline violations before humans look at the code.
+
+## Why Baloo?
+
+- **Catches what linters can't** — logic errors, silent failures, security antipatterns, missing error handling
+- **Respects your conventions** — reads `AGENTS.md` and `CONTRIBUTING.md` from your repo and enforces them
+- **Posts like a teammate** — inline comments on specific lines, severity labels, approval/request-changes decisions
+- **Runs on every push** — new commits get reviewed automatically, with discussion thread tracking across iterations
+- **Self-hosted & private** — your code never leaves your infrastructure; bring your own API keys
+
+## What It Looks Like
+
+When a PR is opened or updated, Baloo posts a review:
+
+```
+🐻 Baloo review completed in 45s.
+Found 2 issue(s): 0 critical, 1 high, 1 medium, 0 low.
+```
+
+Inline comments appear on the exact lines:
+
+> **[HIGH] Security** — `src/auth.py:55`
+>
+> SQL query uses string concatenation instead of parameterized bindings.
+> This is vulnerable to SQL injection.
+>
+> **Recommendation:** Use parameterized queries: `cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))`
 
 ## Features
 
-- Agentic pull request review for opened, reopened, and updated PRs
-- Severity-based routing for inline comments, review summaries, and Checks API annotations
-- Repository-specific guideline enforcement from the target repository's `AGENTS.md` and `CONTRIBUTING.md`
-- Optional fidelity analysis against plan documents
-- Optional PostgreSQL-backed review history dashboard
+| Feature | Description |
+|---|---|
+| **Agentic review** | Uses [PI](https://github.com/mariozechner/pi-coding-agent) to read files, grep patterns, and explore the repo — not just the diff |
+| **Multi-model** | Supports Claude (Sonnet, Haiku, Opus) and Gemini (Flash, Pro) with automatic fallback |
+| **Severity routing** | CRITICAL/HIGH → request changes; MEDIUM → Checks API annotations; LOW → filtered |
+| **Guideline enforcement** | Reads repo-level `AGENTS.md` / `CONTRIBUTING.md` and flags violations |
+| **Discussion tracking** | Follows up on existing threads, skips duplicates, detects addressed feedback |
+| **Fidelity analysis** | Optionally compares PR against design plan documents |
+| **FP reduction** | Optional second LLM pass to verify findings and drop false positives |
+| **Dashboard** | Optional PostgreSQL-backed review history UI with cost tracking |
+| **Dependabot-aware** | Specialized review logic for dependency update PRs |
+
+## Quick Start
+
+### 1. Create a GitHub App
+
+Go to **GitHub Settings → Developer settings → GitHub Apps → New GitHub App**:
+- **Webhook URL**: Your public HTTPS endpoint (e.g. `https://baloo.example.com/webhook`)
+- **Permissions**: Pull requests (read/write), Contents (read), Checks (read/write)
+- **Events**: Pull request
+- Download the private key `.pem` file
+
+### 2. Deploy with Docker
+
+```bash
+git clone https://github.com/Blue-Bear-Security/baloo-bear.git
+cd baloo-bear
+cp .env.example .env
+# Edit .env with your GitHub App ID, private key path, webhook secret, and API keys
+```
+
+```bash
+docker compose up --build
+```
+
+### 3. Install the App
+
+Install the GitHub App on your repositories. Open a PR — Baloo will review it automatically.
+
+📖 **Full setup guide**: [docs/getting-started.md](docs/getting-started.md)
 
 ## Architecture
 
 ```text
-GitHub webhook -> FastAPI handler -> Claude agent -> findings processor -> GitHub review/checks APIs
+┌──────────────┐     webhook      ┌──────────────────┐
+│   GitHub      │ ───────────────→ │   FastAPI         │
+│   (PR event)  │                  │   webhook_handler │
+└──────────────┘                  └────────┬─────────┘
+                                           │
+                                  ┌────────▼─────────┐
+                                  │   PI Agent (RPC)  │
+                                  │   read / grep /   │
+                                  │   find / ls       │
+                                  └────────┬─────────┘
+                                           │
+                                  ┌────────▼─────────┐
+                                  │   Processor       │
+                                  │   filter → route  │
+                                  │   → decide        │
+                                  └────────┬─────────┘
+                                           │
+                              ┌────────────┼────────────┐
+                              ▼            ▼            ▼
+                        ┌──────────┐ ┌──────────┐ ┌──────────┐
+                        │ Review   │ │ Checks   │ │ Dashboard│
+                        │ comments │ │ API      │ │ (opt.)   │
+                        └──────────┘ └──────────┘ └──────────┘
 ```
-
-Key modules:
-
-- `baloo/github/`: webhook handling, GitHub API access, review thread parsing
-- `baloo/agent/`: prompt construction, Claude runtime, structured review output
-- `baloo/processor/`: filtering, routing, approval decisions, formatting
-- `baloo/fidelity/`: optional plan-vs-implementation analysis
-- `baloo/db/` and `baloo/dashboard/`: optional persistence and review history UI
-
-## Prerequisites
-
-- A GitHub App with pull request and contents access
-- An Anthropic API key
-- A public HTTPS endpoint for GitHub webhooks in non-local environments
-
-## Quick Start
-
-The fastest path is the end-to-end guide in [docs/getting-started.md](docs/getting-started.md).
-
-## Docker
-
-Baloo ships with a local-friendly `docker-compose.yml` that builds the application image from this repository.
-
-```bash
-cp .env.docker .env
-docker compose up --build
-```
-
-If you keep the GitHub App private key as a file, place it under `.secrets/` and set `GITHUB_PRIVATE_KEY=.secrets/<your-key>.pem` in `.env`.
-
-`GITHUB_APP_ID` must be the numeric GitHub App ID, not the Client ID.
-
-If you want to use an alternate env file without copying over `.env`, run:
-
-```bash
-BALOO_ENV_FILE=.env.local docker compose up --build
-```
-
-Useful endpoints:
-
-- Health check: `http://localhost:8000/health`
-- Dashboard: `http://localhost:8000/dashboard/` when `DASHBOARD_ENABLED=true`
-
-See [DOCKER.md](DOCKER.md) for container details and deployment notes.
-
-## Container Publishing
-
-The repository includes a GitHub Actions workflow at [.github/workflows/deploy.yml](.github/workflows/deploy.yml) that builds and publishes a container image to GitHub Container Registry on pushes to `main`. If you use a different registry or deploy process, adapt that workflow before relying on it.
-
-## Configuration
-
-Baloo is configured through environment variables. Common settings:
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `GITHUB_APP_ID` | - | Numeric GitHub App ID |
-| `GITHUB_PRIVATE_KEY` | - | Path to a PEM file, typically under `.secrets/`, or inline PEM contents |
-| `GITHUB_WEBHOOK_SECRET` | - | GitHub webhook secret |
-| `ANTHROPIC_API_KEY` | - | Anthropic API key |
-| `APP_HOST` | `0.0.0.0` | Bind host |
-| `APP_PORT` | `8000` | Bind port |
-| `LOG_LEVEL` | `INFO` | Log level |
-| `MAX_CONCURRENT_REVIEWS` | `3` | Maximum reviews processed at once |
-| `AGENT_MODEL` | `claude-sonnet-4-6` | Anthropic model to use |
-| `REVIEW_AUTO_APPROVE` | `true` | Auto-approve PRs with no blocking findings |
-| `REVIEW_MIN_SEVERITY` | `MEDIUM` | Minimum severity to report |
-| `DATABASE_ENABLED` | `false` | Persist review history to PostgreSQL |
-| `DASHBOARD_ENABLED` | `true` | Serve the dashboard UI |
-| `FIDELITY_ENABLED` | `true` | Compare PRs against plan documents |
-
-## Development
-
-For contributor setup, direct local execution, tests, and hooks, see [docs/development.md](docs/development.md).
-
-### Common commands
-
-```bash
-uv sync
-npm install
-uv run python main.py
-uv run pytest
-uv run pytest --cov=baloo --cov-report=term-missing
-uv run ruff check baloo tests
-uv run black --check baloo tests
-```
-
-### Git hooks
-
-The repository uses Husky for local Git hooks and `gitleaks` for staged secret scanning on `pre-commit`.
-
-Hook setup:
-
-```bash
-brew install gitleaks
-npm install
-```
-
-The installed pre-commit hook runs:
-
-```bash
-gitleaks git --staged --pre-commit --no-banner --redact
-```
-
-### Project structure
 
 ```text
 baloo/
-├── baloo/
-│   ├── agent/
-│   ├── config/
-│   ├── db/
-│   ├── fidelity/
-│   ├── github/
-│   └── processor/
-├── tests/
-├── main.py
-└── pyproject.toml
+├── agent/       # PI runtime, prompts, structured output parsing
+├── config/      # Environment-based settings
+├── db/          # PostgreSQL models + migrations (optional)
+├── dashboard/   # Review history UI (optional)
+├── fidelity/    # Plan-vs-implementation analysis (optional)
+├── github/      # Webhooks, API client, auth, Checks API
+└── processor/   # Findings filter, severity routing, decisions, FP verification
 ```
 
-## How It Works
+## Configuration
 
-1. GitHub sends a `pull_request` webhook when a PR is opened or updated.
-2. Baloo verifies the webhook signature and loads PR metadata, diffs, and discussion context.
-3. Baloo fetches `AGENTS.md` and `CONTRIBUTING.md` from the reviewed repository when present.
-4. The Claude agent performs a structured review and emits findings.
-5. Findings are filtered, routed, and posted back to GitHub as review comments, summaries, and checks.
+All settings are environment variables. Key ones:
 
-## Retrieving Review Comments
+| Variable | Default | Description |
+|---|---|---|
+| `GITHUB_APP_ID` | — | Numeric GitHub App ID |
+| `GITHUB_PRIVATE_KEY` | — | Path to `.pem` file or inline PEM |
+| `GITHUB_WEBHOOK_SECRET` | — | Webhook signature secret |
+| `ANTHROPIC_API_KEY` | — | Anthropic API key |
+| `GEMINI_API_KEY` | — | Google Gemini API key (for fallback/multi-model) |
+| `AGENT_MODEL` | `sonnet` | Model short name: `flash`, `haiku`, `sonnet`, `gemini-pro`, `opus` |
+| `AGENT_FALLBACK_MODEL` | `google/gemini-2.5-flash` | Fallback on primary failure |
+| `REVIEW_AUTO_APPROVE` | `true` | Auto-approve PRs with no blocking findings |
+| `REVIEW_MIN_SEVERITY` | `MEDIUM` | Minimum severity to post |
+| `FP_VERIFICATION_ENABLED` | `false` | Enable LLM false-positive verification |
+| `DATABASE_ENABLED` | `false` | Enable PostgreSQL review history |
+| `DASHBOARD_ENABLED` | `false` | Enable review dashboard UI |
+| `FIDELITY_ENABLED` | `true` | Compare PRs against plan docs |
 
-You can query Baloo's review comments with the GitHub CLI:
+Full reference: [`.env.example`](.env.example)
+
+## Development
 
 ```bash
-gh api /repos/{owner}/{repo}/pulls/{pr_number}/comments \
-  --jq '.[] | select(.user.login=="baloo-code-reviewer[bot]") | {path, line, body, created_at}'
+uv sync && npm install     # install deps
+uv run python main.py      # run locally
+uv run pytest              # test
+uv run ruff check baloo    # lint
+uv run black --check baloo # format check
 ```
 
-## Troubleshooting
+See [docs/development.md](docs/development.md) for the full contributor guide.
 
-### Webhook not receiving events
+## Roadmap
 
-- Verify the GitHub App webhook URL is correct and publicly reachable.
-- Verify `GITHUB_WEBHOOK_SECRET` matches your GitHub App configuration.
-- Check webhook delivery logs in GitHub.
-
-### Authentication errors
-
-- Verify the app ID and private key belong to the same GitHub App.
-- Ensure the app has been installed on the target repository.
-- Confirm required GitHub App permissions are granted.
-
-### Agent failures
-
-- Verify `ANTHROPIC_API_KEY` is valid in the running environment.
-- Check application logs with `LOG_LEVEL=DEBUG`.
-- Confirm the configured model is available to your Anthropic account.
+See [docs/ROADMAP.md](docs/ROADMAP.md) for planned features including multi-model review with judge, conversational thread replies, and AST-enriched context.
 
 ## Contributing
 
-Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow and [AGENTS.md](AGENTS.md) for repository-specific guidance for coding agents.
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow and conventions, and [AGENTS.md](AGENTS.md) for AI-agent-specific guidance.
 
 ## Security
 
@@ -181,4 +173,4 @@ Please read [SECURITY.md](SECURITY.md) before reporting vulnerabilities.
 
 ## License
 
-Baloo is released under the MIT license. See [LICENSE](LICENSE).
+MIT — see [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Documentation
+
+## Getting Started
+- **[Getting Started](getting-started.md)** — Set up Baloo end-to-end with Docker, ngrok, and a GitHub App
+- **[Development](development.md)** — Contributor setup: local dev, tests, linting, git hooks
+
+## Features
+- **[Review Agent](features/review-agent.md)** — How the PI-based agentic review works
+- **[Guidelines Enforcement](features/guidelines.md)** — How Baloo reads and enforces repo conventions
+- **[Fidelity Analysis](features/fidelity.md)** — Comparing PRs against design plan documents
+- **[Model Configuration](features/models.md)** — Supported models, fallback, and model selection
+- **[Severity Routing](features/severity-routing.md)** — How findings are routed to reviews, Checks API, or filtered
+- **[Discussion Tracking](features/discussions.md)** — Thread follow-ups, duplicate detection, and conversation context
+- **[FP Verification](features/fp-verification.md)** — LLM-powered false-positive reduction (optional)
+- **[Dashboard](features/dashboard.md)** — Review history UI with cost tracking (optional)
+
+## Reference
+- **[Configuration](configuration.md)** — Full environment variable reference
+- **[ROADMAP](ROADMAP.md)** — Planned features

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,76 @@
+# Configuration Reference
+
+All Baloo settings are environment variables. Set them in `.env`, pass them via `docker-compose.yml`, or export them directly.
+
+## GitHub App
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `GITHUB_APP_ID` | ✅ | — | Numeric GitHub App ID (not the Client ID) |
+| `GITHUB_PRIVATE_KEY` | ✅ | — | Path to `.pem` file (e.g., `.secrets/app.pem`) or inline PEM contents |
+| `GITHUB_WEBHOOK_SECRET` | ✅ | — | Webhook signature verification secret |
+
+## LLM API Keys
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | ✅ | — | Anthropic API key (for Claude models) |
+| `GEMINI_API_KEY` | — | — | Google Gemini API key (for fallback / Gemini models) |
+
+## Application
+
+| Variable | Default | Description |
+|---|---|---|
+| `APP_ENVIRONMENT` | `development` | `development` or `production`. Production disables API docs |
+| `APP_HOST` | `0.0.0.0` | Bind host |
+| `APP_PORT` | `8000` | Bind port |
+| `LOG_LEVEL` | `INFO` | Logging level: DEBUG, INFO, WARNING, ERROR |
+| `MAX_CONCURRENT_REVIEWS` | `3` | Max PRs reviewed simultaneously |
+
+## Agent
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_PROVIDER` | `anthropic` | LLM provider: `anthropic`, `google` |
+| `AGENT_MODEL` | `sonnet` | Model short name or `provider/model` string. See [Models](features/models.md) |
+| `AGENT_FALLBACK_MODEL` | `google/gemini-2.5-flash` | Fallback model (`provider/model`). Empty to disable |
+| `AGENT_MAX_TOKENS` | `4096` | Max output tokens |
+| `AGENT_TEMPERATURE` | `0.2` | Generation temperature |
+| `PI_BINARY_PATH` | `pi` | Path to PI binary |
+| `PI_THINKING_LEVEL` | `medium` | Thinking depth: `off`, `minimal`, `low`, `medium`, `high` |
+
+## Review Behavior
+
+| Variable | Default | Description |
+|---|---|---|
+| `REVIEW_AUTO_APPROVE` | `true` | Auto-approve PRs with no CRITICAL/HIGH findings |
+| `REVIEW_MIN_SEVERITY` | `MEDIUM` | Minimum severity to post: `LOW`, `MEDIUM`, `HIGH`, `CRITICAL` |
+| `REVIEW_USE_CHECKS_API` | `true` | Post MEDIUM findings to Checks API instead of review comments |
+
+## FP Verification
+
+| Variable | Default | Description |
+|---|---|---|
+| `FP_VERIFICATION_ENABLED` | `false` | Enable LLM false-positive verification pass |
+| `FP_VERIFICATION_MODEL` | `haiku` | Model for verification |
+| `FP_VERIFICATION_MAX_CONCURRENT` | `5` | Max parallel verification calls |
+| `FP_AUDIT_LOG_PATH` | `/var/log/baloo/fp-audit.jsonl` | Audit log path. Empty to disable |
+
+## Fidelity Analysis
+
+| Variable | Default | Description |
+|---|---|---|
+| `FIDELITY_ENABLED` | `true` | Compare PRs against design plan documents |
+| `FIDELITY_PLAN_PATH_PATTERN` | `docs/plans/{ticket_id}.md` | Path pattern with `{ticket_id}` placeholder |
+| `FIDELITY_APPROVAL_THRESHOLD` | `90` | Min fidelity score (0–100) for auto-approval boost |
+| `TICKET_ID_PREFIX` | `PROJ` | Ticket ID prefix for extraction (e.g., `PROJ` → `PROJ-123`) |
+
+## Database & Dashboard
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATABASE_ENABLED` | `false` | Enable PostgreSQL persistence |
+| `DATABASE_URL` | — | PostgreSQL connection URL. Auto-set in docker-compose |
+| `DASHBOARD_ENABLED` | `false` | Enable review history dashboard |
+| `DASHBOARD_USERNAME` | — | Dashboard basic auth username |
+| `DASHBOARD_PASSWORD` | — | Dashboard basic auth password |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,100 @@
+# Contributing to Baloo
+
+## Before You Start
+
+- For bugs, feature requests, and design discussions, prefer opening a GitHub issue first unless you already have maintainer guidance.
+- Keep pull requests scoped to one logical change.
+- For sensitive security issues, follow [SECURITY.md](https://github.com/Blue-Bear-Security/baloo-bear/blob/main/SECURITY.md) instead of opening a public issue.
+
+## Development Setup
+
+```bash
+uv sync
+cp .env.example .env
+uv run python main.py
+```
+
+To enable local git hooks:
+
+```bash
+npm install
+```
+
+Common checks before opening a pull request:
+
+```bash
+uv run pytest
+uv run ruff check baloo tests
+uv run black --check baloo tests
+```
+
+## Commit Convention
+
+Semantic commits are recommended:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Types
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Code style changes (formatting, no logic change)
+- `refactor`: Code refactoring
+- `perf`: Performance improvements
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks
+- `ci`: CI/CD changes
+
+### Examples
+
+```bash
+feat(agent): add self-awareness check for PR context
+
+fix(webhook): handle 422 errors with fallback to issue comments
+
+docs: update deployment instructions for Docker
+
+chore(deps): update claude-sdk to 0.1.4
+```
+
+### Footers
+
+```bash
+# Reference GitHub issues
+Refs: #123
+
+# Breaking changes
+BREAKING CHANGE: renamed config parameter MAX_REVIEWS to MAX_CONCURRENT_REVIEWS
+
+# Co-authored commits
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+## Development Workflow
+
+1. Create or identify the GitHub issue for the change when appropriate.
+2. Create a descriptive branch such as `feat/review-guidelines` or `fix/webhook-fallback`.
+3. Make the smallest change that fully addresses the problem.
+4. Add or update tests when behavior changes.
+5. Run the relevant checks locally before opening a PR.
+6. Open a pull request with context, risk notes, and any follow-up work.
+
+## Pull Requests
+
+- Use a clear title that describes the change.
+- Link the related issue when one exists, for example `Closes #123`.
+- Include test coverage notes or explain why tests were not added.
+- Ensure CI passes before requesting review.
+- Address review comments explicitly in follow-up commits or replies.
+
+## Questions?
+
+- Open a GitHub issue for product or implementation questions.
+- Open a GitHub Discussion if you want feedback before writing code.

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -1,0 +1,43 @@
+# Dashboard
+
+Baloo includes an optional review history dashboard backed by PostgreSQL. It provides visibility into review activity, costs, and findings across all repositories.
+
+## What It Shows
+
+- **Review history** — Every review with status, duration, model used, and cost
+- **Findings** — Individual findings per review with severity, category, file, and line
+- **Cost tracking** — Token usage and dollar cost per review and in aggregate
+- **Fidelity scores** — When fidelity analysis is enabled
+
+## Requirements
+
+The dashboard requires:
+
+1. **PostgreSQL** — For storing review data
+2. **Database enabled** — `DATABASE_ENABLED=true`
+3. **Dashboard enabled** — `DASHBOARD_ENABLED=true`
+4. **Credentials** — `DASHBOARD_USERNAME` and `DASHBOARD_PASSWORD`
+
+The default `docker-compose.yml` includes a PostgreSQL container, so no external database setup is needed for local use.
+
+## Access
+
+The dashboard is served at `/dashboard/` and protected by HTTP Basic Auth.
+
+```
+http://localhost:8000/dashboard/
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATABASE_ENABLED` | `false` | Enable PostgreSQL persistence |
+| `DATABASE_URL` | — | PostgreSQL connection URL (auto-set in docker-compose) |
+| `DASHBOARD_ENABLED` | `false` | Enable the dashboard UI |
+| `DASHBOARD_USERNAME` | — | Basic auth username |
+| `DASHBOARD_PASSWORD` | — | Basic auth password |
+
+## Without the Dashboard
+
+If you don't need review history, leave `DATABASE_ENABLED=false`. Baloo works fine without a database — it just won't persist review data between restarts.

--- a/docs/features/discussions.md
+++ b/docs/features/discussions.md
@@ -1,0 +1,61 @@
+# Discussion Tracking
+
+Baloo tracks prior review conversations across PR iterations. When a new commit is pushed, Baloo doesn't just re-review from scratch — it understands what was already discussed.
+
+## What It Does
+
+- **Detects existing threads** — Finds Baloo's previous inline comments on the same PR
+- **Skips duplicates** — If Baloo already flagged the same issue and is awaiting a response, it won't re-post
+- **Posts follow-ups** — If the same issue persists but the developer has replied, Baloo posts a follow-up in the existing thread instead of creating a new one
+- **Injects context** — The review agent sees a digest of prior discussions so it doesn't contradict its own earlier recommendations
+
+## How Matching Works
+
+Baloo uses fuzzy matching to link new findings to existing threads:
+
+1. **Exact match** — Same file + same line number
+2. **Fuzzy match** — Same file + nearby line (±5 lines) + similar issue content (Jaccard similarity on extracted terms)
+
+Matching accounts for line drift when code is modified between iterations.
+
+## Thread States
+
+| State | Meaning | Baloo's Behavior |
+|---|---|---|
+| **Awaiting response** | Baloo posted, developer hasn't replied | Skip (don't re-post) |
+| **Active discussion** | Developer replied | May post follow-up in same thread |
+| **New finding** | No existing thread | Post as new inline comment |
+
+## Consistency Rules
+
+The review agent is instructed to:
+
+- **Not contradict** previous recommendations unless code changed significantly
+- **Not flip-flop** between different valid approaches
+- **Check if recommendations were addressed** before re-flagging
+
+## Impact on Decisions
+
+Open threads affect the approval decision:
+
+- If Baloo has open threads awaiting response and no new findings, it still holds the "Request Changes" status
+- The summary reports how many threads remain open
+
+## Example Flow
+
+```
+Push 1: Baloo finds SQL injection on auth.py:55
+  → Posts inline comment, requests changes
+
+Developer replies: "We use an ORM, this is safe"
+
+Push 2: Baloo re-reviews
+  → Sees existing thread on auth.py:55
+  → Agent reads the discussion context
+  → If issue is gone: doesn't re-flag
+  → If issue persists: posts follow-up in the same thread
+```
+
+## Configuration
+
+Discussion tracking is always on. There are no feature flags — it's core to how Baloo behaves across PR iterations.

--- a/docs/features/fidelity.md
+++ b/docs/features/fidelity.md
@@ -1,0 +1,79 @@
+# Fidelity Analysis
+
+Fidelity analysis compares a PR's actual changes against a design plan document, scoring how closely the implementation matches the plan.
+
+## Why Fidelity?
+
+When teams write design docs or implementation plans before coding, fidelity analysis closes the loop:
+
+- Did the PR implement what was planned?
+- Are there planned items missing from the PR?
+- Did the PR add scope beyond the plan?
+
+This is especially useful for teams that use ticket-linked plan files as part of their workflow.
+
+## How It Works
+
+1. **Extract ticket ID** — Baloo looks for a ticket ID in the PR branch name, title, or description (e.g., `PROJ-123` from branch `feat/PROJ-123-add-auth`)
+2. **Fetch plan file** — Looks for a plan document at a configurable path (default: `docs/plans/{ticket_id}.md`) in the PR branch
+3. **Analyze** — An LLM compares the plan against the PR diff
+4. **Score** — Produces a fidelity score (0–100) and a breakdown of matched/missing/extra items
+5. **Report** — Posts the fidelity report as a separate PR comment
+
+## Example Output
+
+```
+📋 Fidelity Report — PROJ-123
+
+Score: 85/100
+
+✅ Implemented:
+- Add JWT token validation middleware
+- Create /api/auth/refresh endpoint
+- Add rate limiting to auth endpoints
+
+❌ Missing:
+- Add integration tests for token refresh flow
+
+➕ Extra (not in plan):
+- Added logout endpoint (not planned but reasonable)
+```
+
+## Plan File Format
+
+Plan files are freeform markdown. Baloo works best when the plan lists concrete deliverables:
+
+```markdown
+# PROJ-123 — Add Authentication
+
+## Planned Changes
+- Add JWT middleware in `app/middleware/auth.py`
+- Create `/api/auth/login` and `/api/auth/refresh` endpoints
+- Add rate limiting (10 req/min) to all auth endpoints
+- Write integration tests in `tests/api/test_auth.py`
+
+## Out of Scope
+- OAuth2 provider integration (separate ticket)
+```
+
+## Impact on Approval
+
+Fidelity score affects the approval decision:
+
+- **Score ≥ threshold** (default 90) + no CRITICAL/HIGH findings → **auto-approve**
+- **Score < threshold** → approval requires clean review findings only (fidelity doesn't block, but doesn't help)
+
+This means a high-fidelity PR with only MEDIUM issues can still be auto-approved.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FIDELITY_ENABLED` | `true` | Enable fidelity analysis |
+| `FIDELITY_PLAN_PATH_PATTERN` | `docs/plans/{ticket_id}.md` | Path pattern for plan files |
+| `FIDELITY_APPROVAL_THRESHOLD` | `90` | Minimum score for auto-approval boost |
+| `TICKET_ID_PREFIX` | `PROJ` | Prefix for ticket extraction (e.g., `PROJ` matches `PROJ-123`) |
+
+## No Plan? No Report
+
+If Baloo can't find a ticket ID or plan file, fidelity analysis is silently skipped. It never blocks a review.

--- a/docs/features/fp-verification.md
+++ b/docs/features/fp-verification.md
@@ -1,0 +1,74 @@
+# False-Positive Verification
+
+An optional second LLM pass that re-examines each finding before posting, dropping false positives to improve developer trust.
+
+## How It Works
+
+1. The main review agent produces findings
+2. Each finding is independently sent to a **cheap/fast model** (Haiku or Flash)
+3. The verifier sees: the finding description + the actual code context (diff hunk)
+4. It classifies each finding as **real issue** or **false positive**
+5. False positives are dropped before posting
+
+## Why a Separate Pass?
+
+The review agent optimizes for **recall** (finding all issues). The verification pass optimizes for **precision** (only keeping real ones). Separating these concerns gives better results than asking one model to do both.
+
+## Fail-Open Design
+
+If verification errors (model timeout, parse failure), the finding is **kept**. It's better to over-report than to silently drop a real bug.
+
+## Audit Log
+
+Every verdict is logged to a JSONL file for offline review and prompt tuning:
+
+```json
+{
+  "timestamp": "2026-04-14T13:00:00Z",
+  "repo": "org/repo",
+  "pr_number": 42,
+  "finding": {
+    "file": "src/auth.py",
+    "line": 55,
+    "severity": "HIGH",
+    "category": "Security",
+    "title": "SQL injection risk"
+  },
+  "verdict": "fp",
+  "reason": "The query uses parameterized bindings, not string concat",
+  "model": "claude-haiku-4-5-20251001",
+  "cost_usd": 0.0003
+}
+```
+
+Use this log to:
+- Review rejected findings and confirm they're actually FPs
+- Identify patterns in false positives to improve the review prompt
+- Track FP reduction effectiveness over time
+
+## Cost
+
+Per finding verification:
+- Haiku: ~$0.0003
+- Flash: ~$0.0001
+
+Typical review with 5 findings: **$0.0005–$0.0015** extra. Negligible compared to the main review cost.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FP_VERIFICATION_ENABLED` | `false` | Enable the verification pass |
+| `FP_VERIFICATION_MODEL` | `haiku` | Model for verification (short name or provider/model) |
+| `FP_VERIFICATION_MAX_CONCURRENT` | `5` | Max parallel verification calls |
+| `FP_AUDIT_LOG_PATH` | `/var/log/baloo/fp-audit.jsonl` | Audit log path. Empty to disable logging |
+
+## Enabling
+
+```bash
+FP_VERIFICATION_ENABLED=true
+FP_VERIFICATION_MODEL=haiku
+FP_AUDIT_LOG_PATH=/var/log/baloo/fp-audit.jsonl
+```
+
+Start with verification enabled on a staging environment. Review the audit log to confirm it's dropping actual false positives before enabling in production.

--- a/docs/features/guidelines.md
+++ b/docs/features/guidelines.md
@@ -1,0 +1,71 @@
+# Guidelines Enforcement
+
+Baloo reads convention files from the repository being reviewed and uses them to enforce project-specific rules.
+
+## How It Works
+
+When reviewing a PR, Baloo fetches these files from the target repository (if they exist):
+
+- **`AGENTS.md`** — Repository guidance for coding agents (architecture, conventions, tooling)
+- **`CONTRIBUTING.md`** — Contributor guidelines (commit format, branch naming, workflow)
+
+The contents are injected into the review agent's prompt. The agent then flags any PR changes that contradict the documented conventions.
+
+## What Gets Flagged
+
+Guidelines violations are reported as **CRITICAL** severity with category **"Guidelines"**. Examples:
+
+- Branch name doesn't follow the naming convention (e.g., `fix/thing` when repo requires `fix(scope): thing`)
+- Commit messages missing required ticket references
+- Code that violates architectural decisions stated in AGENTS.md
+- Dependency management that contradicts documented conventions
+- Using a tool or pattern explicitly discouraged by the guidelines
+
+## Setting Up Your Repository
+
+### AGENTS.md
+
+This file tells Baloo (and other coding agents) how your project works:
+
+```markdown
+# AGENTS.md
+
+## Architecture
+- Backend: Python 3.11, FastAPI
+- All database access goes through the repository pattern in `app/repos/`
+
+## Conventions
+- Branch names: `feat/description` or `fix/description`
+- Semantic commits required
+- All new endpoints need tests in `tests/api/`
+
+## Common Commands
+- `uv run pytest` — run tests
+- `uv run ruff check` — lint
+```
+
+### CONTRIBUTING.md
+
+Standard contributor guidelines. Baloo reads this alongside AGENTS.md:
+
+```markdown
+# Contributing
+
+## Commit Format
+<type>(<scope>): <subject>
+
+Types: feat, fix, docs, refactor, test, chore
+
+## Pull Requests
+- Link the related issue
+- Include test coverage
+- Run lint before opening
+```
+
+## No Guidelines? No Problem
+
+If neither file exists in the repository, Baloo skips the guidelines compliance check entirely. It won't invent rules that aren't documented.
+
+## Configuration
+
+Guidelines enforcement is always on when the files exist. There is no separate toggle — if you don't want it, simply don't include `AGENTS.md` or `CONTRIBUTING.md` in your repository.

--- a/docs/features/models.md
+++ b/docs/features/models.md
@@ -1,0 +1,80 @@
+# Model Configuration
+
+Baloo supports multiple LLM providers and models. You can use short names for convenience or specify full `provider/model` strings.
+
+## Model Registry
+
+| Short Name | Provider | Model ID | Max Turns | Tier |
+|---|---|---|---|---|
+| `flash` | Google | gemini-2.5-flash | 10 | Economy |
+| `haiku` | Anthropic | claude-haiku-4-5 | 10 | Economy |
+| `sonnet` | Anthropic | claude-sonnet-4-6 | 20 | Standard |
+| `gemini-pro` | Google | gemini-2.5-pro | 20 | Standard |
+| `opus` | Anthropic | claude-opus-4-6 | 30 | Premium |
+
+## Choosing a Model
+
+- **Economy** (`flash`, `haiku`) — Good for simple PRs (docs, deps, configs). Fast and cheap. Also used internally for FP verification.
+- **Standard** (`sonnet`, `gemini-pro`) — The default. Handles most code reviews well. Best cost/quality balance.
+- **Premium** (`opus`) — Best for complex PRs with deep logic, security-sensitive code, or architectural changes.
+
+## Configuration
+
+```bash
+# Use a short name
+AGENT_MODEL=sonnet
+
+# Or a full provider/model string
+AGENT_MODEL=anthropic/claude-sonnet-4-6
+
+# Premium model for highest quality
+AGENT_MODEL=opus
+```
+
+## Automatic Fallback
+
+If the primary model fails (rate limit, timeout, availability), Baloo automatically retries with a fallback model:
+
+```bash
+AGENT_FALLBACK_MODEL=google/gemini-2.5-flash
+```
+
+The fallback uses a different provider to maximize availability. Set to empty to disable fallback.
+
+When fallback is used, the review metadata includes:
+- `fallback_used: true`
+- `primary_model` — which model failed
+- `primary_error` — why it failed
+
+## API Keys
+
+Each provider needs its own API key:
+
+| Provider | Environment Variable |
+|---|---|
+| Anthropic | `ANTHROPIC_API_KEY` |
+| Google | `GEMINI_API_KEY` |
+
+## Thinking Level
+
+Controls the depth of reasoning the model uses:
+
+```bash
+PI_THINKING_LEVEL=medium  # off, minimal, low, medium, high
+```
+
+Higher thinking = better analysis but slower and more expensive. `medium` is the default and recommended for most use cases.
+
+## Cost Estimates
+
+Approximate cost per review (typical 5-file PR):
+
+| Model | Cost per Review |
+|---|---|
+| `flash` | ~$0.005 |
+| `haiku` | ~$0.01 |
+| `sonnet` | ~$0.03–0.08 |
+| `gemini-pro` | ~$0.05–0.15 |
+| `opus` | ~$0.15–0.40 |
+
+Actual costs depend on PR size, number of agent turns, and thinking level.

--- a/docs/features/review-agent.md
+++ b/docs/features/review-agent.md
@@ -1,0 +1,55 @@
+# Review Agent
+
+Baloo uses [PI](https://github.com/mariozechner/pi-coding-agent) as its agentic runtime. When a PR is opened or updated, Baloo spawns a PI agent process that actively explores the repository to produce a thorough review.
+
+## How It Works
+
+1. **Webhook arrives** — GitHub sends a `pull_request` event
+2. **Context assembly** — Baloo fetches the PR diff, file list, metadata, and any prior discussion threads
+3. **Agent spawns** — A PI process starts in RPC mode with **read-only tools**: `read`, `grep`, `find`, `ls`
+4. **Agentic review** — The agent reads changed files in full, greps for security patterns, explores project structure, checks for tests and configs
+5. **Structured output** — The agent returns a JSON object with findings (file, line, severity, category, description, recommendation)
+6. **Post-processing** — Findings go through FP verification (optional), severity filtering, duplicate detection, and severity routing before being posted
+
+## Why Agentic?
+
+Unlike simple "diff-in, comments-out" reviewers, Baloo's agent can:
+
+- **Read full files** — not just the diff, but the entire file for context
+- **Search the codebase** — grep for patterns, find related files, check if tests exist
+- **Follow references** — if a function is changed, the agent can check where it's called
+- **Read project conventions** — examines `AGENTS.md` and `CONTRIBUTING.md` for repo-specific rules
+
+## Read-Only Guarantee
+
+The agent has **no write access**. It cannot execute commands, modify files, or make API calls. All mutations (posting comments, updating GitHub) happen in the deterministic Python code after the agent returns its findings.
+
+## Tools Available
+
+| Tool | Purpose |
+|---|---|
+| `read` | Read file contents (full or by line range) |
+| `grep` | Search for patterns across files |
+| `find` | Locate files by name or pattern |
+| `ls` | List directory contents |
+
+## What the Agent Reviews
+
+The system prompt instructs the agent to check, in priority order:
+
+1. **Security** — SQL injection, XSS, secrets exposure, command injection, auth/authz issues
+2. **Bugs** — Logic errors, null refs, race conditions, error handling gaps
+3. **Silent failures** — Swallowed exceptions, missing error logging, silent default substitution
+4. **Guidelines** — Violations of conventions in `AGENTS.md` / `CONTRIBUTING.md`
+5. **Performance** — N+1 queries, blocking operations, algorithm efficiency
+6. **Quality** — DRY, complexity, naming, test coverage
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `AGENT_MODEL` | `sonnet` | Model to use (see [Models](models.md)) |
+| `AGENT_FALLBACK_MODEL` | `google/gemini-2.5-flash` | Fallback if primary fails |
+| `AGENT_MAX_TOKENS` | `4096` | Max output tokens |
+| `AGENT_TEMPERATURE` | `0.2` | Temperature for generation |
+| `PI_THINKING_LEVEL` | `medium` | Thinking depth: off, minimal, low, medium, high |

--- a/docs/features/severity-routing.md
+++ b/docs/features/severity-routing.md
@@ -1,0 +1,54 @@
+# Severity Routing
+
+Baloo routes findings to different GitHub surfaces based on severity, so developers see critical issues prominently while non-blocking suggestions stay out of the way.
+
+## Routing Rules
+
+| Severity | Where It Goes | Blocks PR? |
+|---|---|---|
+| **CRITICAL** | Inline review comment + "Request Changes" | ✅ Yes |
+| **HIGH** | Inline review comment + "Request Changes" | ✅ Yes |
+| **MEDIUM** | GitHub Checks API annotation | ❌ No |
+| **LOW** | Filtered out (not posted) | ❌ No |
+
+## How It Looks
+
+### CRITICAL / HIGH → Review Comments
+
+Posted as inline comments on the exact file and line. The PR review is submitted with "Request Changes" status, which blocks merge (if branch protection requires it).
+
+### MEDIUM → Checks API
+
+Posted as annotations on a GitHub Check called "Baloo Code Quality". These appear in the Checks tab and as non-blocking annotations on the PR diff, but don't block merge.
+
+If the Checks API fails (e.g., missing permissions), MEDIUM findings fall back to regular issue comments.
+
+### LOW → Filtered
+
+Findings below the minimum severity threshold are not posted. This reduces noise for developers.
+
+## Severity Guidelines
+
+The agent assigns severity based on these guidelines:
+
+- **CRITICAL** — Security vulnerabilities, data loss, silent failures, guidelines violations
+- **HIGH** — Bugs or logic errors that can break functionality
+- **MEDIUM** — Quality, maintainability, or performance issues
+- **LOW** — Style or minor polish
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `REVIEW_MIN_SEVERITY` | `MEDIUM` | Minimum severity to post. Set to `LOW` to see everything, `HIGH` to reduce noise |
+| `REVIEW_USE_CHECKS_API` | `true` | Post MEDIUM findings to Checks API. When `false`, MEDIUM findings go to review comments |
+| `REVIEW_AUTO_APPROVE` | `true` | Auto-approve PRs with no CRITICAL/HIGH findings |
+
+## Approval Decision Logic
+
+```
+CRITICAL or HIGH found  →  Request Changes
+No blocking issues + high fidelity score  →  Approve
+No blocking issues + auto-approve enabled  →  Approve
+Otherwise  →  Comment only (no approval or rejection)
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,4 +249,4 @@ After the canary repository works:
 
 For direct code-level development and test commands, see [docs/development.md](development.md).
 
-For more container details, see [DOCKER.md](../DOCKER.md).
+For more container details, see [DOCKER.md](https://github.com/Blue-Bear-Security/baloo-bear/blob/main/DOCKER.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/baloo-banner.png" alt="Baloo — AI Code Review Agent" width="600">
+  <img src="assets/baloo-banner.png" alt="Baloo — AI Code Review Agent" width="600">
 </p>
 
 <p align="center">
@@ -84,7 +84,7 @@ docker compose up --build
 
 Install the GitHub App on your repositories. Open a PR — Baloo will review it automatically.
 
-📖 **Full setup guide**: [docs/getting-started.md](docs/getting-started.md)
+📖 **Full setup guide**: [getting-started.md](getting-started.md)
 
 ## Architecture
 
@@ -145,21 +145,21 @@ All settings are environment variables. Key ones:
 | `DASHBOARD_ENABLED` | `false` | Enable review dashboard UI |
 | `FIDELITY_ENABLED` | `true` | Compare PRs against plan docs |
 
-Full reference: [docs/configuration.md](docs/configuration.md)
+Full reference: [configuration.md](configuration.md)
 
 ## Documentation
 
-📖 **[Full documentation](docs/README.md)** — Feature guides, configuration reference, and more
+📖 **[Full documentation](./)** — Feature guides, configuration reference, and more
 
 Feature guides:
-- [Review Agent](docs/features/review-agent.md) — How the agentic review works
-- [Guidelines Enforcement](docs/features/guidelines.md) — Repo convention checking
-- [Fidelity Analysis](docs/features/fidelity.md) — Plan-vs-implementation scoring
-- [Models](docs/features/models.md) — Supported models and fallback
-- [Severity Routing](docs/features/severity-routing.md) — How findings reach developers
-- [Discussion Tracking](docs/features/discussions.md) — Thread follow-ups across iterations
-- [FP Verification](docs/features/fp-verification.md) — False-positive reduction
-- [Dashboard](docs/features/dashboard.md) — Review history UI
+- [Review Agent](features/review-agent.md) — How the agentic review works
+- [Guidelines Enforcement](features/guidelines.md) — Repo convention checking
+- [Fidelity Analysis](features/fidelity.md) — Plan-vs-implementation scoring
+- [Models](features/models.md) — Supported models and fallback
+- [Severity Routing](features/severity-routing.md) — How findings reach developers
+- [Discussion Tracking](features/discussions.md) — Thread follow-ups across iterations
+- [FP Verification](features/fp-verification.md) — False-positive reduction
+- [Dashboard](features/dashboard.md) — Review history UI
 
 ## Development
 
@@ -171,20 +171,20 @@ uv run ruff check baloo    # lint
 uv run black --check baloo # format check
 ```
 
-See [docs/development.md](docs/development.md) for the full contributor guide.
+See [development.md](development.md) for the full contributor guide.
 
 ## Roadmap
 
-See [docs/ROADMAP.md](docs/ROADMAP.md) for planned features including multi-model review with judge, conversational thread replies, and AST-enriched context.
+See [ROADMAP.md](ROADMAP.md) for planned features including multi-model review with judge, conversational thread replies, and AST-enriched context.
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow and conventions, and [AGENTS.md](AGENTS.md) for AI-agent-specific guidance.
+Contributions are welcome! See [CONTRIBUTING.md](contributing.md) for workflow and conventions, and [AGENTS.md](https://github.com/Blue-Bear-Security/baloo-bear/blob/main/AGENTS.md) for AI-agent-specific guidance.
 
 ## Security
 
-Please read [SECURITY.md](SECURITY.md) before reporting vulnerabilities.
+Please read [SECURITY.md](https://github.com/Blue-Bear-Security/baloo-bear/blob/main/SECURITY.md) before reporting vulnerabilities.
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](https://github.com/Blue-Bear-Security/baloo-bear/blob/main/LICENSE).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+site_name: Baloo
+site_description: AI-powered code review agent for GitHub pull requests
+site_url: https://blue-bear-security.github.io/baloo-bear
+repo_url: https://github.com/Blue-Bear-Security/baloo-bear
+repo_name: Blue-Bear-Security/baloo-bear
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Features:
+    - Review Agent: features/review-agent.md
+    - Guidelines Enforcement: features/guidelines.md
+    - Fidelity Analysis: features/fidelity.md
+    - Model Configuration: features/models.md
+    - Severity Routing: features/severity-routing.md
+    - Discussion Tracking: features/discussions.md
+    - FP Verification: features/fp-verification.md
+    - Dashboard: features/dashboard.md
+  - Configuration: configuration.md
+  - Development: development.md
+  - Roadmap: ROADMAP.md
+  - Contributing: contributing.md


### PR DESCRIPTION
## Summary

Make the repo presentable for open-source release.

## Changes

- **README** — Full rewrite: value prop, feature table, architecture diagram, badges, quick start, inline example
- **CI workflow** — `.github/workflows/ci.yml`: pytest + ruff + black on Python 3.11/3.12/3.13
- **Issue templates** — Bug report + feature request
- **PR template** — Checklist (tests, lint, format)
- **Repo metadata** — Description + 12 topics set via `gh repo edit`
- **Banner placeholder** — `docs/assets/.gitkeep` (need to create actual image)

## Still TODO (separate PRs)
- [ ] Create banner image / logo for `docs/assets/baloo-banner.png`
- [ ] Social preview image (GitHub repo settings)
- [ ] Enable GitHub Discussions
- [ ] First release tag once public