### PR TITLE
fix: add log timestamps and recover agent output after errors

### DIFF
--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -54,7 +54,14 @@ class BalooAgent(PIAgentBase):
             if structured_data is not None:
                 comments = findings_to_comments(structured_data)
             else:
-                logger.warning("No structured output received from agent")
+                logger.warning(
+                    "No structured output received from agent "
+                    "(model: %s, turns: %s, tokens_out: %s, is_error: %s)",
+                    metadata.get("model"),
+                    metadata.get("num_turns"),
+                    metadata.get("output_tokens"),
+                    metadata.get("is_error"),
+                )
                 metadata["agent_error"] = True
                 metadata["error_category"] = metadata.get("error_category", "no_output")
 

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -15,7 +15,7 @@ import logging
 import re
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from baloo.config.settings import get_settings
@@ -41,6 +41,7 @@ class PIRunResult:
     """Result of a PI agent run."""
 
     assistant_text: str = ""
+    all_assistant_texts: list[str] = field(default_factory=list)
     input_tokens: int = 0
     output_tokens: int = 0
     cache_read_tokens: int = 0
@@ -143,6 +144,7 @@ class PIAgentBase:
             "cost_usd": result.cost_usd,
             "num_turns": result.num_turns,
             "duration_seconds": result.duration_seconds,
+            "is_error": result.is_error,
         }
 
     # -----------------------------------------------------------------
@@ -248,9 +250,26 @@ class PIAgentBase:
         # Parse structured JSON from assistant text
         structured_output = _extract_json_from_text(result.assistant_text)
 
+        # If the last message didn't contain parseable JSON (common after an
+        # error stop reason), try earlier assistant messages — the review JSON
+        # is often emitted in a turn before the one that errored.
+        if structured_output is None and len(result.all_assistant_texts) > 1:
+            for i, earlier_text in enumerate(reversed(result.all_assistant_texts[:-1])):
+                candidate = _extract_json_from_text(earlier_text)
+                if candidate is not None:
+                    logger.info(
+                        "%s: recovered structured output from assistant message %d/%d",
+                        self.agent_name,
+                        len(result.all_assistant_texts) - 1 - i,
+                        len(result.all_assistant_texts),
+                    )
+                    structured_output = candidate
+                    metadata["recovered_from_earlier_turn"] = True
+                    break
+
         if structured_output is None and result.assistant_text:
             logger.warning(
-                "%s: could not parse JSON from assistant response (%d chars). " "Raw text: %s...",
+                "%s: could not parse JSON from assistant response (%d chars). Raw text: %s...",
                 self.agent_name,
                 len(result.assistant_text),
                 result.assistant_text[:1000].replace("\n", " "),
@@ -394,6 +413,7 @@ class PIAgentBase:
 
         # 3. Stream events until agent_end
         last_assistant_text = ""
+        all_assistant_texts: list[str] = []
         turn_count = 0
 
         while True:
@@ -433,6 +453,7 @@ class PIAgentBase:
                             text_parts.append(block)
                     if text_parts:
                         last_assistant_text = "\n".join(text_parts)
+                        all_assistant_texts.append(last_assistant_text)
 
                     # Accumulate usage
                     usage = msg.get("usage", {})
@@ -465,6 +486,7 @@ class PIAgentBase:
                 pass
 
         result.assistant_text = last_assistant_text
+        result.all_assistant_texts = all_assistant_texts
         result.num_turns = turn_count
 
         return result

--- a/main.py
+++ b/main.py
@@ -1,16 +1,46 @@
 """Main entry point for Baloo application."""
 
 import logging
+
 import uvicorn
+
 from baloo.config.settings import settings
 from baloo.github.webhook_handler import app
-from baloo.version import get_version_info, VERSION, COMMIT_SHA, BUILD_DATE
+from baloo.version import BUILD_DATE, COMMIT_SHA, VERSION, get_version_info
 
-# Configure logging
-logging.basicConfig(
-    level=settings.log_level,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-)
+# Logging format shared by the app and uvicorn
+LOG_FORMAT = "%(asctime)s %(levelname)-5s [%(name)s] %(message)s"
+
+# Configure root logger (covers all non-uvicorn loggers)
+logging.basicConfig(level=settings.log_level, format=LOG_FORMAT)
+
+# Uvicorn log config — override its default formatters so every line
+# gets a timestamp, matching the rest of the application output.
+UVICORN_LOG_CONFIG: dict = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {"format": LOG_FORMAT},
+        "access": {"format": LOG_FORMAT},
+    },
+    "handlers": {
+        "default": {
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+        },
+        "access": {
+            "formatter": "access",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "loggers": {
+        "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
+    },
+}
 
 # Suppress verbose logs from third-party libraries
 logging.getLogger("httpcore").setLevel(logging.WARNING)
@@ -22,7 +52,11 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     """Run the Baloo webhook server."""
     # Format commit SHA for display (only truncate if it's a real SHA)
-    commit_display = COMMIT_SHA[:8] if COMMIT_SHA not in ('unknown', 'dev', '') and len(COMMIT_SHA) >= 8 else COMMIT_SHA
+    commit_display = (
+        COMMIT_SHA[:8]
+        if COMMIT_SHA not in ("unknown", "dev", "") and len(COMMIT_SHA) >= 8
+        else COMMIT_SHA
+    )
 
     logger.info("=" * 80)
     logger.info(get_version_info())
@@ -36,6 +70,7 @@ def main() -> None:
         host=settings.app_host,
         port=settings.app_port,
         log_level=settings.log_level.lower(),
+        log_config=UVICORN_LOG_CONFIG,
     )
 
 


### PR DESCRIPTION
## Summary
- **Log timestamps**: uvicorn's `run()` overwrites the root logger's formatter, so all non-uvicorn logs lost their timestamps. Now passes a custom `log_config` dict to `uvicorn.run()` with a shared `LOG_FORMAT` that includes `%(asctime)s`.
- **Agent error recovery**: When the PI agent hits an error stop reason after multiple turns of analysis (~$0.30 of work), the structured JSON review was silently discarded. The agent accumulates all assistant messages now, and when JSON extraction fails on the last (errored) message, it walks earlier messages newest-first to recover the review output. Also exposes `is_error` in metadata and enriches the "no structured output" warning for debugging.

## Test plan
- [x] `uv run ruff check` — clean
- [x] `uv run black --check` — clean
- [x] `uv run pytest -q` — 269 passed
- [ ] Deploy and verify log output includes timestamps
- [ ] Trigger an agent error and confirm review output is recovered from earlier turns