### PR TITLE
chore: fix CI dev-tooling install and repair lint bugs

### DIFF
--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -1,7 +1,6 @@
 """PI-based agent client for code review."""
 
 import logging
-from typing import List
 
 from baloo.agent.config import get_agent_options
 from baloo.agent.pi_runtime import PIAgentBase
@@ -9,7 +8,7 @@ from baloo.agent.prompts import (
     build_pr_review_prompt,
 )
 from baloo.agent.schemas import findings_to_comments
-from baloo.github.models import PRContext, ReviewResult, ReviewComment
+from baloo.github.models import PRContext, ReviewResult
 from baloo.processor.decision_engine import DecisionEngine
 from baloo.processor.formatter import CommentFormatter
 
@@ -39,7 +38,9 @@ class BalooAgent(PIAgentBase):
         if model_override:
             self.options = get_agent_options(model_override)
 
-        logger.info(f"Starting review for {pr_context.repo_full_name}#{pr_context.pr_number} using {self.options.model}")
+        logger.info(
+            f"Starting review for {pr_context.repo_full_name}#{pr_context.pr_number} using {self.options.model}"
+        )
 
         try:
             # Build review prompt
@@ -121,10 +122,7 @@ class BalooAgent(PIAgentBase):
             fallback_provider, fallback_model = fallback.split("/", 1)
 
             # Don't fallback to the same provider/model we just failed with
-            if (
-                fallback_provider == self.options.provider
-                and fallback_model == self.options.model
-            ):
+            if fallback_provider == self.options.provider and fallback_model == self.options.model:
                 raise
 
             logger.warning(
@@ -149,9 +147,7 @@ class BalooAgent(PIAgentBase):
                 result[1]["primary_error"] = str(primary_err)
                 return result
             except Exception as fallback_err:
-                logger.error(
-                    "Fallback model %s also failed: %s", fallback, fallback_err
-                )
+                logger.error("Fallback model %s also failed: %s", fallback, fallback_err)
                 # Restore original model info on the exception metadata
                 if hasattr(primary_err, "metadata"):
                     raise primary_err from fallback_err

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -15,8 +15,8 @@ import logging
 import re
 import time
 import uuid
-from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any
 
 from baloo.config.settings import get_settings
 
@@ -132,7 +132,7 @@ class PIAgentBase:
     # Helpers
     # -----------------------------------------------------------------
 
-    def _build_metadata(self, result: PIRunResult) -> Dict[str, Any]:
+    def _build_metadata(self, result: PIRunResult) -> dict[str, Any]:
         """Build metadata dict from a PIRunResult."""
         return {
             "model": result.model or self.options.model,
@@ -149,7 +149,7 @@ class PIAgentBase:
     # Main query interface
     # -----------------------------------------------------------------
 
-    async def run_query(self, query: str) -> Tuple[Any, Dict[str, Any]]:
+    async def run_query(self, query: str) -> tuple[Any, dict[str, Any]]:
         """Run a query through the PI agent and return structured output + metadata.
 
         Returns:
@@ -164,14 +164,19 @@ class PIAgentBase:
 
         cmd = [
             pi_binary,
-            "--mode", "rpc",
+            "--mode",
+            "rpc",
             "--no-session",
-            "--provider", self.options.provider,
-            "--model", f"{self.options.provider}/{self.options.model}",
+            "--provider",
+            self.options.provider,
+            "--model",
+            f"{self.options.provider}/{self.options.model}",
             # Read-only tools only — no bash, no write, no edit
-            "--tools", "read,grep,find,ls",
+            "--tools",
+            "read,grep,find,ls",
             # Inject system prompt
-            "--system-prompt", self.options.system_prompt,
+            "--system-prompt",
+            self.options.system_prompt,
         ]
 
         logger.info(
@@ -245,8 +250,7 @@ class PIAgentBase:
 
         if structured_output is None and result.assistant_text:
             logger.warning(
-                "%s: could not parse JSON from assistant response (%d chars). "
-                "Raw text: %s...",
+                "%s: could not parse JSON from assistant response (%d chars). " "Raw text: %s...",
                 self.agent_name,
                 len(result.assistant_text),
                 result.assistant_text[:1000].replace("\n", " "),
@@ -271,12 +275,10 @@ class PIAgentBase:
         "Your previous response could not be parsed as JSON. "
         "Please re-emit ONLY the JSON object matching the output schema "
         "from your analysis. No markdown fences, no explanation — just "
-        "the raw JSON object with \"findings\" and \"summary\" keys."
+        'the raw JSON object with "findings" and "summary" keys.'
     )
 
-    async def _retry_json(
-        self, *, proc_cwd: str | None
-    ) -> Tuple[Any, Dict[str, Any] | None]:
+    async def _retry_json(self, *, proc_cwd: str | None) -> tuple[Any, dict[str, Any] | None]:
         """Spawn a cheap follow-up session to ask the model to fix its JSON.
 
         Uses the same model but with thinking off and max 2 turns to keep
@@ -287,12 +289,17 @@ class PIAgentBase:
 
         cmd = [
             pi_binary,
-            "--mode", "rpc",
+            "--mode",
+            "rpc",
             "--no-session",
-            "--provider", self.options.provider,
-            "--model", f"{self.options.provider}/{self.options.model}",
-            "--tools", "read,grep,find,ls",
-            "--system-prompt", self.options.system_prompt,
+            "--provider",
+            self.options.provider,
+            "--model",
+            f"{self.options.provider}/{self.options.model}",
+            "--tools",
+            "read,grep,find,ls",
+            "--system-prompt",
+            self.options.system_prompt,
         ]
 
         start = time.time()
@@ -317,9 +324,7 @@ class PIAgentBase:
             original_opts = self.options
             self.options = retry_opts
             try:
-                result = await self._drive_session(
-                    proc, self._JSON_RETRY_PROMPT, start
-                )
+                result = await self._drive_session(proc, self._JSON_RETRY_PROMPT, start)
             finally:
                 self.options = original_opts
                 if proc.returncode is None:

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -83,15 +83,22 @@ def _is_simple_pr(pr_context: PRContext | dict[str, Any]) -> bool:
 
     # Check if all files are dependency or config files
     simple_file_patterns = [
-        'requirements.txt', 'package.json', 'package-lock.json',
-        'go.mod', 'go.sum', 'Gemfile', 'Gemfile.lock',
-        '.md', '.txt', '.yml', '.yaml', '.toml', '.ini'
+        "requirements.txt",
+        "package.json",
+        "package-lock.json",
+        "go.mod",
+        "go.sum",
+        "Gemfile",
+        "Gemfile.lock",
+        ".md",
+        ".txt",
+        ".yml",
+        ".yaml",
+        ".toml",
+        ".ini",
     ]
 
-    return all(
-        any(f.endswith(pattern) for pattern in simple_file_patterns)
-        for f in changed_files
-    )
+    return all(any(f.endswith(pattern) for pattern in simple_file_patterns) for f in changed_files)
 
 
 # Maximum characters to show in recommendation summary fallback
@@ -138,8 +145,8 @@ def _extract_baloo_recommendations(threads: list) -> str:
 
         if len(parts) > 1 and parts[1].strip():
             # Extract first few lines after recommendation marker
-            rec_lines = parts[1].split('\n')[0:3]  # Get first 3 lines
-            rec_summary = '\n'.join(rec_lines).strip()
+            rec_lines = parts[1].split("\n")[0:3]  # Get first 3 lines
+            rec_summary = "\n".join(rec_lines).strip()
 
             # Fallback if extraction resulted in empty string
             if not rec_summary:
@@ -213,27 +220,38 @@ def _is_dependabot_pr(pr_context: PRContext | dict[str, Any]) -> bool:
     description = (_ctx_get(pr_context, "description", "") or "").lower()
 
     # Explicit Dependabot detection
-    if 'dependabot' in author or 'dependabot' in title or 'dependabot' in description:
+    if "dependabot" in author or "dependabot" in title or "dependabot" in description:
         return True
 
     # Known dependency update bots (whitelist)
-    dependency_bots = ['renovate[bot]', 'dependabot[bot]', 'dependabot-preview[bot]']
+    dependency_bots = ["renovate[bot]", "dependabot[bot]", "dependabot-preview[bot]"]
     if author in dependency_bots:
         return True
 
     # Bot with dependency-specific keywords (stricter check)
-    if author.endswith('[bot]'):
+    if author.endswith("[bot]"):
         # More specific dependency-related keywords
-        dependency_keywords = ['bump', 'upgrade']
+        dependency_keywords = ["bump", "upgrade"]
         if any(kw in title for kw in dependency_keywords):
             # Additional check: verify dependency files are being changed
             changed_files = _ctx_get(pr_context, "changed_file_paths", [])
             dep_file_patterns = [
-                'requirements.txt', 'package.json', 'package-lock.json',
-                'go.mod', 'go.sum', 'Gemfile', 'Gemfile.lock',
-                'pom.xml', 'build.gradle', 'yarn.lock', 'Cargo.toml', 'Cargo.lock'
+                "requirements.txt",
+                "package.json",
+                "package-lock.json",
+                "go.mod",
+                "go.sum",
+                "Gemfile",
+                "Gemfile.lock",
+                "pom.xml",
+                "build.gradle",
+                "yarn.lock",
+                "Cargo.toml",
+                "Cargo.lock",
             ]
-            if any(any(f.endswith(pattern) for pattern in dep_file_patterns) for f in changed_files):
+            if any(
+                any(f.endswith(pattern) for pattern in dep_file_patterns) for f in changed_files
+            ):
                 return True
 
     return False
@@ -245,12 +263,12 @@ def _is_security_patch(pr_context: PRContext | dict[str, Any]) -> bool:
     description = (_ctx_get(pr_context, "description", "") or "").lower()
 
     return (
-        'security' in title or
-        'security' in description or
-        'vulnerability' in title or
-        'vulnerability' in description or
-        'cve' in title or
-        'cve' in description
+        "security" in title
+        or "security" in description
+        or "vulnerability" in title
+        or "vulnerability" in description
+        or "cve" in title
+        or "cve" in description
     )
 
 
@@ -376,7 +394,7 @@ def build_pr_review_prompt(pr_context: PRContext | dict[str, Any]) -> str:
         guidelines_section = (
             f"The following guidelines were fetched directly from this repository:\n\n"
             f"```\n{repo_guidelines}\n```\n\n"
-            f"Flag any violations of the conventions documented above as **CRITICAL** with category \"Guidelines\".\n"
+            f'Flag any violations of the conventions documented above as **CRITICAL** with category "Guidelines".\n'
             f"Only flag a violation if the guidelines explicitly require a specific convention."
         )
     else:

--- a/baloo/agent/schemas.py
+++ b/baloo/agent/schemas.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -13,14 +12,10 @@ from baloo.github.models import FindingCategory, ReviewComment, ReviewSeverity
 logger = logging.getLogger(__name__)
 
 # Lookup for case-insensitive category matching
-_CATEGORY_LOOKUP: dict[str, str] = {
-    v.value.upper(): v.value for v in FindingCategory
-}
+_CATEGORY_LOOKUP: dict[str, str] = {v.value.upper(): v.value for v in FindingCategory}
 
 # Lookup for case-insensitive severity matching
-_SEVERITY_LOOKUP: dict[str, str] = {
-    v.value.upper(): v.value for v in ReviewSeverity
-}
+_SEVERITY_LOOKUP: dict[str, str] = {v.value.upper(): v.value for v in ReviewSeverity}
 
 
 def _normalize_category(raw: str) -> str:

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -1,6 +1,7 @@
 """Configuration settings for Baloo using Pydantic."""
 
 import os
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -18,13 +19,17 @@ class Settings(BaseSettings):
     # GitHub App Configuration
     github_app_id: str = Field(default="", description="GitHub App ID")
     github_private_key: str = Field(default="", description="GitHub App private key (PEM format)")
-    github_webhook_secret: str = Field(default="", description="GitHub webhook secret for signature validation")
+    github_webhook_secret: str = Field(
+        default="", description="GitHub webhook secret for signature validation"
+    )
 
     # Anthropic Configuration
     anthropic_api_key: str = Field(default="", description="Anthropic API key for Claude")
 
     # Application Configuration
-    app_environment: str = Field(default="development", description="Application environment (development, production)")
+    app_environment: str = Field(
+        default="development", description="Application environment (development, production)"
+    )
     app_host: str = Field(default="0.0.0.0", description="Application host")
     app_port: int = Field(default=8000, description="Application port")
     log_level: str = Field(default="INFO", description="Logging level")
@@ -34,7 +39,9 @@ class Settings(BaseSettings):
     )
 
     # Agent Configuration
-    agent_provider: str = Field(default="anthropic", description="LLM provider (anthropic, google, openai)")
+    agent_provider: str = Field(
+        default="anthropic", description="LLM provider (anthropic, google, openai)"
+    )
     agent_model: str = Field(default="claude-sonnet-4-6", description="Model to use for reviews")
     agent_fallback_model: str = Field(
         default="google/gemini-2.5-flash",
@@ -76,15 +83,9 @@ class Settings(BaseSettings):
     )
 
     # Dashboard Configuration
-    dashboard_enabled: bool = Field(
-        default=True, description="Enable the review history dashboard"
-    )
-    dashboard_username: str = Field(
-        default="", description="Dashboard basic auth username"
-    )
-    dashboard_password: str = Field(
-        default="", description="Dashboard basic auth password"
-    )
+    dashboard_enabled: bool = Field(default=True, description="Enable the review history dashboard")
+    dashboard_username: str = Field(default="", description="Dashboard basic auth username")
+    dashboard_password: str = Field(default="", description="Dashboard basic auth password")
 
     # Fidelity Report Configuration
     fidelity_enabled: bool = Field(

--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -60,9 +60,7 @@ class DashboardService:
             error_statuses = ["error", "agent_error"]
             errors_total = (
                 await session.execute(
-                    select(func.count(Review.id)).where(
-                        Review.review_status.in_(error_statuses)
-                    )
+                    select(func.count(Review.id)).where(Review.review_status.in_(error_statuses))
                 )
             ).scalar() or 0
 
@@ -90,27 +88,33 @@ class DashboardService:
 
             # Recent failures
             recent_failures = (
-                await session.execute(
-                    select(Review)
-                    .where(Review.review_status.in_(error_statuses))
-                    .order_by(Review.started_at.desc())
-                    .limit(5)
+                (
+                    await session.execute(
+                        select(Review)
+                        .where(Review.review_status.in_(error_statuses))
+                        .order_by(Review.started_at.desc())
+                        .limit(5)
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
 
             # Recent reviews
             recent = (
-                await session.execute(
-                    select(Review).order_by(Review.started_at.desc()).limit(5)
-                )
-            ).scalars().all()
+                (await session.execute(select(Review).order_by(Review.started_at.desc()).limit(5)))
+                .scalars()
+                .all()
+            )
 
             # Reviews per hour (last 24h)
             last_24h = now - timedelta(hours=24)
-            
+
             # Dialect-aware hour grouping
             if "postgres" in settings.database_url:
-                hour_label = func.to_char(func.date_trunc("hour", Review.started_at), "YYYY-MM-DD HH24:00")
+                hour_label = func.to_char(
+                    func.date_trunc("hour", Review.started_at), "YYYY-MM-DD HH24:00"
+                )
             else:
                 # Default to SQLite
                 hour_label = func.strftime("%Y-%m-%d %H:00", Review.started_at)
@@ -181,10 +185,14 @@ class DashboardService:
 
             # Distinct repos for filter dropdown
             repos = (
-                await session.execute(
-                    select(Review.repo_full_name).distinct().order_by(Review.repo_full_name)
+                (
+                    await session.execute(
+                        select(Review.repo_full_name).distinct().order_by(Review.repo_full_name)
+                    )
                 )
-            ).scalars().all()
+                .scalars()
+                .all()
+            )
 
         total_pages = max(1, -(-total // per_page))  # ceil division
         return {
@@ -204,9 +212,7 @@ class DashboardService:
 
         async with factory() as session:
             result = await session.execute(
-                select(Review)
-                .options(selectinload(Review.findings))
-                .where(Review.id == review_id)
+                select(Review).options(selectinload(Review.findings)).where(Review.id == review_id)
             )
             return result.scalars().first()
 
@@ -262,8 +268,9 @@ class DashboardService:
             # Previous period stats for trends
             prev_total_cost = (
                 await session.execute(
-                    select(func.sum(Review.cost_usd))
-                    .where(Review.started_at >= prev_since, Review.started_at < since)
+                    select(func.sum(Review.cost_usd)).where(
+                        Review.started_at >= prev_since, Review.started_at < since
+                    )
                 )
             ).scalar() or 0
             prev_error_total = (
@@ -277,8 +284,9 @@ class DashboardService:
             ).scalar() or 0
             prev_total_in_period = (
                 await session.execute(
-                    select(func.count(Review.id))
-                    .where(Review.started_at >= prev_since, Review.started_at < since)
+                    select(func.count(Review.id)).where(
+                        Review.started_at >= prev_since, Review.started_at < since
+                    )
                 )
             ).scalar() or 0
             prev_success_rate = (

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -38,7 +38,10 @@ async def reviews_list(
     search: str | None = Query(None),
 ):
     data = await DashboardService.list_reviews(
-        page=page, repo_filter=repo, status_filter=status, search_filter=search,
+        page=page,
+        repo_filter=repo,
+        status_filter=status,
+        search_filter=search,
     )
     ctx = {"repo": repo, "status": status, "search": search, **data}
     # HTMX partial swap

--- a/baloo/db/engine.py
+++ b/baloo/db/engine.py
@@ -53,9 +53,7 @@ def _run_alembic_migrations(database_url: str) -> bool:
     alembic_ini = project_root / "alembic.ini"
 
     if not alembic_ini.exists():
-        logger.warning(
-            "alembic.ini not found at %s, skipping migrations", alembic_ini
-        )
+        logger.warning("alembic.ini not found at %s, skipping migrations", alembic_ini)
         return False
 
     # Convert async URL to sync for Alembic
@@ -81,8 +79,7 @@ def _run_alembic_migrations(database_url: str) -> bool:
 
         if "reviews" in tables and "alembic_version" not in tables:
             logger.info(
-                "Existing DB without alembic_version detected, "
-                "stamping baseline revision 001"
+                "Existing DB without alembic_version detected, " "stamping baseline revision 001"
             )
             command.stamp(alembic_cfg, "001")
     except Exception as e:

--- a/baloo/db/migrations/versions/001_initial_schema.py
+++ b/baloo/db/migrations/versions/001_initial_schema.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2026-02-06
 
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/baloo/db/migrations/versions/002_add_error_tracking.py
+++ b/baloo/db/migrations/versions/002_add_error_tracking.py
@@ -8,6 +8,7 @@ Adds error_category to classify failure modes (agent_error, buffer_overflow,
 json_parse_error, fallback_used, prompt_too_long, etc.) and fallback_model
 to record when a secondary model was used.
 """
+
 from collections.abc import Sequence
 
 import sqlalchemy as sa

--- a/baloo/db/service.py
+++ b/baloo/db/service.py
@@ -17,11 +17,13 @@ logger = logging.getLogger(__name__)
 
 class ReviewServiceError(Exception):
     """Base exception for ReviewService."""
+
     pass
 
 
 class ReviewNotFoundError(ReviewServiceError):
     """Raised when a review is not found in the database."""
+
     pass
 
 
@@ -63,7 +65,7 @@ class ReviewService:
 
         Returns:
             The review ID.
-        
+
         Raises:
             ReviewServiceError: If database operation fails.
         """
@@ -83,10 +85,7 @@ class ReviewService:
                     session.add(review)
                     await session.flush()
 
-                logger.info(
-                    f"Started review {review.id} for "
-                    f"{repo_full_name}#{pr_number}"
-                )
+                logger.info(f"Started review {review.id} for " f"{repo_full_name}#{pr_number}")
                 return review.id
 
         except Exception as e:

--- a/baloo/fidelity/fidelity_analyzer.py
+++ b/baloo/fidelity/fidelity_analyzer.py
@@ -1,7 +1,6 @@
 """Fidelity analyzer using PI agent."""
 
 import logging
-from typing import Optional
 
 from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions
 from baloo.fidelity.models import (
@@ -33,7 +32,7 @@ class FidelityAgent(PIAgentBase):
         pr_title: str,
         diff: str,
         ticket_id: str,
-    ) -> Optional[FidelityResult]:
+    ) -> FidelityResult | None:
         """
         Run fidelity analysis comparing PR changes to design plan.
 
@@ -75,7 +74,7 @@ class FidelityAgent(PIAgentBase):
 
     def _parse_structured_fidelity(
         self, data: dict | None, ticket_id: str
-    ) -> Optional[FidelityResult]:
+    ) -> FidelityResult | None:
         """Validate structured output and convert to FidelityResult."""
         if data is None:
             logger.warning("No structured output received from fidelity agent")
@@ -102,7 +101,7 @@ async def analyze_fidelity(
     pr_title: str,
     diff: str,
     ticket_id: str,
-) -> Optional[FidelityResult]:
+) -> FidelityResult | None:
     """Legacy wrapper for FidelityAgent (maintains compatibility)."""
     agent = FidelityAgent()
     return await agent.analyze(plan_content, pr_title, diff, ticket_id)

--- a/baloo/fidelity/fidelity_report.py
+++ b/baloo/fidelity/fidelity_report.py
@@ -1,6 +1,5 @@
 """Format fidelity analysis results as markdown report."""
 
-
 from baloo.fidelity.models import FidelityResult
 
 
@@ -64,11 +63,13 @@ def _format_result(result: FidelityResult) -> str:
 
     # Requirements checklist
     if result.requirements:
-        lines.extend([
-            "### Requirement Checklist",
-            "| Requirement | Status | Evidence |",
-            "|-------------|--------|----------|",
-        ])
+        lines.extend(
+            [
+                "### Requirement Checklist",
+                "| Requirement | Status | Evidence |",
+                "|-------------|--------|----------|",
+            ]
+        )
         for req in result.requirements:
             status_icon = _get_status_icon(req.status)
             evidence = req.evidence or "-"
@@ -80,21 +81,25 @@ def _format_result(result: FidelityResult) -> str:
 
     # Hidden extras
     if result.extras:
-        lines.extend([
-            "### Hidden Extras",
-            "_Changes implemented beyond the plan:_",
-            "",
-        ])
+        lines.extend(
+            [
+                "### Hidden Extras",
+                "_Changes implemented beyond the plan:_",
+                "",
+            ]
+        )
         for extra in result.extras:
             lines.append(f"- {extra}")
         lines.append("")
 
     # Critical discrepancies
     if result.discrepancies:
-        lines.extend([
-            "### Critical Discrepancies",
-            "",
-        ])
+        lines.extend(
+            [
+                "### Critical Discrepancies",
+                "",
+            ]
+        )
         for disc in result.discrepancies:
             severity_icon = _get_severity_icon(disc.severity)
             lines.append(f"- {severity_icon} **[{disc.severity}]** {disc.description}")

--- a/baloo/fidelity/models.py
+++ b/baloo/fidelity/models.py
@@ -1,6 +1,5 @@
 """Pydantic models for fidelity report data."""
 
-
 from pydantic import BaseModel, Field
 
 
@@ -18,9 +17,7 @@ class Discrepancy(BaseModel):
     """A discrepancy between the plan and implementation."""
 
     description: str = Field(description="Description of the discrepancy")
-    severity: str = Field(
-        default="MEDIUM", description="Severity: LOW, MEDIUM, HIGH"
-    )
+    severity: str = Field(default="MEDIUM", description="Severity: LOW, MEDIUM, HIGH")
 
 
 class FidelityOutput(BaseModel):
@@ -42,12 +39,8 @@ class FidelityResult(BaseModel):
     """Result of fidelity analysis comparing PR to design plan."""
 
     ticket_id: str = Field(description="The ticket ID (e.g., PROJ-123)")
-    fidelity_score: int = Field(
-        description="Fidelity score 0-100 indicating alignment with plan"
-    )
-    logic_summary: str = Field(
-        description="2-sentence business explanation of the implementation"
-    )
+    fidelity_score: int = Field(description="Fidelity score 0-100 indicating alignment with plan")
+    logic_summary: str = Field(description="2-sentence business explanation of the implementation")
     requirements: list[Requirement] = Field(
         default_factory=list, description="Requirements and their fulfillment status"
     )
@@ -57,6 +50,4 @@ class FidelityResult(BaseModel):
     discrepancies: list[Discrepancy] = Field(
         default_factory=list, description="Critical differences from the plan"
     )
-    metadata: dict = Field(
-        default_factory=dict, description="Metadata like cost, tokens"
-    )
+    metadata: dict = Field(default_factory=dict, description="Metadata like cost, tokens")

--- a/baloo/fidelity/plan_fetcher.py
+++ b/baloo/fidelity/plan_fetcher.py
@@ -53,10 +53,7 @@ async def fetch_plan_content(
 
         # Find files that start with the ticket ID
         ticket_prefix = f"{ticket_id}-"
-        matching_files = [
-            f for f in files
-            if f.startswith(ticket_prefix) and f.endswith(".md")
-        ]
+        matching_files = [f for f in files if f.startswith(ticket_prefix) and f.endswith(".md")]
 
         if not matching_files:
             logger.info(f"No plan file found for {ticket_id} at {exact_path}")
@@ -67,13 +64,9 @@ async def fetch_plan_content(
         plan_path = f"{plans_dir}/{plan_file}"
         logger.debug(f"Found matching plan file: {plan_path}")
 
-        content = await github_client.get_file_content(
-            repo_full_name, plan_path, ref
-        )
+        content = await github_client.get_file_content(repo_full_name, plan_path, ref)
         if content:
-            logger.info(
-                f"Found plan file for {ticket_id} ({plan_file}): {len(content)} chars"
-            )
+            logger.info(f"Found plan file for {ticket_id} ({plan_file}): {len(content)} chars")
             return content
 
         return None

--- a/baloo/fidelity/ticket_extractor.py
+++ b/baloo/fidelity/ticket_extractor.py
@@ -8,9 +8,6 @@ from baloo.config.settings import get_settings
 logger = logging.getLogger(__name__)
 
 
-
-
-
 def extract_ticket_id(
     branch_name: str,
     pr_title: str,
@@ -36,7 +33,7 @@ def extract_ticket_id(
     """
     if prefix is None:
         prefix = get_settings().ticket_id_prefix
-    
+
     pattern = re.compile(rf"{prefix}-(\d+)", re.IGNORECASE)
 
     # Try branch name first
@@ -60,7 +57,6 @@ def extract_ticket_id(
 
     logger.debug("No ticket ID found in PR metadata")
     return None
-
 
 
 def _extract_from_branch(branch_name: str, prefix: str, pattern: re.Pattern) -> str | None:

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -111,8 +111,12 @@ class GitHubAPIClient:
                 diff = diff_response.text
 
             # Fetch discussion data
-            review_comments_url = f"{self.base_url}/repos/{repo_full_name}/pulls/{pr_number}/comments"
-            issue_comments_url = f"{self.base_url}/repos/{repo_full_name}/issues/{pr_number}/comments"
+            review_comments_url = (
+                f"{self.base_url}/repos/{repo_full_name}/pulls/{pr_number}/comments"
+            )
+            issue_comments_url = (
+                f"{self.base_url}/repos/{repo_full_name}/issues/{pr_number}/comments"
+            )
             reviews_url = f"{self.base_url}/repos/{repo_full_name}/pulls/{pr_number}/reviews"
 
             review_comments = await self._fetch_paginated_json(
@@ -178,6 +182,7 @@ class GitHubAPIClient:
             review_result: Review result to post
         """
         import logging
+
         logger = logging.getLogger(__name__)
 
         async with httpx.AsyncClient() as client:
@@ -211,7 +216,9 @@ class GitHubAPIClient:
                     review_url, headers=self._get_headers(), json=review_payload
                 )
                 response.raise_for_status()
-                logger.info(f"Successfully posted review with {len(review_result.comments)} inline comments")
+                logger.info(
+                    f"Successfully posted review with {len(review_result.comments)} inline comments"
+                )
 
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 422:
@@ -234,14 +241,14 @@ class GitHubAPIClient:
                         await self.post_comment(repo_full_name, pr_number, comment_body)
                         logger.info(f"Posted issue comment {i+1}/{len(review_result.comments)}")
 
-                    logger.info(f"Successfully posted review as {len(review_result.comments)} issue comments")
+                    logger.info(
+                        f"Successfully posted review as {len(review_result.comments)} issue comments"
+                    )
                 else:
                     # Other HTTP error - re-raise
                     raise
 
-    async def post_comment(
-        self, repo_full_name: str, pr_number: int, comment: str
-    ) -> int:
+    async def post_comment(self, repo_full_name: str, pr_number: int, comment: str) -> int:
         """
         Post a general comment to a pull request.
 
@@ -254,9 +261,7 @@ class GitHubAPIClient:
             The comment ID
         """
         async with httpx.AsyncClient() as client:
-            comment_url = (
-                f"{self.base_url}/repos/{repo_full_name}/issues/{pr_number}/comments"
-            )
+            comment_url = f"{self.base_url}/repos/{repo_full_name}/issues/{pr_number}/comments"
             response = await client.post(
                 comment_url,
                 headers=self._get_headers(),
@@ -265,9 +270,7 @@ class GitHubAPIClient:
             response.raise_for_status()
             return response.json()["id"]
 
-    async def edit_comment(
-        self, repo_full_name: str, comment_id: int, comment: str
-    ) -> None:
+    async def edit_comment(self, repo_full_name: str, comment_id: int, comment: str) -> None:
         """
         Edit an existing comment.
 
@@ -277,9 +280,7 @@ class GitHubAPIClient:
             comment: New comment text
         """
         async with httpx.AsyncClient() as client:
-            comment_url = (
-                f"{self.base_url}/repos/{repo_full_name}/issues/comments/{comment_id}"
-            )
+            comment_url = f"{self.base_url}/repos/{repo_full_name}/issues/comments/{comment_id}"
             response = await client.patch(
                 comment_url,
                 headers=self._get_headers(),
@@ -305,7 +306,9 @@ class GitHubAPIClient:
             True if reply was successful, False if comment is outdated (404)
         """
         async with httpx.AsyncClient() as client:
-            reply_url = f"{self.base_url}/repos/{repo_full_name}/pulls/comments/{review_comment_id}/replies"
+            reply_url = (
+                f"{self.base_url}/repos/{repo_full_name}/pulls/comments/{review_comment_id}/replies"
+            )
             response = await client.post(
                 reply_url,
                 headers=self._get_headers(),
@@ -370,7 +373,7 @@ class GitHubAPIClient:
                 # Check for common merge patterns
                 merge_patterns = [
                     f"merge branch '{base_branch}'",
-                    f"merge branch \"{base_branch}\"",
+                    f'merge branch "{base_branch}"',
                     f"merge {base_branch} into",
                     "merge pull request",
                     "merge remote-tracking branch",
@@ -384,7 +387,10 @@ class GitHubAPIClient:
 
                         # If it only has a few conflict resolution files, likely just a sync
                         if len(files) <= 3:
-                            return True, f"merge commit with only {len(files)} file(s) (conflict resolution)"
+                            return (
+                                True,
+                                f"merge commit with only {len(files)} file(s) (conflict resolution)",
+                            )
 
             return False, ""
 
@@ -455,9 +461,7 @@ class GitHubAPIClient:
                 params["ref"] = ref
 
             try:
-                response = await client.get(
-                    url, headers=self._get_headers(), params=params
-                )
+                response = await client.get(url, headers=self._get_headers(), params=params)
 
                 if response.status_code == 404:
                     return []
@@ -486,7 +490,9 @@ class GitHubAPIClient:
         page = 1
 
         while True:
-            response = await client.get(url, headers=headers, params={"per_page": 100, "page": page})
+            response = await client.get(
+                url, headers=headers, params={"per_page": 100, "page": page}
+            )
             response.raise_for_status()
             data = response.json()
             if not data:

--- a/baloo/github/checks_api.py
+++ b/baloo/github/checks_api.py
@@ -9,6 +9,9 @@ from baloo.github.models import ReviewComment
 
 logger = logging.getLogger(__name__)
 
+# GitHub limits annotations to 50 per request
+MAX_ANNOTATIONS = 50
+
 
 def _enum_value(value: object) -> object:
     """Return enum values for user-facing strings without changing plain strings."""
@@ -39,12 +42,7 @@ class GitHubChecksClient:
         }
 
     async def create_check_run(
-        self,
-        repo_full_name: str,
-        commit_sha: str,
-        name: str,
-        conclusion: str,
-        summary: str
+        self, repo_full_name: str, commit_sha: str, name: str, conclusion: str, summary: str
     ) -> str:
         """
         Create a GitHub Check Run.
@@ -66,10 +64,7 @@ class GitHubChecksClient:
                 "head_sha": commit_sha,
                 "status": "completed",
                 "conclusion": conclusion,
-                "output": {
-                    "title": name,
-                    "summary": summary
-                }
+                "output": {"title": name, "summary": summary},
             }
 
             logger.debug(f"Creating check run: {name} for {repo_full_name}@{commit_sha[:7]}")
@@ -82,10 +77,7 @@ class GitHubChecksClient:
             return str(data["id"])
 
     async def add_annotations(
-        self,
-        repo_full_name: str,
-        check_run_id: str,
-        findings: list[ReviewComment]
+        self, repo_full_name: str, check_run_id: str, findings: list[ReviewComment]
     ) -> None:
         """
         Add annotations to a check run.
@@ -100,9 +92,6 @@ class GitHubChecksClient:
         if not findings:
             logger.debug("No findings to annotate")
             return
-
-        # GitHub limits annotations to 50 per request
-        MAX_ANNOTATIONS = 50
 
         if len(findings) > MAX_ANNOTATIONS:
             logger.warning(
@@ -121,7 +110,7 @@ class GitHubChecksClient:
                 "end_line": finding.line,
                 "annotation_level": "warning",  # Can be: notice, warning, failure
                 "message": f"{category}: {finding.body}",
-                "title": f"[{severity}] {category}"
+                "title": f"[{severity}] {category}",
             }
             annotations.append(annotation)
 
@@ -131,7 +120,7 @@ class GitHubChecksClient:
                 "output": {
                     "title": "Baloo Code Quality",
                     "summary": f"Found {len(findings)} code quality issue(s)",
-                    "annotations": annotations
+                    "annotations": annotations,
                 }
             }
 

--- a/baloo/github/discussions.py
+++ b/baloo/github/discussions.py
@@ -88,7 +88,9 @@ def build_review_threads(raw_comments: Sequence[dict]) -> list[DiscussionThread]
     threads: dict[int, list[dict]] = {}
 
     for comment in raw_comments:
-        root_id = comment.get("in_reply_to_id") or comment.get("original_comment_id") or comment["id"]
+        root_id = (
+            comment.get("in_reply_to_id") or comment.get("original_comment_id") or comment["id"]
+        )
         threads.setdefault(root_id, []).append(comment)
 
     discussion_threads: list[DiscussionThread] = []
@@ -108,7 +110,9 @@ def build_review_threads(raw_comments: Sequence[dict]) -> list[DiscussionThread]
         is_baloo_thread = any(comment.is_baloo for comment in discussion_comments)
         last_comment = discussion_comments[-1]
         awaiting_response = is_baloo_thread and last_comment.is_baloo
-        resolved = determine_resolution_state(is_baloo_thread, awaiting_response, discussion_comments)
+        resolved = determine_resolution_state(
+            is_baloo_thread, awaiting_response, discussion_comments
+        )
 
         discussion_threads.append(
             DiscussionThread(

--- a/baloo/github/models.py
+++ b/baloo/github/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 class ReviewSeverity(str, Enum):
     """Standard severity levels for review findings."""
+
     CRITICAL = "CRITICAL"
     HIGH = "HIGH"
     MEDIUM = "MEDIUM"
@@ -19,6 +20,7 @@ class ReviewSeverity(str, Enum):
 
 class FindingCategory(str, Enum):
     """Standard categories for review findings."""
+
     SECURITY = "Security"
     BUGS = "Bugs"
     SILENT_FAILURES = "Silent Failures"

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -19,6 +19,7 @@ from baloo.db.engine import close_db, init_db
 from baloo.db.service import ReviewCompleteDTO, ReviewService
 from baloo.fidelity.fidelity_analyzer import analyze_fidelity
 from baloo.fidelity.fidelity_report import format_fidelity_report
+from baloo.fidelity.models import FidelityResult
 from baloo.fidelity.plan_fetcher import fetch_plan_content
 from baloo.fidelity.ticket_extractor import extract_ticket_id
 from baloo.github.api_client import GitHubAPIClient
@@ -88,7 +89,9 @@ def get_review_semaphore() -> asyncio.Semaphore:
     global review_semaphore
     if review_semaphore is None:
         review_semaphore = asyncio.Semaphore(settings.max_concurrent_reviews)
-        logger.info(f"Initialized review queue with max {settings.max_concurrent_reviews} concurrent reviews")
+        logger.info(
+            f"Initialized review queue with max {settings.max_concurrent_reviews} concurrent reviews"
+        )
     return review_semaphore
 
 
@@ -147,10 +150,10 @@ def _extract_issue_signature(body: str) -> str:
     if match:
         category = match.group(1).strip().lower()
         remainder = match.group(2).strip().lower()
-        
+
         # Strip markdown bolding/italics/backticks
         remainder = re.sub(r"[`*_]", "", remainder)
-        
+
         # Normalize whitespace
         remainder = " ".join(remainder.split())
         return f"{category}:{remainder}"
@@ -218,10 +221,10 @@ def _match_thread(
         # 3. Check content similarity
         if not thread.comments:
             continue
-            
+
         thread_sig = _extract_issue_signature(thread.comments[0].body)
         similarity = _calculate_similarity(comment_sig, thread_sig)
-        
+
         # DEBUG
         # print(f"Comparing line {comment.line} with thread at {thread.line}")
         # print(f"Similarity: {similarity}")
@@ -243,7 +246,9 @@ def _match_thread(
 
 
 @app.post("/webhook")
-async def handle_webhook(request: Request, background_tasks: BackgroundTasks) -> dict[str, str | int]:
+async def handle_webhook(
+    request: Request, background_tasks: BackgroundTasks
+) -> dict[str, str | int]:
     """
     Handle GitHub webhook events.
 
@@ -280,9 +285,7 @@ async def handle_webhook(request: Request, background_tasks: BackgroundTasks) ->
             if action in ["opened", "synchronize", "reopened", "ready_for_review"]:
                 # Skip draft PRs
                 if webhook_payload.pull_request.draft:
-                    logger.info(
-                        f"Skipping draft PR: {repo_name}#{pr_number} (action: {action})"
-                    )
+                    logger.info(f"Skipping draft PR: {repo_name}#{pr_number} (action: {action})")
                     return {"status": "skipped", "reason": "draft PR"}
 
                 # For synchronize events, check if this is just a merge/sync commit
@@ -295,9 +298,7 @@ async def handle_webhook(request: Request, background_tasks: BackgroundTasks) ->
                         repo_name, head_sha, base_branch
                     )
                     if is_merge:
-                        logger.info(
-                            f"Skipping review for {repo_name}#{pr_number}: {merge_reason}"
-                        )
+                        logger.info(f"Skipping review for {repo_name}#{pr_number}: {merge_reason}")
                         return {"status": "skipped", "reason": merge_reason}
 
                 # Check current queue status
@@ -359,7 +360,7 @@ async def _run_fidelity_analysis(
     github_client: GitHubAPIClient,
     repo_full_name: str,
     pr_context,
-) -> tuple[str, Any | None]:
+) -> tuple[str, FidelityResult | None]:
     """
     Run fidelity analysis comparing PR changes to design plan.
 
@@ -395,11 +396,14 @@ async def _run_fidelity_analysis(
 
         if not plan_content:
             logger.info(f"Fidelity: No plan file found for {ticket_id}")
-            return format_fidelity_report(
-                no_plan=True,
-                ticket_id=ticket_id,
-                plan_path=plan_path,
-            ), None
+            return (
+                format_fidelity_report(
+                    no_plan=True,
+                    ticket_id=ticket_id,
+                    plan_path=plan_path,
+                ),
+                None,
+            )
 
         # Run fidelity analysis
         logger.info(f"Fidelity: Analyzing {ticket_id} against plan")
@@ -456,9 +460,7 @@ async def process_pr_review(
                     repo_full_name=repo_full_name,
                     pr_number=pr_number,
                     trigger_reason=trigger_reason,
-                    started_at=datetime.fromtimestamp(
-                        review_start_time, tz=timezone.utc
-                    ),
+                    started_at=datetime.fromtimestamp(review_start_time, tz=timezone.utc),
                 )
 
             # Initialize GitHub client
@@ -485,6 +487,7 @@ async def process_pr_review(
 
             # Initialize agent and perform review
             from baloo.agent.client import BalooAgent
+
             agent = BalooAgent()
             agent_result = await agent.review_pr(pr_context)
             agent_metadata = agent_result.metadata
@@ -526,13 +529,9 @@ async def process_pr_review(
             summary_text = f"{summary_text}\n\n{decision_summary}"
 
             if follow_up_comments:
-                summary_text += (
-                    f"\n\n↪️ Baloo added follow-ups to {len(follow_up_comments)} existing thread(s)."
-                )
+                summary_text += f"\n\n↪️ Baloo added follow-ups to {len(follow_up_comments)} existing thread(s)."
             if skipped_duplicates:
-                summary_text += (
-                    f"\n\n↪️ Skipped {skipped_duplicates} existing Baloo thread(s) already awaiting a response."
-                )
+                summary_text += f"\n\n↪️ Skipped {skipped_duplicates} existing Baloo thread(s) already awaiting a response."
             if awaiting_threads:
                 summary_text += (
                     f"\n\n⏳ {awaiting_threads} Baloo thread(s) remain open from earlier reviews."
@@ -600,16 +599,18 @@ async def process_pr_review(
                         commit_sha=pr_context.head_sha,
                         name="Baloo Code Quality",
                         conclusion="neutral",
-                        summary=f"Found {len(routed['checks'])} code quality issue(s) (MEDIUM severity)"
+                        summary=f"Found {len(routed['checks'])} code quality issue(s) (MEDIUM severity)",
                     )
 
                     await checks_client.add_annotations(
                         repo_full_name=repo_full_name,
                         check_run_id=check_run_id,
-                        findings=routed["checks"]
+                        findings=routed["checks"],
                     )
 
-                    logger.info(f"Successfully posted GitHub Check with {len(routed['checks'])} annotations")
+                    logger.info(
+                        f"Successfully posted GitHub Check with {len(routed['checks'])} annotations"
+                    )
 
                 except Exception as check_error:
                     logger.error(f"Failed to post GitHub Check: {check_error}", exc_info=True)
@@ -646,9 +647,7 @@ async def process_pr_review(
                 logger.info("No blocking issues found, posting approval review")
                 approval_msg = "✅ No critical or high severity issues found. Safe to merge!"
                 if routed["checks"]:
-                    approval_msg += (
-                        f"\n\n💡 {len(routed['checks'])} medium severity suggestion(s) available in the Checks tab."
-                    )
+                    approval_msg += f"\n\n💡 {len(routed['checks'])} medium severity suggestion(s) available in the Checks tab."
 
                 await github_client.post_review(
                     repo_full_name,
@@ -675,17 +674,23 @@ async def process_pr_review(
                         f"{counts.get(ReviewSeverity.LOW.value, 0)} low."
                     )
                 elif not request_changes and approve:
-                    completion_msg = f"✅ Baloo review completed in {review_duration}s. No issues found!"
+                    completion_msg = (
+                        f"✅ Baloo review completed in {review_duration}s. No issues found!"
+                    )
                 elif awaiting_threads:
                     completion_msg = (
                         f"🐻 Baloo review completed in {review_duration}s. "
                         f"Still waiting on {awaiting_threads} existing thread(s)."
                     )
                 else:
-                    completion_msg = f"🐻 Baloo review completed in {review_duration}s. No new issues found."
+                    completion_msg = (
+                        f"🐻 Baloo review completed in {review_duration}s. No new issues found."
+                    )
 
                 try:
-                    await github_client.edit_comment(repo_full_name, progress_comment_id, completion_msg)
+                    await github_client.edit_comment(
+                        repo_full_name, progress_comment_id, completion_msg
+                    )
                 except Exception as edit_err:
                     logger.warning(f"Failed to update progress comment: {edit_err}")
 
@@ -725,7 +730,11 @@ async def process_pr_review(
                 agent_had_error = review_metadata.get("agent_error", False)
                 error_category = review_metadata.get("error_category")
                 error_detail = review_metadata.get("error_detail")
-                fallback_model = review_metadata.get("primary_model") if review_metadata.get("fallback_used") else None
+                fallback_model = (
+                    review_metadata.get("primary_model")
+                    if review_metadata.get("fallback_used")
+                    else None
+                )
 
                 if agent_had_error:
                     review_status = "agent_error"
@@ -750,11 +759,7 @@ async def process_pr_review(
                     agent_turns=review_metadata.get("num_turns"),
                     files_examined=len(pr_context.files_changed),
                     auto_approved=approve and not request_changes,
-                    fidelity_score=(
-                        fidelity_result.fidelity_score
-                        if fidelity_result
-                        else None
-                    ),
+                    fidelity_score=(fidelity_result.fidelity_score if fidelity_result else None),
                     error_message=error_detail,
                     error_category=error_category,
                     fallback_model=fallback_model,
@@ -800,7 +805,7 @@ async def process_pr_review(
                 await github_client.edit_comment(
                     repo_full_name,
                     progress_comment_id,
-                    "👋 This review was cancelled because a new commit was pushed. Baloo is starting a new review!"
+                    "👋 This review was cancelled because a new commit was pushed. Baloo is starting a new review!",
                 )
             except Exception:
                 pass

--- a/baloo/processor/decision_engine.py
+++ b/baloo/processor/decision_engine.py
@@ -25,7 +25,7 @@ class DecisionEngine:
             Tuple of (approve, request_changes)
         """
         settings = get_settings()
-        
+
         # Count by severity using shared utility
         counts = count_by_severity(comments)
         critical_count = counts.get(ReviewSeverity.CRITICAL.value, 0)

--- a/baloo/processor/formatter.py
+++ b/baloo/processor/formatter.py
@@ -1,6 +1,6 @@
 """Format review comments and summaries as Markdown."""
 
-from typing import Any, Dict, List
+from typing import Any
 
 from baloo.github.models import ReviewComment
 
@@ -16,9 +16,7 @@ class CommentFormatter:
     }
 
     @staticmethod
-    def format_summary(
-        comments: list[ReviewComment], metadata: Dict[str, Any] = None
-    ) -> str:
+    def format_summary(comments: list[ReviewComment], metadata: dict[str, Any] = None) -> str:
         """
         Format a review summary markdown.
 
@@ -45,18 +43,24 @@ class CommentFormatter:
             summary_parts.append("✅ **No issues found!** Code looks good.")
         else:
             stats = []
-            if critical > 0: stats.append(f"🔴 **{critical}** Critical")
-            if high > 0: stats.append(f"🟠 **{high}** High")
-            if medium > 0: stats.append(f"🟡 **{medium}** Medium")
-            if low > 0: stats.append(f"🔵 **{low}** Low")
-            
+            if critical > 0:
+                stats.append(f"🔴 **{critical}** Critical")
+            if high > 0:
+                stats.append(f"🟠 **{high}** High")
+            if medium > 0:
+                stats.append(f"🟡 **{medium}** Medium")
+            if low > 0:
+                stats.append(f"🔵 **{low}** Low")
+
             summary_parts.append(" | ".join(stats))
             summary_parts.append(f"\n**Total**: {len(comments)} issue(s) found")
 
             if critical > 0 or high > 0:
                 summary_parts.append("\n⚠️ **Please address CRITICAL/HIGH issues before merging**")
             else:
-                summary_parts.append("\n✅ **No blocking issues - safe to merge** (consider addressing MEDIUM/LOW items)")
+                summary_parts.append(
+                    "\n✅ **No blocking issues - safe to merge** (consider addressing MEDIUM/LOW items)"
+                )
 
         if metadata:
             summary_parts.append(CommentFormatter.format_metadata_section(metadata))
@@ -64,7 +68,7 @@ class CommentFormatter:
         return "\n".join(summary_parts)
 
     @staticmethod
-    def format_metadata_section(metadata: Dict[str, Any]) -> str:
+    def format_metadata_section(metadata: dict[str, Any]) -> str:
         """
         Format agent metadata as a collapsible HTML details section.
 

--- a/baloo/processor/severity_router.py
+++ b/baloo/processor/severity_router.py
@@ -1,11 +1,9 @@
 """Route review findings by severity and provide counting utilities."""
 
-from typing import Dict
-
-from baloo.github.models import FindingCategory, ReviewComment, ReviewSeverity
+from baloo.github.models import ReviewComment, ReviewSeverity
 
 
-def count_by_severity(findings: list[ReviewComment]) -> Dict[str, int]:
+def count_by_severity(findings: list[ReviewComment]) -> dict[str, int]:
     """
     Count findings by their severity level.
 
@@ -54,7 +52,4 @@ def route_findings(findings: list[ReviewComment]) -> dict:
         # LOW severity is currently not routed to a specific GitHub reporting mechanism
         # but could be added to the digest.
 
-    return {
-        "review": review_findings,
-        "checks": checks_findings
-    }
+    return {"review": review_findings, "checks": checks_findings}

--- a/baloo/version.py
+++ b/baloo/version.py
@@ -15,5 +15,9 @@ def get_version_info() -> str:
         return f"Baloo v{VERSION} (local development)"
 
     # Only truncate if it's a real SHA (not 'unknown', 'dev', or empty)
-    commit_display = COMMIT_SHA[:8] if COMMIT_SHA not in ('unknown', 'dev', '') and len(COMMIT_SHA) >= 8 else COMMIT_SHA
+    commit_display = (
+        COMMIT_SHA[:8]
+        if COMMIT_SHA not in ("unknown", "dev", "") and len(COMMIT_SHA) >= 8
+        else COMMIT_SHA
+    )
     return f"Baloo v{VERSION} (commit: {commit_display}, built: {BUILD_DATE})"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "pygments>=2.20.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
@@ -54,7 +54,11 @@ target-version = ["py310", "py311"]
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP"]
+# E501 (line length) is handled by black; strings/comments that exceed the limit are intentional
+ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/agent/test_client_integration.py
+++ b/tests/agent/test_client_integration.py
@@ -30,7 +30,7 @@ def sample_pr_context():
                 additions=10,
                 deletions=5,
                 changes=15,
-                patch="@@ -1,5 +1,10 @@\n+new code"
+                patch="@@ -1,5 +1,10 @@\n+new code",
             )
         ],
     )
@@ -38,15 +38,19 @@ def sample_pr_context():
     return PRContext(
         metadata=metadata,
         discussion=discussion,
-        diff="diff --git a/test.py b/test.py\n@@ -1,5 +1,10 @@"
+        diff="diff --git a/test.py b/test.py\n@@ -1,5 +1,10 @@",
     )
 
 
-def _make_pi_events(structured_output: dict | None, usage: dict = None, is_error: bool = False) -> list[bytes]:
+def _make_pi_events(
+    structured_output: dict | None, usage: dict = None, is_error: bool = False
+) -> list[bytes]:
     """Build the sequence of JSONL events a PI process would emit."""
     usage = usage or {
-        "input": 500, "output": 100,
-        "cacheRead": 0, "cacheWrite": 0,
+        "input": 500,
+        "output": 100,
+        "cacheRead": 0,
+        "cacheWrite": 0,
         "cost": {"total": 0.01},
     }
 
@@ -61,13 +65,16 @@ def _make_pi_events(structured_output: dict | None, usage: dict = None, is_error
         {"type": "agent_start"},
         {"type": "turn_start"},
         {"type": "message_start", "message": {"role": "assistant"}},
-        {"type": "message_end", "message": {
-            "role": "assistant",
-            "content": [{"type": "text", "text": assistant_text}] if assistant_text else [],
-            "model": "claude-sonnet-4-6",
-            "usage": usage,
-            "stopReason": "error" if is_error else "stop",
-        }},
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": assistant_text}] if assistant_text else [],
+                "model": "claude-sonnet-4-6",
+                "usage": usage,
+                "stopReason": "error" if is_error else "stop",
+            },
+        },
         {"type": "turn_end"},
         {"type": "agent_end"},
     ]
@@ -105,7 +112,10 @@ class TestBalooAgentErrorHandling:
     async def test_review_pr_handles_process_crash(self, sample_pr_context):
         """Test graceful handling of PI process crash."""
         events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
             json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
             b"",  # EOF — process crashed
         ]
@@ -124,8 +134,10 @@ class TestBalooAgentErrorHandling:
         """Test handling when PI binary cannot be spawned."""
         agent = BalooAgent()
 
-        with patch("baloo.agent.pi_runtime.asyncio.create_subprocess_exec",
-                    side_effect=FileNotFoundError("pi not found")):
+        with patch(
+            "baloo.agent.pi_runtime.asyncio.create_subprocess_exec",
+            side_effect=FileNotFoundError("pi not found"),
+        ):
             result = await agent.review_pr(sample_pr_context)
 
             assert "error" in result.summary.lower() or "failed" in result.summary.lower()
@@ -164,14 +176,16 @@ class TestBalooAgentSuccessPath:
     async def test_review_pr_successful_with_findings(self, sample_pr_context):
         """Test successful review with valid structured findings."""
         structured = {
-            "findings": [{
-                "file": "test.py",
-                "line": 5,
-                "severity": "HIGH",
-                "category": "Security",
-                "title": "SQL Injection",
-                "description": "Unsafe query",
-            }],
+            "findings": [
+                {
+                    "file": "test.py",
+                    "line": 5,
+                    "severity": "HIGH",
+                    "category": "Security",
+                    "title": "SQL Injection",
+                    "description": "Unsafe query",
+                }
+            ],
             "summary": {"total_issues": 1},
         }
         events = _make_pi_events(structured)
@@ -207,7 +221,9 @@ class TestBalooAgentSuccessPath:
     async def test_review_pr_medium_severity_approves(self, sample_pr_context):
         """Test that MEDIUM/LOW severity issues don't block approval."""
         structured = {
-            "findings": [{"file": "test.py", "line": 1, "severity": "MEDIUM", "title": "Minor issue"}],
+            "findings": [
+                {"file": "test.py", "line": 1, "severity": "MEDIUM", "title": "Minor issue"}
+            ],
         }
         events = _make_pi_events(structured)
         agent = BalooAgent()
@@ -238,12 +254,13 @@ class TestBalooAgentModelSelection:
                 head_branch="docs",
                 head_sha="abc",
                 files_changed=[
-                    FileChange(filename="README.md", status="modified",
-                               additions=2, deletions=1, changes=3)
+                    FileChange(
+                        filename="README.md", status="modified", additions=2, deletions=1, changes=3
+                    )
                 ],
             ),
             discussion=PRDiscussionContext(),
-            diff="diff --git a/README.md"
+            diff="diff --git a/README.md",
         )
 
         events = _make_pi_events({"findings": [], "summary": {}})
@@ -258,11 +275,14 @@ class TestBalooAgentModelSelection:
     @pytest.mark.asyncio
     async def test_uses_sonnet_for_complex_pr(self, sample_pr_context):
         """Test that Sonnet is used for complex PRs."""
-        sample_pr_context.files_changed.extend([
-            FileChange(filename=f"file{i}.py", status="added",
-                       additions=50, deletions=0, changes=50)
-            for i in range(5)
-        ])
+        sample_pr_context.files_changed.extend(
+            [
+                FileChange(
+                    filename=f"file{i}.py", status="added", additions=50, deletions=0, changes=50
+                )
+                for i in range(5)
+            ]
+        )
 
         events = _make_pi_events({"findings": [], "summary": {}})
         agent = BalooAgent()
@@ -287,12 +307,17 @@ class TestBalooAgentModelSelection:
                 head_branch="feature/auth",
                 head_sha="abc",
                 files_changed=[
-                    FileChange(filename="src/auth/login.py", status="modified",
-                               additions=20, deletions=5, changes=25)
+                    FileChange(
+                        filename="src/auth/login.py",
+                        status="modified",
+                        additions=20,
+                        deletions=5,
+                        changes=25,
+                    )
                 ],
             ),
             discussion=PRDiscussionContext(),
-            diff="diff --git a/src/auth/login.py b/src/auth/login.py\n+def verify_token():"
+            diff="diff --git a/src/auth/login.py b/src/auth/login.py\n+def verify_token():",
         )
 
         events = _make_pi_events({"findings": [], "summary": {}})
@@ -312,7 +337,9 @@ class TestBalooAgentSeveritySummary:
     async def test_summary_includes_critical_severity(self, sample_pr_context):
         """Test that CRITICAL severity is included in summary."""
         structured = {
-            "findings": [{"file": "test.py", "line": 1, "severity": "CRITICAL", "title": "Critical issue"}],
+            "findings": [
+                {"file": "test.py", "line": 1, "severity": "CRITICAL", "title": "Critical issue"}
+            ],
         }
         events = _make_pi_events(structured)
         agent = BalooAgent()
@@ -349,8 +376,19 @@ class TestBalooAgentFallback:
         """Test that primary failure triggers fallback to secondary model."""
         # Primary model fails
         fail_events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
-            json.dumps({"type": "response", "command": "prompt", "success": False, "error": "API key invalid"}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
+            json.dumps(
+                {
+                    "type": "response",
+                    "command": "prompt",
+                    "success": False,
+                    "error": "API key invalid",
+                }
+            ).encode()
+            + b"\n",
         ]
         # Fallback model succeeds
         success_events = _make_pi_events({"findings": [], "summary": {}})
@@ -359,6 +397,7 @@ class TestBalooAgentFallback:
         call_count = 0
 
         with patch("baloo.agent.pi_runtime.asyncio.create_subprocess_exec") as mock_exec:
+
             def side_effect(*args, **kwargs):
                 nonlocal call_count
                 call_count += 1
@@ -379,14 +418,22 @@ class TestBalooAgentFallback:
     async def test_no_fallback_when_same_model(self, sample_pr_context):
         """Test that fallback is skipped when it's the same as primary."""
         fail_events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
-            json.dumps({"type": "response", "command": "prompt", "success": False, "error": "API error"}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
+            json.dumps(
+                {"type": "response", "command": "prompt", "success": False, "error": "API error"}
+            ).encode()
+            + b"\n",
         ]
 
         agent = BalooAgent()
         # Set fallback to same as primary
-        with patch("baloo.config.settings.settings.agent_fallback_model",
-                    f"{agent.options.provider}/{agent.options.model}"):
+        with patch(
+            "baloo.config.settings.settings.agent_fallback_model",
+            f"{agent.options.provider}/{agent.options.model}",
+        ):
             with patch("baloo.agent.pi_runtime.asyncio.create_subprocess_exec") as mock_exec:
                 mock_exec.return_value = _mock_pi_process(fail_events)
                 result = await agent.review_pr(sample_pr_context)
@@ -402,8 +449,10 @@ class TestBalooAgentMetadata:
     async def test_metadata_captures_cost_and_tokens(self, sample_pr_context):
         """Test that metadata includes cost and token counts."""
         usage = {
-            "input": 2000, "output": 500,
-            "cacheRead": 1000, "cacheWrite": 200,
+            "input": 2000,
+            "output": 500,
+            "cacheRead": 1000,
+            "cacheWrite": 200,
             "cost": {"total": 0.10},
         }
         structured = {"findings": [], "summary": {}}

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -9,7 +9,6 @@ import pytest
 from baloo.agent.pi_runtime import (
     PIAgentBase,
     PIAgentOptions,
-    PIRunResult,
     _extract_json_from_text,
 )
 
@@ -60,7 +59,7 @@ class TestExtractJsonFromText:
 
     def test_json_array_not_object(self):
         """Arrays should not match — we expect an object."""
-        data = _extract_json_from_text('[1, 2, 3]')
+        data = _extract_json_from_text("[1, 2, 3]")
         # Strategy 1 parses it but it's a list, not dict
         # Our function returns whatever json.loads gives
         assert data == [1, 2, 3]
@@ -107,9 +106,7 @@ class TestPIAgentBase:
     @pytest.mark.asyncio
     async def test_read_event_parses_json(self):
         reader = AsyncMock(spec=asyncio.StreamReader)
-        reader.readline = AsyncMock(
-            return_value=b'{"type": "agent_end"}\n'
-        )
+        reader.readline = AsyncMock(return_value=b'{"type": "agent_end"}\n')
         event = await PIAgentBase._read_event(reader)
         assert event == {"type": "agent_end"}
 
@@ -130,9 +127,7 @@ class TestPIAgentBase:
     @pytest.mark.asyncio
     async def test_read_event_strips_cr(self):
         reader = AsyncMock(spec=asyncio.StreamReader)
-        reader.readline = AsyncMock(
-            return_value=b'{"type": "test"}\r\n'
-        )
+        reader.readline = AsyncMock(return_value=b'{"type": "test"}\r\n')
         event = await PIAgentBase._read_event(reader)
         assert event == {"type": "test"}
 
@@ -142,7 +137,13 @@ class TestPIAgentBaseRunQuery:
 
     def _make_events(self, structured_output: dict, usage: dict = None) -> list[bytes]:
         """Build the sequence of JSONL events a PI process would emit."""
-        usage = usage or {"input": 500, "output": 100, "cacheRead": 0, "cacheWrite": 0, "cost": {"total": 0.01}}
+        usage = usage or {
+            "input": 500,
+            "output": 100,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "cost": {"total": 0.01},
+        }
         assistant_text = json.dumps(structured_output)
 
         events = [
@@ -155,13 +156,16 @@ class TestPIAgentBaseRunQuery:
             # Turn
             {"type": "turn_start"},
             {"type": "message_start", "message": {"role": "assistant"}},
-            {"type": "message_end", "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": assistant_text}],
-                "model": "claude-sonnet-4-6",
-                "usage": usage,
-                "stopReason": "stop",
-            }},
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": assistant_text}],
+                    "model": "claude-sonnet-4-6",
+                    "usage": usage,
+                    "stopReason": "stop",
+                },
+            },
             {"type": "turn_end"},
             # Done
             {"type": "agent_end"},
@@ -185,11 +189,13 @@ class TestPIAgentBaseRunQuery:
             proc.stdout = AsyncMock(spec=asyncio.StreamReader)
 
             event_iter = iter(events)
+
             async def fake_readline():
                 try:
                     return next(event_iter)
                 except StopIteration:
                     return b""
+
             proc.stdout.readline = fake_readline
 
             proc.stderr = AsyncMock()
@@ -224,11 +230,13 @@ class TestPIAgentBaseRunQuery:
             proc.stdout = AsyncMock(spec=asyncio.StreamReader)
 
             event_iter = iter(events)
+
             async def fake_readline():
                 try:
                     return next(event_iter)
                 except StopIteration:
                     return b""
+
             proc.stdout.readline = fake_readline
 
             proc.stderr = AsyncMock()
@@ -244,7 +252,10 @@ class TestPIAgentBaseRunQuery:
     async def test_process_crash(self):
         """Test handling of PI process crashing (stdout closes early)."""
         events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
             json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
             b"",  # EOF — process crashed
         ]
@@ -260,11 +271,13 @@ class TestPIAgentBaseRunQuery:
             proc.stdout = AsyncMock(spec=asyncio.StreamReader)
 
             event_iter = iter(events)
+
             async def fake_readline():
                 try:
                     return next(event_iter)
                 except StopIteration:
                     return b""
+
             proc.stdout.readline = fake_readline
 
             proc.stderr = AsyncMock()
@@ -282,12 +295,15 @@ class TestPIAgentBaseRunQuery:
     async def test_command_failure(self):
         """Test handling of PI command returning failure."""
         events = [
-            json.dumps({
-                "type": "response",
-                "command": "set_thinking_level",
-                "success": False,
-                "error": "Model not found",
-            }).encode() + b"\n",
+            json.dumps(
+                {
+                    "type": "response",
+                    "command": "set_thinking_level",
+                    "success": False,
+                    "error": "Model not found",
+                }
+            ).encode()
+            + b"\n",
         ]
 
         agent = PIAgentBase(PIAgentOptions())
@@ -301,11 +317,13 @@ class TestPIAgentBaseRunQuery:
             proc.stdout = AsyncMock(spec=asyncio.StreamReader)
 
             event_iter = iter(events)
+
             async def fake_readline():
                 try:
                     return next(event_iter)
                 except StopIteration:
                     return b""
+
             proc.stdout.readline = fake_readline
 
             proc.stderr = AsyncMock()
@@ -326,16 +344,31 @@ class TestPIAgentBaseRunQuery:
         agent = PIAgentBase(PIAgentOptions(max_turns=1))
 
         events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
             json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
             json.dumps({"type": "turn_start"}).encode() + b"\n",
-            json.dumps({"type": "message_end", "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": '{"findings": []}'}],
-                "model": "test",
-                "usage": {"input": 100, "output": 50, "cacheRead": 0, "cacheWrite": 0, "cost": {"total": 0.005}},
-                "stopReason": "toolUse",
-            }}).encode() + b"\n",
+            json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": '{"findings": []}'}],
+                        "model": "test",
+                        "usage": {
+                            "input": 100,
+                            "output": 50,
+                            "cacheRead": 0,
+                            "cacheWrite": 0,
+                            "cost": {"total": 0.005},
+                        },
+                        "stopReason": "toolUse",
+                    },
+                }
+            ).encode()
+            + b"\n",
             json.dumps({"type": "turn_end"}).encode() + b"\n",
             # After abort, agent_end would come
             json.dumps({"type": "agent_end"}).encode() + b"\n",
@@ -350,11 +383,13 @@ class TestPIAgentBaseRunQuery:
             proc.stdout = AsyncMock(spec=asyncio.StreamReader)
 
             event_iter = iter(events)
+
             async def fake_readline():
                 try:
                     return next(event_iter)
                 except StopIteration:
                     return b""
+
             proc.stdout.readline = fake_readline
 
             proc.stderr = AsyncMock()
@@ -374,32 +409,69 @@ class TestPIAgentBaseRunQuery:
         """Test that invalid JSON triggers a retry that succeeds."""
         # First run returns non-JSON text
         bad_events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
             json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
             json.dumps({"type": "turn_start"}).encode() + b"\n",
-            json.dumps({"type": "message_end", "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": "Here are my findings about the code..."}],
-                "model": "test",
-                "usage": {"input": 500, "output": 200, "cacheRead": 0, "cacheWrite": 0, "cost": {"total": 0.01}},
-                "stopReason": "stop",
-            }}).encode() + b"\n",
+            json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "Here are my findings about the code..."}
+                        ],
+                        "model": "test",
+                        "usage": {
+                            "input": 500,
+                            "output": 200,
+                            "cacheRead": 0,
+                            "cacheWrite": 0,
+                            "cost": {"total": 0.01},
+                        },
+                        "stopReason": "stop",
+                    },
+                }
+            ).encode()
+            + b"\n",
             json.dumps({"type": "turn_end"}).encode() + b"\n",
             json.dumps({"type": "agent_end"}).encode() + b"\n",
         ]
 
         # Retry returns valid JSON
         good_events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
             json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
             json.dumps({"type": "turn_start"}).encode() + b"\n",
-            json.dumps({"type": "message_end", "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": '{"findings": [{"file": "a.py", "line": 1}], "summary": {}}'}],
-                "model": "test",
-                "usage": {"input": 100, "output": 50, "cacheRead": 0, "cacheWrite": 0, "cost": {"total": 0.002}},
-                "stopReason": "stop",
-            }}).encode() + b"\n",
+            json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": '{"findings": [{"file": "a.py", "line": 1}], "summary": {}}',
+                            }
+                        ],
+                        "model": "test",
+                        "usage": {
+                            "input": 100,
+                            "output": 50,
+                            "cacheRead": 0,
+                            "cacheWrite": 0,
+                            "cost": {"total": 0.002},
+                        },
+                        "stopReason": "stop",
+                    },
+                }
+            ).encode()
+            + b"\n",
             json.dumps({"type": "turn_end"}).encode() + b"\n",
             json.dumps({"type": "agent_end"}).encode() + b"\n",
         ]
@@ -408,6 +480,7 @@ class TestPIAgentBaseRunQuery:
         call_count = 0
 
         with patch("baloo.agent.pi_runtime.asyncio.create_subprocess_exec") as mock_exec:
+
             def make_proc(*args, **kwargs):
                 nonlocal call_count
                 call_count += 1
@@ -449,31 +522,58 @@ class TestPIAgentBaseRunQuery:
     @pytest.mark.asyncio
     async def test_usage_aggregation_across_turns(self):
         """Test that token usage is aggregated across multiple turns."""
-        usage1 = {"input": 200, "output": 50, "cacheRead": 0, "cacheWrite": 0, "cost": {"total": 0.005}}
-        usage2 = {"input": 300, "output": 75, "cacheRead": 0, "cacheWrite": 0, "cost": {"total": 0.008}}
+        usage1 = {
+            "input": 200,
+            "output": 50,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "cost": {"total": 0.005},
+        }
+        usage2 = {
+            "input": 300,
+            "output": 75,
+            "cacheRead": 0,
+            "cacheWrite": 0,
+            "cost": {"total": 0.008},
+        }
 
         events = [
-            json.dumps({"type": "response", "command": "set_thinking_level", "success": True}).encode() + b"\n",
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
             json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
             # Turn 1
             json.dumps({"type": "turn_start"}).encode() + b"\n",
-            json.dumps({"type": "message_end", "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": "Let me check..."}],
-                "model": "test",
-                "usage": usage1,
-                "stopReason": "toolUse",
-            }}).encode() + b"\n",
+            json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Let me check..."}],
+                        "model": "test",
+                        "usage": usage1,
+                        "stopReason": "toolUse",
+                    },
+                }
+            ).encode()
+            + b"\n",
             json.dumps({"type": "turn_end"}).encode() + b"\n",
             # Turn 2
             json.dumps({"type": "turn_start"}).encode() + b"\n",
-            json.dumps({"type": "message_end", "message": {
-                "role": "assistant",
-                "content": [{"type": "text", "text": '{"findings": [], "summary": {}}'}],
-                "model": "test",
-                "usage": usage2,
-                "stopReason": "stop",
-            }}).encode() + b"\n",
+            json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": '{"findings": [], "summary": {}}'}],
+                        "model": "test",
+                        "usage": usage2,
+                        "stopReason": "stop",
+                    },
+                }
+            ).encode()
+            + b"\n",
             json.dumps({"type": "turn_end"}).encode() + b"\n",
             json.dumps({"type": "agent_end"}).encode() + b"\n",
         ]
@@ -489,11 +589,13 @@ class TestPIAgentBaseRunQuery:
             proc.stdout = AsyncMock(spec=asyncio.StreamReader)
 
             event_iter = iter(events)
+
             async def fake_readline():
                 try:
                     return next(event_iter)
                 except StopIteration:
                     return b""
+
             proc.stdout.readline = fake_readline
 
             proc.stderr = AsyncMock()

--- a/tests/agent/test_schemas.py
+++ b/tests/agent/test_schemas.py
@@ -132,13 +132,15 @@ class TestReviewOutput:
     def test_finding_with_extra_fields_ignored(self):
         """Test that unknown finding fields are ignored."""
         data = {
-            "findings": [{
-                "file": "a.py",
-                "line": 1,
-                "title": "X",
-                "confidence": 0.95,
-                "suggested_fix": "do something",
-            }]
+            "findings": [
+                {
+                    "file": "a.py",
+                    "line": 1,
+                    "title": "X",
+                    "confidence": 0.95,
+                    "suggested_fix": "do something",
+                }
+            ]
         }
         output = ReviewOutput.model_validate(data)
         assert len(output.findings) == 1
@@ -352,14 +354,16 @@ class TestNormalizeCategory:
     def test_findings_with_uppercase_category(self):
         """End-to-end: agent returns UPPERCASE category, parsed correctly."""
         data = {
-            "findings": [{
-                "file": "test.py",
-                "line": 1,
-                "severity": "MEDIUM",
-                "category": "QUALITY",
-                "title": "Test",
-                "description": "Desc",
-            }]
+            "findings": [
+                {
+                    "file": "test.py",
+                    "line": 1,
+                    "severity": "MEDIUM",
+                    "category": "QUALITY",
+                    "title": "Test",
+                    "description": "Desc",
+                }
+            ]
         }
         comments = findings_to_comments(data)
         assert len(comments) == 1

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -100,9 +100,7 @@ async def test_review_findings_relationship(async_session: AsyncSession):
         trigger_reason="pull_request:opened",
         started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
-    finding1 = Finding(
-        file_path="a.py", severity="HIGH", category="Bugs", body="Null pointer"
-    )
+    finding1 = Finding(file_path="a.py", severity="HIGH", category="Bugs", body="Null pointer")
     finding2 = Finding(
         file_path="b.py", severity="LOW", category="Quality", body="Missing docstring"
     )
@@ -111,9 +109,7 @@ async def test_review_findings_relationship(async_session: AsyncSession):
     async with async_session.begin():
         async_session.add(review)
 
-    result = await async_session.execute(
-        select(Review).where(Review.id == review.id)
-    )
+    result = await async_session.execute(select(Review).where(Review.id == review.id))
     saved = result.scalar_one()
     await async_session.refresh(saved, ["findings"])
     assert len(saved.findings) == 2
@@ -142,9 +138,7 @@ async def test_cascade_delete(async_session: AsyncSession):
         to_delete = await async_session.get(Review, review_id)
         await async_session.delete(to_delete)
 
-    result = await async_session.execute(
-        select(Finding).where(Finding.review_id == review_id)
-    )
+    result = await async_session.execute(select(Finding).where(Finding.review_id == review_id))
     assert result.scalars().all() == []
 
 

--- a/tests/db/test_service.py
+++ b/tests/db/test_service.py
@@ -129,9 +129,7 @@ async def test_complete_review_success(db_session_factory):
         assert review.pr_title == "Add feature"
         assert review.tokens_input == 1000
 
-        result = await session.execute(
-            select(Finding).where(Finding.review_id == review_id)
-        )
+        result = await session.execute(select(Finding).where(Finding.review_id == review_id))
         findings = result.scalars().all()
         assert len(findings) == 2
 
@@ -194,9 +192,7 @@ async def test_complete_review_no_findings(db_session_factory):
     )
 
     async with db_session_factory() as session:
-        result = await session.execute(
-            select(Finding).where(Finding.review_id == review_id)
-        )
+        result = await session.execute(select(Finding).where(Finding.review_id == review_id))
         assert result.scalars().all() == []
 
 

--- a/tests/fidelity/test_ticket_extractor.py
+++ b/tests/fidelity/test_ticket_extractor.py
@@ -1,8 +1,10 @@
 """Tests for ticket ID extraction from PR metadata."""
 
 import re
-import pytest
 from unittest.mock import patch
+
+import pytest
+
 from baloo.fidelity.ticket_extractor import (
     _extract_from_branch,
     _extract_from_description,
@@ -34,8 +36,12 @@ class TestExtractFromBranch:
 
     def test_feat_slash_format(self):
         """Test feat/DEN-XXX/description format."""
-        assert _extract_from_branch("feat/DEN-123/add-feature", DEN_PREFIX, DEN_PATTERN) == "DEN-123"
-        assert _extract_from_branch("feat/DEN-1234/some-thing", DEN_PREFIX, DEN_PATTERN) == "DEN-1234"
+        assert (
+            _extract_from_branch("feat/DEN-123/add-feature", DEN_PREFIX, DEN_PATTERN) == "DEN-123"
+        )
+        assert (
+            _extract_from_branch("feat/DEN-1234/some-thing", DEN_PREFIX, DEN_PATTERN) == "DEN-1234"
+        )
 
     def test_fix_slash_format(self):
         """Test fix/DEN-XXX/description format."""
@@ -43,7 +49,9 @@ class TestExtractFromBranch:
 
     def test_chore_slash_format(self):
         """Test chore/DEN-XXX/description format."""
-        assert _extract_from_branch("chore/DEN-789/update-deps", DEN_PREFIX, DEN_PATTERN) == "DEN-789"
+        assert (
+            _extract_from_branch("chore/DEN-789/update-deps", DEN_PREFIX, DEN_PATTERN) == "DEN-789"
+        )
 
     def test_dash_format(self):
         """Test DEN-XXX-description format."""
@@ -72,7 +80,9 @@ class TestExtractFromTitle:
 
     def test_bracketed_format(self):
         """Test [DEN-XXX] format."""
-        assert _extract_from_title("[DEN-123] Add new feature", DEN_PREFIX, DEN_PATTERN) == "DEN-123"
+        assert (
+            _extract_from_title("[DEN-123] Add new feature", DEN_PREFIX, DEN_PATTERN) == "DEN-123"
+        )
         assert _extract_from_title("[DEN-1234] Fix bug", DEN_PREFIX, DEN_PATTERN) == "DEN-1234"
 
     def test_colon_prefix(self):
@@ -82,12 +92,17 @@ class TestExtractFromTitle:
 
     def test_dash_prefix(self):
         """Test DEN-XXX - format."""
-        assert _extract_from_title("DEN-123 - Add new feature", DEN_PREFIX, DEN_PATTERN) == "DEN-123"
+        assert (
+            _extract_from_title("DEN-123 - Add new feature", DEN_PREFIX, DEN_PATTERN) == "DEN-123"
+        )
 
     def test_anywhere_in_title(self):
         """Test DEN-XXX anywhere in title (fallback)."""
         assert _extract_from_title("Fix the DEN-789 issue", DEN_PREFIX, DEN_PATTERN) == "DEN-789"
-        assert _extract_from_title("Implement feature for DEN-100", DEN_PREFIX, DEN_PATTERN) == "DEN-100"
+        assert (
+            _extract_from_title("Implement feature for DEN-100", DEN_PREFIX, DEN_PATTERN)
+            == "DEN-100"
+        )
 
     def test_case_insensitive(self):
         """Test that extraction is case-insensitive."""
@@ -105,7 +120,12 @@ class TestExtractFromDescription:
 
     def test_explicit_ticket_reference(self):
         """Test Ticket: DEN-XXX format."""
-        assert _extract_from_description("Ticket: DEN-123\n\nDescription here", DEN_PREFIX, DEN_PATTERN) == "DEN-123"
+        assert (
+            _extract_from_description(
+                "Ticket: DEN-123\n\nDescription here", DEN_PREFIX, DEN_PATTERN
+            )
+            == "DEN-123"
+        )
         assert _extract_from_description("ticket: den-456", DEN_PREFIX, DEN_PATTERN) == "DEN-456"
 
     def test_fixes_pattern(self):
@@ -148,7 +168,7 @@ class TestExtractTicketId:
             branch_name="feat/DEN-111/feature",
             pr_title="[DEN-222] Title",
             pr_description="Ticket: DEN-333",
-            prefix="DEN"
+            prefix="DEN",
         )
         assert ticket_id == "DEN-111"
 
@@ -158,7 +178,7 @@ class TestExtractTicketId:
             branch_name="feature-branch",
             pr_title="[DEN-222] Title",
             pr_description="Ticket: DEN-333",
-            prefix="DEN"
+            prefix="DEN",
         )
         assert ticket_id == "DEN-222"
 
@@ -168,7 +188,7 @@ class TestExtractTicketId:
             branch_name="feature-branch",
             pr_title="Add new feature",
             pr_description="Ticket: DEN-333",
-            prefix="DEN"
+            prefix="DEN",
         )
         assert ticket_id == "DEN-333"
 
@@ -178,37 +198,28 @@ class TestExtractTicketId:
             branch_name="feature-branch",
             pr_title="Add new feature",
             pr_description="This is a description",
-            prefix="DEN"
+            prefix="DEN",
         )
         assert ticket_id is None
 
     def test_none_description(self, patch_settings):
         """Test with None description."""
         ticket_id = extract_ticket_id(
-            branch_name="feat/DEN-123/feature",
-            pr_title="Title",
-            pr_description=None,
-            prefix="DEN"
+            branch_name="feat/DEN-123/feature", pr_title="Title", pr_description=None, prefix="DEN"
         )
         assert ticket_id == "DEN-123"
 
     def test_empty_description(self, patch_settings):
         """Test with empty description."""
         ticket_id = extract_ticket_id(
-            branch_name="feature-branch",
-            pr_title="Add feature",
-            pr_description="",
-            prefix="DEN"
+            branch_name="feature-branch", pr_title="Add feature", pr_description="", prefix="DEN"
         )
         assert ticket_id is None
 
     def test_normalizes_to_uppercase(self, patch_settings):
         """Test that ticket ID is normalized to uppercase."""
         ticket_id = extract_ticket_id(
-            branch_name="feat/den-123/feature",
-            pr_title="",
-            pr_description=None,
-            prefix="DEN"
+            branch_name="feat/den-123/feature", pr_title="", pr_description=None, prefix="DEN"
         )
         assert ticket_id == "DEN-123"
 
@@ -218,6 +229,6 @@ class TestExtractTicketId:
             branch_name="feat/JIRA-999/feature",
             pr_title="Title",
             pr_description=None,
-            prefix="JIRA"
+            prefix="JIRA",
         )
         assert ticket_id == "JIRA-999"

--- a/tests/github/test_cancellation.py
+++ b/tests/github/test_cancellation.py
@@ -4,23 +4,22 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 
-from baloo.github.webhook_handler import app, active_reviews
+from baloo.github.webhook_handler import active_reviews, app
 
 
 def create_payload(repo_name: str, pr_number: int, head_sha: str):
     """Create a valid PullRequestWebhookPayload dictionary."""
-    owner_login = repo_name.split("/")[0]
     repo_short_name = repo_name.split("/")[1]
-    
+
     user_data = {
         "login": "testuser",
         "id": 1,
         "avatar_url": "https://example.com/avatar.png",
-        "html_url": "https://github.com/testuser"
+        "html_url": "https://github.com/testuser",
     }
-    
+
     return {
         "action": "synchronize",
         "number": pr_number,
@@ -32,7 +31,7 @@ def create_payload(repo_name: str, pr_number: int, head_sha: str):
             "user": user_data,
             "head": {"sha": head_sha},
             "base": {"ref": "main"},
-            "draft": False
+            "draft": False,
         },
         "repository": {
             "id": 123,
@@ -40,20 +39,20 @@ def create_payload(repo_name: str, pr_number: int, head_sha: str):
             "full_name": repo_name,
             "owner": user_data,
             "html_url": f"https://github.com/{repo_name}",
-            "default_branch": "main"
+            "default_branch": "main",
         },
         "installation": {"id": 456},
-        "sender": user_data
+        "sender": user_data,
     }
 
 
 @pytest.mark.asyncio
 async def test_cancels_redundant_review():
     """Test that a new commit on the same PR cancels the ongoing review."""
-    
+
     repo_name = "test/repo"
     pr_number = 123
-    
+
     # Event loop for async coordination
     task_started_event = asyncio.Event()
     task_cancelled_event = asyncio.Event()
@@ -72,10 +71,12 @@ async def test_cancels_redundant_review():
 
     # Mock dependencies
     # We patch process_pr_review in webhook_handler where it is used
-    with patch("baloo.github.webhook_handler.verify_webhook_signature", return_value=True), \
-         patch("baloo.github.webhook_handler.process_pr_review", side_effect=mock_process_review), \
-         patch("baloo.github.webhook_handler.GitHubAPIClient") as mock_github_client_class:
-        
+    with (
+        patch("baloo.github.webhook_handler.verify_webhook_signature", return_value=True),
+        patch("baloo.github.webhook_handler.process_pr_review", side_effect=mock_process_review),
+        patch("baloo.github.webhook_handler.GitHubAPIClient") as mock_github_client_class,
+    ):
+
         # Setup mock GitHub client instance
         mock_github = MagicMock()
         mock_github.is_merge_or_sync_commit = AsyncMock(return_value=(False, ""))
@@ -86,40 +87,48 @@ async def test_cancels_redundant_review():
 
             # 1. Trigger first review
             payload1 = create_payload(repo_name, pr_number, "sha1")
-            
+
             # First request starts the task
-            await client.post("/webhook", json=payload1, headers={"X-GitHub-Event": "pull_request", "X-Hub-Signature-256": "sha256=test"})
-            
+            await client.post(
+                "/webhook",
+                json=payload1,
+                headers={"X-GitHub-Event": "pull_request", "X-Hub-Signature-256": "sha256=test"},
+            )
+
             # Wait for task to actually start
             try:
                 await asyncio.wait_for(task_started_event.wait(), timeout=2.0)
             except asyncio.TimeoutError:
                 pytest.fail("Task failed to start or event not set")
-            
+
             assert (repo_name, pr_number) in active_reviews
             task1 = active_reviews[(repo_name, pr_number)]
-            
+
             # Check if task1 is actually running
             assert not task1.done(), f"Task finished prematurely: {task1}"
 
             # 2. Trigger second review for SAME PR
             payload2 = create_payload(repo_name, pr_number, "sha2")
-            
+
             # Second request should cancel the first task
-            await client.post("/webhook", json=payload2, headers={"X-GitHub-Event": "pull_request", "X-Hub-Signature-256": "sha256=test"})
-            
+            await client.post(
+                "/webhook",
+                json=payload2,
+                headers={"X-GitHub-Event": "pull_request", "X-Hub-Signature-256": "sha256=test"},
+            )
+
             # Wait for first task to be cancelled
             try:
                 await asyncio.wait_for(task_cancelled_event.wait(), timeout=2.0)
             except asyncio.TimeoutError:
                 pytest.fail("First task was not cancelled by second request")
-            
+
             assert task1.cancelled() or task1.done()
-            
+
             # Verify second task is now the active one
             task2 = active_reviews[(repo_name, pr_number)]
             assert task2 != task1
-            
+
             # Cleanup: cancel second task
             task2.cancel()
             try:

--- a/tests/github/test_discussions.py
+++ b/tests/github/test_discussions.py
@@ -98,16 +98,18 @@ def test_build_discussion_digest_counts_awaiting_threads():
 
     digest, awaiting = build_discussion_digest(
         [awaiting_thread, resolved_thread],
-        [build_discussion_comment(
-            {
-                "id": 7,
-                "body": "General question",
-                "created_at": "2025-02-14T10:00:00Z",
-                "updated_at": "2025-02-14T10:00:00Z",
-                "user": {"login": "reviewer"},
-            },
-            source="issue_comment",
-        )],
+        [
+            build_discussion_comment(
+                {
+                    "id": 7,
+                    "body": "General question",
+                    "created_at": "2025-02-14T10:00:00Z",
+                    "updated_at": "2025-02-14T10:00:00Z",
+                    "user": {"login": "reviewer"},
+                },
+                source="issue_comment",
+            )
+        ],
     )
 
     assert awaiting == 1

--- a/tests/github/test_merge_detection.py
+++ b/tests/github/test_merge_detection.py
@@ -151,9 +151,7 @@ class TestMergeCommitDetection:
         """Should detect merge from remote-tracking branch."""
         commit_info = {
             "parents": [{"sha": "abc123"}, {"sha": "def456"}],
-            "commit": {
-                "message": "Merge remote-tracking branch 'origin/main' into feature"
-            },
+            "commit": {"message": "Merge remote-tracking branch 'origin/main' into feature"},
             "files": [{"filename": "conflict.py"}],
         }
 

--- a/tests/github/test_thread_matching.py
+++ b/tests/github/test_thread_matching.py
@@ -161,9 +161,7 @@ class TestMatchThread:
 
     def test_exact_line_match(self):
         """Should match thread on exact same line."""
-        thread = _make_thread(
-            1, "file.py", 50, "**[HIGH] Bugs** - Issue description"
-        )
+        thread = _make_thread(1, "file.py", 50, "**[HIGH] Bugs** - Issue description")
         lookup = _build_thread_lookup([thread])
 
         comment = ReviewComment(
@@ -180,9 +178,7 @@ class TestMatchThread:
 
     def test_fuzzy_line_match_within_tolerance(self):
         """Should match thread within LINE_MATCH_TOLERANCE lines."""
-        thread = _make_thread(
-            1, "file.py", 50, "**[HIGH] Bugs** - Race condition in handler"
-        )
+        thread = _make_thread(1, "file.py", 50, "**[HIGH] Bugs** - Race condition in handler")
         lookup = _build_thread_lookup([thread])
 
         # Comment is 3 lines away (within tolerance of 5)
@@ -200,9 +196,7 @@ class TestMatchThread:
 
     def test_no_match_outside_tolerance(self):
         """Should not match thread outside LINE_MATCH_TOLERANCE."""
-        thread = _make_thread(
-            1, "file.py", 50, "**[HIGH] Bugs** - Issue description"
-        )
+        thread = _make_thread(1, "file.py", 50, "**[HIGH] Bugs** - Issue description")
         lookup = _build_thread_lookup([thread])
 
         # Comment is 10 lines away (outside tolerance of 5)
@@ -219,9 +213,7 @@ class TestMatchThread:
 
     def test_no_match_different_file(self):
         """Should not match thread in different file."""
-        thread = _make_thread(
-            1, "file1.py", 50, "**[HIGH] Bugs** - Issue description"
-        )
+        thread = _make_thread(1, "file1.py", 50, "**[HIGH] Bugs** - Issue description")
         lookup = _build_thread_lookup([thread])
 
         comment = ReviewComment(
@@ -237,12 +229,8 @@ class TestMatchThread:
 
     def test_prefers_exact_line_match_over_fuzzy(self):
         """Should prefer exact line match when multiple threads exist."""
-        thread_exact = _make_thread(
-            1, "file.py", 50, "**[HIGH] Bugs** - Exact match issue"
-        )
-        thread_nearby = _make_thread(
-            2, "file.py", 48, "**[HIGH] Bugs** - Nearby issue"
-        )
+        thread_exact = _make_thread(1, "file.py", 50, "**[HIGH] Bugs** - Exact match issue")
+        thread_nearby = _make_thread(2, "file.py", 48, "**[HIGH] Bugs** - Nearby issue")
         lookup = _build_thread_lookup([thread_exact, thread_nearby])
 
         comment = ReviewComment(
@@ -259,9 +247,7 @@ class TestMatchThread:
 
     def test_requires_content_similarity_for_fuzzy_match(self):
         """Fuzzy match should require content similarity."""
-        thread = _make_thread(
-            1, "file.py", 50, "**[HIGH] Security** - SQL injection vulnerability"
-        )
+        thread = _make_thread(1, "file.py", 50, "**[HIGH] Security** - SQL injection vulnerability")
         lookup = _build_thread_lookup([thread])
 
         # Same line range but completely different issue
@@ -279,9 +265,7 @@ class TestMatchThread:
 
     def test_no_match_for_non_baloo_thread(self):
         """Should not match non-Baloo threads."""
-        thread = _make_thread(
-            1, "file.py", 50, "Developer comment", is_baloo=False
-        )
+        thread = _make_thread(1, "file.py", 50, "Developer comment", is_baloo=False)
         lookup = _build_thread_lookup([thread])
 
         comment = ReviewComment(

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -37,7 +37,7 @@ async def test_updates_progress_comment_when_no_actionable_findings():
                 line=1,
                 body="Low severity observation",
                 severity="LOW",
-                category="Quality"
+                category="Quality",
             )
         ],
         approve=True,
@@ -45,10 +45,12 @@ async def test_updates_progress_comment_when_no_actionable_findings():
     )
     mock_agent.review_pr = AsyncMock(return_value=mock_review_result)
 
-    with patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client), \
-         patch("baloo.agent.client.BalooAgent", return_value=mock_agent), \
-         patch("baloo.config.settings.settings.review_auto_approve", False), \
-         patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"):
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.review_auto_approve", False),
+        patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"),
+    ):
 
         await process_pr_review(
             repo_full_name="test/repo",
@@ -96,10 +98,12 @@ async def test_posts_approval_when_auto_approve_enabled():
     )
     mock_agent.review_pr = AsyncMock(return_value=mock_review_result)
 
-    with patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client), \
-         patch("baloo.agent.client.BalooAgent", return_value=mock_agent), \
-         patch("baloo.config.settings.settings.review_auto_approve", True), \
-         patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"):
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.review_auto_approve", True),
+        patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"),
+    ):
 
         await process_pr_review(
             repo_full_name="test/repo",
@@ -161,14 +165,21 @@ async def test_approves_clean_review_with_high_fidelity_score():
         discrepancies=[],
     )
 
-    with patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client), \
-         patch("baloo.agent.client.BalooAgent", return_value=mock_agent), \
-         patch("baloo.config.settings.settings.review_auto_approve", False), \
-         patch("baloo.config.settings.settings.fidelity_enabled", True), \
-         patch("baloo.config.settings.settings.fidelity_approval_threshold", 90), \
-         patch("baloo.github.webhook_handler.analyze_fidelity", AsyncMock(return_value=fidelity_result)), \
-         patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"), \
-         patch("baloo.github.webhook_handler.fetch_plan_content", AsyncMock(return_value="# Plan content")):
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.review_auto_approve", False),
+        patch("baloo.config.settings.settings.fidelity_enabled", True),
+        patch("baloo.config.settings.settings.fidelity_approval_threshold", 90),
+        patch(
+            "baloo.github.webhook_handler.analyze_fidelity", AsyncMock(return_value=fidelity_result)
+        ),
+        patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"),
+        patch(
+            "baloo.github.webhook_handler.fetch_plan_content",
+            AsyncMock(return_value="# Plan content"),
+        ),
+    ):
 
         await process_pr_review(
             repo_full_name="test/repo",
@@ -219,7 +230,7 @@ async def test_approves_with_medium_issues_when_high_fidelity():
                 line=10,
                 body="This function has a performance issue that should be addressed",
                 severity="MEDIUM",
-                category="Performance"
+                category="Performance",
             )
         ],
         approve=False,
@@ -237,16 +248,23 @@ async def test_approves_with_medium_issues_when_high_fidelity():
         discrepancies=[],
     )
 
-    with patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client), \
-         patch("baloo.agent.client.BalooAgent", return_value=mock_agent), \
-         patch("baloo.config.settings.settings.review_auto_approve", False), \
-         patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"), \
-         patch("baloo.config.settings.settings.fidelity_enabled", True), \
-         patch("baloo.config.settings.settings.fidelity_approval_threshold", 90), \
-         patch("baloo.config.settings.settings.review_use_checks_api", False), \
-         patch("baloo.github.webhook_handler.analyze_fidelity", AsyncMock(return_value=fidelity_result)), \
-         patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"), \
-         patch("baloo.github.webhook_handler.fetch_plan_content", AsyncMock(return_value="# Plan content")):
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.review_auto_approve", False),
+        patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"),
+        patch("baloo.config.settings.settings.fidelity_enabled", True),
+        patch("baloo.config.settings.settings.fidelity_approval_threshold", 90),
+        patch("baloo.config.settings.settings.review_use_checks_api", False),
+        patch(
+            "baloo.github.webhook_handler.analyze_fidelity", AsyncMock(return_value=fidelity_result)
+        ),
+        patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"),
+        patch(
+            "baloo.github.webhook_handler.fetch_plan_content",
+            AsyncMock(return_value="# Plan content"),
+        ),
+    ):
 
         await process_pr_review(
             repo_full_name="test/repo",
@@ -259,7 +277,8 @@ async def test_approves_with_medium_issues_when_high_fidelity():
         # Verify approval review was posted (MEDIUM issues don't prevent fidelity-based approval)
         mock_github_client.post_review.assert_called()
         approval_calls = [
-            call for call in mock_github_client.post_review.call_args_list
+            call
+            for call in mock_github_client.post_review.call_args_list
             if call[0][2].approve is True
         ]
         assert len(approval_calls) == 1, "Should approve when high fidelity despite MEDIUM issues"
@@ -307,14 +326,21 @@ async def test_does_not_approve_with_low_fidelity_score():
         discrepancies=[],
     )
 
-    with patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client), \
-         patch("baloo.agent.client.BalooAgent", return_value=mock_agent), \
-         patch("baloo.config.settings.settings.review_auto_approve", False), \
-         patch("baloo.config.settings.settings.fidelity_enabled", True), \
-         patch("baloo.config.settings.settings.fidelity_approval_threshold", 90), \
-         patch("baloo.github.webhook_handler.analyze_fidelity", AsyncMock(return_value=fidelity_result)), \
-         patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"), \
-         patch("baloo.github.webhook_handler.fetch_plan_content", AsyncMock(return_value="# Plan content")):
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.review_auto_approve", False),
+        patch("baloo.config.settings.settings.fidelity_enabled", True),
+        patch("baloo.config.settings.settings.fidelity_approval_threshold", 90),
+        patch(
+            "baloo.github.webhook_handler.analyze_fidelity", AsyncMock(return_value=fidelity_result)
+        ),
+        patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"),
+        patch(
+            "baloo.github.webhook_handler.fetch_plan_content",
+            AsyncMock(return_value="# Plan content"),
+        ),
+    ):
 
         await process_pr_review(
             repo_full_name="test/repo",

--- a/tests/mocks/pr_contexts.py
+++ b/tests/mocks/pr_contexts.py
@@ -157,8 +157,7 @@ mock_pr_large = PRContext(
         base_branch="main",
         head_branch="refactor/database",
         files_changed=[
-            mock_file_change(f"db/models/model_{i}.py", "modified", 50, 30)
-            for i in range(1, 6)
+            mock_file_change(f"db/models/model_{i}.py", "modified", 50, 30) for i in range(1, 6)
         ],
     ),
     discussion=PRDiscussionContext(),

--- a/tests/processor/test_decision_engine.py
+++ b/tests/processor/test_decision_engine.py
@@ -146,8 +146,10 @@ class TestMakeDecisionWithFidelity:
         comments = []
         fidelity = _make_fidelity_result(70)  # Below threshold
 
-        with patch("baloo.config.settings.settings.fidelity_approval_threshold", 90), \
-             patch("baloo.config.settings.settings.review_auto_approve", False):
+        with (
+            patch("baloo.config.settings.settings.fidelity_approval_threshold", 90),
+            patch("baloo.config.settings.settings.review_auto_approve", False),
+        ):
             approve, request_changes = DecisionEngine.make_decision(
                 comments, fidelity_result=fidelity
             )
@@ -171,8 +173,10 @@ class TestMakeDecisionWithFidelity:
         comments = []
         fidelity = _make_fidelity_result(89)  # Just below threshold
 
-        with patch("baloo.config.settings.settings.fidelity_approval_threshold", 90), \
-             patch("baloo.config.settings.settings.review_auto_approve", True):
+        with (
+            patch("baloo.config.settings.settings.fidelity_approval_threshold", 90),
+            patch("baloo.config.settings.settings.review_auto_approve", True),
+        ):
             approve, request_changes = DecisionEngine.make_decision(
                 comments, fidelity_result=fidelity
             )
@@ -185,9 +189,7 @@ class TestMakeDecisionWithFidelity:
         comments = []
 
         with patch("baloo.config.settings.settings.review_auto_approve", True):
-            approve, request_changes = DecisionEngine.make_decision(
-                comments, fidelity_result=None
-            )
+            approve, request_changes = DecisionEngine.make_decision(comments, fidelity_result=None)
             assert approve is True
             assert request_changes is False
 

--- a/tests/test_checks_api.py
+++ b/tests/test_checks_api.py
@@ -39,7 +39,7 @@ async def test_create_check_run():
                 commit_sha="abc123def",
                 name="Test Check",
                 conclusion="neutral",
-                summary="Test summary"
+                summary="Test summary",
             )
 
             # Verify
@@ -65,15 +65,11 @@ async def test_add_annotations_includes_category():
             line=10,
             body="Security issue description",
             severity="MEDIUM",
-            category="Security"
+            category="Security",
         ),
         ReviewComment(
-            path="main.py",
-            line=25,
-            body="Bug description",
-            severity="MEDIUM",
-            category="Bugs"
-        )
+            path="main.py", line=25, body="Bug description", severity="MEDIUM", category="Bugs"
+        ),
     ]
 
     with patch("baloo.github.checks_api.GitHubAuth") as mock_auth_class:
@@ -97,9 +93,7 @@ async def test_add_annotations_includes_category():
 
             # Call the method
             await client.add_annotations(
-                repo_full_name="owner/repo",
-                check_run_id="12345",
-                findings=findings
+                repo_full_name="owner/repo", check_run_id="12345", findings=findings
             )
 
             # Verify
@@ -143,9 +137,7 @@ async def test_add_annotations_empty_list():
 
             # Call with empty list
             await client.add_annotations(
-                repo_full_name="owner/repo",
-                check_run_id="12345",
-                findings=[]
+                repo_full_name="owner/repo", check_run_id="12345", findings=[]
             )
 
             # Should not make any API calls
@@ -158,11 +150,7 @@ async def test_add_annotations_truncates_to_50():
     # Create 100 findings
     findings = [
         ReviewComment(
-            path=f"file{i}.py",
-            line=i,
-            body=f"Issue {i}",
-            severity="MEDIUM",
-            category="Quality"
+            path=f"file{i}.py", line=i, body=f"Issue {i}", severity="MEDIUM", category="Quality"
         )
         for i in range(100)
     ]
@@ -188,9 +176,7 @@ async def test_add_annotations_truncates_to_50():
 
             # Call the method
             await client.add_annotations(
-                repo_full_name="owner/repo",
-                check_run_id="12345",
-                findings=findings
+                repo_full_name="owner/repo", check_run_id="12345", findings=findings
             )
 
             # Verify only 50 annotations were sent
@@ -228,7 +214,7 @@ async def test_create_check_run_with_different_conclusions():
                     commit_sha="abc123",
                     name="Test",
                     conclusion=conclusion,
-                    summary="Test"
+                    summary="Test",
                 )
 
                 # Verify conclusion was set correctly

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -85,23 +85,23 @@ def test_prompt_without_discussion_digest():
 
 def test_is_dependabot_pr_detects_dependabot_author():
     """Test detection via dependabot author."""
-    pr = {'author': 'dependabot[bot]', 'title': '', 'description': ''}
+    pr = {"author": "dependabot[bot]", "title": "", "description": ""}
     assert _is_dependabot_pr(pr) is True
 
 
 def test_is_dependabot_pr_detects_dependabot_in_title():
     """Test detection via dependabot in title."""
-    pr = {'author': 'user', 'title': 'dependabot update', 'description': ''}
+    pr = {"author": "user", "title": "dependabot update", "description": ""}
     assert _is_dependabot_pr(pr) is True
 
 
 def test_is_dependabot_pr_detects_bot_with_bump_keyword():
     """Test detection of bot with bump in title and dependency files."""
     pr = {
-        'author': 'renovate[bot]',
-        'title': 'Bump package version',
-        'description': '',
-        'changed_file_paths': ['package.json']
+        "author": "renovate[bot]",
+        "title": "Bump package version",
+        "description": "",
+        "changed_file_paths": ["package.json"],
     }
     assert _is_dependabot_pr(pr) is True
 
@@ -109,100 +109,100 @@ def test_is_dependabot_pr_detects_bot_with_bump_keyword():
 def test_is_dependabot_pr_rejects_bot_with_bump_but_no_dep_files():
     """Test that bots with bump keyword but no dependency files are rejected."""
     pr = {
-        'author': 'some-bot[bot]',
-        'title': 'Bump version in docs',
-        'description': '',
-        'changed_file_paths': ['docs/version.md']
+        "author": "some-bot[bot]",
+        "title": "Bump version in docs",
+        "description": "",
+        "changed_file_paths": ["docs/version.md"],
     }
     assert _is_dependabot_pr(pr) is False
 
 
 def test_is_dependabot_pr_rejects_unrelated_bot():
     """Test that non-dependency bots are not detected."""
-    pr = {'author': 'codecov[bot]', 'title': 'Coverage report updated', 'description': ''}
+    pr = {"author": "codecov[bot]", "title": "Coverage report updated", "description": ""}
     assert _is_dependabot_pr(pr) is False
 
 
 def test_is_dependabot_pr_rejects_regular_user():
     """Test that regular users are not detected."""
-    pr = {'author': 'john-doe', 'title': 'Update code', 'description': ''}
+    pr = {"author": "john-doe", "title": "Update code", "description": ""}
     assert _is_dependabot_pr(pr) is False
 
 
 def test_is_security_patch_detects_security_in_title():
     """Test detection via security keyword in title."""
-    pr = {'title': 'Security update for django', 'description': ''}
+    pr = {"title": "Security update for django", "description": ""}
     assert _is_security_patch(pr) is True
 
 
 def test_is_security_patch_detects_vulnerability_in_description():
     """Test detection via vulnerability keyword in description."""
-    pr = {'title': '', 'description': 'Fixes vulnerability in auth module'}
+    pr = {"title": "", "description": "Fixes vulnerability in auth module"}
     assert _is_security_patch(pr) is True
 
 
 def test_is_security_patch_detects_cve():
     """Test detection via CVE identifier."""
-    pr = {'title': 'Bump django', 'description': 'Fixes CVE-2024-1234'}
+    pr = {"title": "Bump django", "description": "Fixes CVE-2024-1234"}
     assert _is_security_patch(pr) is True
 
 
 def test_is_security_patch_rejects_regular_pr():
     """Test that non-security PRs are not detected."""
-    pr = {'title': 'Add new feature', 'description': 'Implements user dashboard'}
+    pr = {"title": "Add new feature", "description": "Implements user dashboard"}
     assert _is_security_patch(pr) is False
 
 
 def test_security_patch_notice_in_prompt():
     """Test that security patch notice appears in prompt for Dependabot security PR."""
     pr_context = {
-        'title': 'chore(deps): Bump js-yaml from 4.1.0 to 4.1.1',
-        'author': 'dependabot[bot]',
-        'description': 'Security fix for prototype pollution',
-        'files_changed': [{'filename': 'package-lock.json'}],
-        'changed_file_paths': ['package-lock.json'],
-        'diff': '...',
+        "title": "chore(deps): Bump js-yaml from 4.1.0 to 4.1.1",
+        "author": "dependabot[bot]",
+        "description": "Security fix for prototype pollution",
+        "files_changed": [{"filename": "package-lock.json"}],
+        "changed_file_paths": ["package-lock.json"],
+        "diff": "...",
     }
 
     prompt = build_pr_review_prompt(pr_context)
 
-    assert '🔒 SECURITY PATCH DETECTED' in prompt
-    assert 'OLD version has vulnerability' in prompt
-    assert 'Do NOT report the upgrade itself as introducing a vulnerability' in prompt
-    assert 'Default to APPROVE' in prompt
+    assert "🔒 SECURITY PATCH DETECTED" in prompt
+    assert "OLD version has vulnerability" in prompt
+    assert "Do NOT report the upgrade itself as introducing a vulnerability" in prompt
+    assert "Default to APPROVE" in prompt
 
 
 def test_dependabot_notice_in_prompt():
     """Test that Dependabot notice appears for non-security dependency update."""
     pr_context = {
-        'title': 'Bump package from 1.0 to 1.1',
-        'author': 'dependabot[bot]',
-        'description': 'Regular update',
-        'files_changed': [{'filename': 'requirements.txt'}],
-        'changed_file_paths': ['requirements.txt'],
-        'diff': '...',
+        "title": "Bump package from 1.0 to 1.1",
+        "author": "dependabot[bot]",
+        "description": "Regular update",
+        "files_changed": [{"filename": "requirements.txt"}],
+        "changed_file_paths": ["requirements.txt"],
+        "diff": "...",
     }
 
     prompt = build_pr_review_prompt(pr_context)
 
-    assert '🤖 DEPENDABOT PR DETECTED' in prompt
-    assert 'automated dependency update' in prompt
+    assert "🤖 DEPENDABOT PR DETECTED" in prompt
+    assert "automated dependency update" in prompt
 
 
 def test_no_special_notice_for_regular_pr():
     """Test that regular PRs don't get special notices."""
     pr_context = {
-        'title': 'Add feature',
-        'author': 'developer',
-        'description': 'New feature',
-        'base_branch': 'main',
-        'head_branch': 'feature/add-feature',
-        'files_changed': [{'filename': 'app.py'}],
-        'changed_file_paths': ['app.py'],
-        'diff': '...',
+        "title": "Add feature",
+        "author": "developer",
+        "description": "New feature",
+        "base_branch": "main",
+        "head_branch": "feature/add-feature",
+        "files_changed": [{"filename": "app.py"}],
+        "changed_file_paths": ["app.py"],
+        "diff": "...",
     }
 
     prompt = build_pr_review_prompt(pr_context)
 
-    assert '🔒 SECURITY PATCH DETECTED' not in prompt
-    assert '🤖 DEPENDABOT PR DETECTED' not in prompt
+    assert "🔒 SECURITY PATCH DETECTED" not in prompt
+    assert "🤖 DEPENDABOT PR DETECTED" not in prompt

--- a/tests/test_severity_router.py
+++ b/tests/test_severity_router.py
@@ -8,24 +8,27 @@ def test_route_findings_splits_by_severity():
     """Test that findings are correctly routed by severity."""
     findings = [
         ReviewComment(
-            path="a.py", line=1, body="Critical security issue",
-            severity="CRITICAL", category="Security"
+            path="a.py",
+            line=1,
+            body="Critical security issue",
+            severity="CRITICAL",
+            category="Security",
         ),
         ReviewComment(
-            path="b.py", line=2, body="High priority bug",
-            severity="HIGH", category="Bugs"
+            path="b.py", line=2, body="High priority bug", severity="HIGH", category="Bugs"
         ),
         ReviewComment(
-            path="c.py", line=3, body="Medium quality issue",
-            severity="MEDIUM", category="Quality"
+            path="c.py", line=3, body="Medium quality issue", severity="MEDIUM", category="Quality"
         ),
         ReviewComment(
-            path="d.py", line=4, body="Medium performance issue",
-            severity="MEDIUM", category="Performance"
+            path="d.py",
+            line=4,
+            body="Medium performance issue",
+            severity="MEDIUM",
+            category="Performance",
         ),
         ReviewComment(
-            path="e.py", line=5, body="Low style issue",
-            severity="LOW", category="Quality"
+            path="e.py", line=5, body="Low style issue", severity="LOW", category="Quality"
         ),
     ]
 
@@ -56,12 +59,10 @@ def test_route_findings_only_critical():
     """Test routing with only CRITICAL findings."""
     findings = [
         ReviewComment(
-            path="a.py", line=1, body="Critical issue 1",
-            severity="CRITICAL", category="Security"
+            path="a.py", line=1, body="Critical issue 1", severity="CRITICAL", category="Security"
         ),
         ReviewComment(
-            path="b.py", line=2, body="Critical issue 2",
-            severity="CRITICAL", category="Security"
+            path="b.py", line=2, body="Critical issue 2", severity="CRITICAL", category="Security"
         ),
     ]
 
@@ -75,12 +76,10 @@ def test_route_findings_only_medium():
     """Test routing with only MEDIUM findings."""
     findings = [
         ReviewComment(
-            path="a.py", line=1, body="Medium issue 1",
-            severity="MEDIUM", category="Quality"
+            path="a.py", line=1, body="Medium issue 1", severity="MEDIUM", category="Quality"
         ),
         ReviewComment(
-            path="b.py", line=2, body="Medium issue 2",
-            severity="MEDIUM", category="Performance"
+            path="b.py", line=2, body="Medium issue 2", severity="MEDIUM", category="Performance"
         ),
     ]
 
@@ -97,7 +96,7 @@ def test_route_findings_preserves_finding_data():
         line=42,
         body="Test issue with detailed description",
         severity="HIGH",
-        category="Bugs"
+        category="Bugs",
     )
 
     routed = route_findings([finding])

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
     { name = "black" },
@@ -172,32 +172,35 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite", marker = "extra == 'dev'", specifier = ">=0.20.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.7.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.24.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pygithub", specifier = ">=2.1.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "requests", specifier = ">=2.33.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.285" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.23.0" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "black", specifier = ">=23.7.0" },
+    { name = "mypy", specifier = ">=1.5.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.21.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "ruff", specifier = ">=0.0.285" },
+]
 
 [[package]]
 name = "black"


### PR DESCRIPTION
## Summary
- Fix red CI on `main`: `uv sync` wasn't installing the dev group, so `ruff`/`black`/`pytest` were missing in CI. Moved dev tools to PEP 735 `[dependency-groups].dev`, which `uv sync` installs by default — no `--extra dev` needed locally or in CI.
- Repair three real lint bugs the broken CI was hiding: an undefined `Any` in a return annotation (`webhook_handler._run_fidelity_analysis`), a function-scope `MAX_ANNOTATIONS` that should be a module constant (`checks_api`), and a dead `owner_login` local in a test helper.
- Migrate deprecated top-level `[tool.ruff]` lint config to `[tool.ruff.lint]` and ignore `E501` — black owns line layout; the remaining long lines are unbreakable strings/log messages.
- Mechanical `ruff --fix` + `black` pass across the codebase (second commit, kept separate for reviewability). Mostly import sorting, `UP` pyupgrade rewrites, and argument-list reflow. No behavior changes.

## Test plan
- [x] `uv run ruff check baloo tests` — clean
- [x] `uv run black --check baloo tests` — 68 files clean
- [x] `uv run pytest -q` — 252 passed (previously 241 passed + 10 errors from missing `aiosqlite`)
- [ ] GitHub Actions CI green on this branch