### PR TITLE
docs: remove shipped FP reduction pass from roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,14 +7,7 @@ of findings and produces a single merged review, keeping findings both models
 agree on and adjudicating conflicts.  Goal: higher recall without more false
 positives.
 
-## 2. False-positive reduction pass
-After the agent produces findings, run a second lightweight pass that
-re-examines each finding in isolation: read the flagged code, check the
-claim, and decide "real issue" vs "false positive".  Drop FPs before
-posting.  This can use a cheaper model (Flash/Haiku) since each check is
-scoped to a single finding + file context.
-
-## 3. Conversational thread agent
+## 2. Conversational thread agent
 When a developer replies to a Baloo inline comment (`pull_request_review_comment`
 event), don't re-review the whole PR.  Instead, run a lightweight
 thread-reply agent that:
@@ -30,7 +23,7 @@ prompts and the FP-reduction pass over time.
 > `pull_request_review`) are currently disabled in the webhook handler.
 > Re-enable selectively when implementing this feature.
 
-## 4. AST-enriched context for the review agent
+## 3. AST-enriched context for the review agent
 Before the PI agent reviews a PR, parse changed files into ASTs and provide
 structural context alongside the raw diff.  This gives the agent:
 - Function/class boundaries for each hunk ("this change is inside `AuthService.validate_token`")


### PR DESCRIPTION
## Summary
- Remove the FP reduction pass from the roadmap — shipped in PR #1
- Renumber remaining items (3 left: multi-model judge, conversational threads, AST context)