### PR TITLE
feat: execution logs dashboard & JSON parsing fix

### DIFF
--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -1,6 +1,7 @@
 """PI-based agent client for code review."""
 
 import logging
+from typing import Any
 
 from baloo.agent.config import get_agent_options
 from baloo.agent.pi_runtime import PIAgentBase
@@ -46,8 +47,23 @@ class BalooAgent(PIAgentBase):
             # Build review prompt
             review_query = build_pr_review_prompt(pr_context)
 
+            # Create execution logger if database is enabled
+            review_logger = None
+            logger_session = None
+            review_id = getattr(pr_context, '_review_id', None)
+            if review_id:
+                from baloo.agent.logger import ReviewLogger
+                from baloo.config.settings import get_settings
+                from baloo.db.engine import get_session_factory
+
+                settings = get_settings()
+                if settings.database_enabled:
+                    factory = get_session_factory(settings.database_url)
+                    logger_session = factory()
+                    review_logger = ReviewLogger(review_id=review_id, session=logger_session)
+
             # Run agent using base class
-            structured_data, metadata = await self._run_with_fallback(review_query)
+            structured_data, metadata = await self._run_with_fallback(review_query, review_logger=review_logger)
 
             # Convert structured output to review comments
             comments = []
@@ -78,6 +94,14 @@ class BalooAgent(PIAgentBase):
                 request_changes=request_changes,
                 metadata=metadata,
             )
+
+            # Flush and close the logger session
+            if logger_session is not None:
+                try:
+                    await logger_session.commit()
+                    await logger_session.close()
+                except Exception:
+                    pass
 
             return result
 
@@ -114,12 +138,12 @@ class BalooAgent(PIAgentBase):
             return "auth_error"
         return "agent_error"
 
-    async def _run_with_fallback(self, query: str):
+    async def _run_with_fallback(self, query: str, review_logger: Any = None):
         """Run query with automatic fallback to secondary model on failure."""
         from baloo.config.settings import get_settings
 
         try:
-            return await self.run_query(query)
+            return await self.run_query(query, review_logger=review_logger)
         except Exception as primary_err:
             settings = get_settings()
             fallback = settings.agent_fallback_model
@@ -140,6 +164,13 @@ class BalooAgent(PIAgentBase):
                 fallback,
             )
 
+            if review_logger:
+                await review_logger.fallback_triggered(
+                    primary_model=f"{self.options.provider}/{self.options.model}",
+                    fallback_model=fallback,
+                    error=str(primary_err),
+                )
+
             # Swap to fallback model
             original_provider = self.options.provider
             original_model = self.options.model
@@ -147,7 +178,7 @@ class BalooAgent(PIAgentBase):
             self.options.model = fallback_model
 
             try:
-                result = await self.run_query(query)
+                result = await self.run_query(query, review_logger=review_logger)
                 # Tag metadata so callers know fallback was used
                 result[1]["fallback_used"] = True
                 result[1]["primary_model"] = f"{original_provider}/{original_model}"

--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -50,7 +50,7 @@ class BalooAgent(PIAgentBase):
             # Create execution logger if database is enabled
             review_logger = None
             logger_session = None
-            review_id = getattr(pr_context, '_review_id', None)
+            review_id = getattr(pr_context, "_review_id", None)
             if review_id:
                 from baloo.agent.logger import ReviewLogger
                 from baloo.config.settings import get_settings
@@ -63,7 +63,9 @@ class BalooAgent(PIAgentBase):
                     review_logger = ReviewLogger(review_id=review_id, session=logger_session)
 
             # Run agent using base class
-            structured_data, metadata = await self._run_with_fallback(review_query, review_logger=review_logger)
+            structured_data, metadata = await self._run_with_fallback(
+                review_query, review_logger=review_logger
+            )
 
             # Convert structured output to review comments
             comments = []

--- a/baloo/agent/logger.py
+++ b/baloo/agent/logger.py
@@ -57,9 +57,7 @@ class ReviewLogger:
             metadata={"model": model, "thinking_level": thinking_level},
         )
 
-    async def turn_completed(
-        self, turn_number: int, tokens_in: int, tokens_out: int
-    ) -> None:
+    async def turn_completed(self, turn_number: int, tokens_in: int, tokens_out: int) -> None:
         await self._log(
             "turn_completed",
             f"Turn {turn_number} completed ({tokens_in} in / {tokens_out} out)",
@@ -98,9 +96,7 @@ class ReviewLogger:
             raw_text=raw_text,
         )
 
-    async def fallback_triggered(
-        self, primary_model: str, fallback_model: str, error: str
-    ) -> None:
+    async def fallback_triggered(self, primary_model: str, fallback_model: str, error: str) -> None:
         await self._log(
             "fallback_triggered",
             f"Falling back from {primary_model} to {fallback_model}: {error[:200]}",

--- a/baloo/agent/logger.py
+++ b/baloo/agent/logger.py
@@ -1,0 +1,136 @@
+"""Structured execution logger for review tasks."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from baloo.db.models import ReviewLog
+
+logger = logging.getLogger(__name__)
+
+
+class ReviewLogger:
+    """Emits structured log events to the review_logs table.
+
+    If review_id is None (database disabled), all methods are no-ops.
+    Errors are swallowed to avoid crashing the review pipeline.
+    """
+
+    def __init__(self, review_id: int | None, session: Any = None):
+        self._review_id = review_id
+        self._session = session
+
+    @property
+    def active(self) -> bool:
+        return self._review_id is not None and self._session is not None
+
+    async def _log(
+        self,
+        event_type: str,
+        message: str,
+        raw_text: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        if not self.active:
+            return
+        try:
+            row = ReviewLog(
+                review_id=self._review_id,
+                created_at=datetime.now(timezone.utc),
+                event_type=event_type,
+                message=message,
+                raw_text=raw_text,
+                metadata_json=json.dumps(metadata) if metadata else None,
+            )
+            self._session.add(row)
+            await self._session.flush()
+        except Exception as exc:
+            logger.debug("ReviewLogger failed to write %s: %s", event_type, exc)
+
+    async def agent_started(self, model: str, thinking_level: str) -> None:
+        await self._log(
+            "agent_started",
+            f"Agent started with model {model}",
+            metadata={"model": model, "thinking_level": thinking_level},
+        )
+
+    async def turn_completed(
+        self, turn_number: int, tokens_in: int, tokens_out: int
+    ) -> None:
+        await self._log(
+            "turn_completed",
+            f"Turn {turn_number} completed ({tokens_in} in / {tokens_out} out)",
+            metadata={
+                "turn_number": turn_number,
+                "tokens_in": tokens_in,
+                "tokens_out": tokens_out,
+            },
+        )
+
+    async def tool_use(self, tool_name: str, file_path: str | None = None) -> None:
+        msg = f"Tool call: {tool_name}"
+        if file_path:
+            msg += f" ({file_path})"
+        await self._log(
+            "tool_use",
+            msg,
+            metadata={"tool_name": tool_name, "file_path": file_path},
+        )
+
+    async def json_parse_failed(self, raw_text: str, char_count: int) -> None:
+        await self._log(
+            "json_parse_failed",
+            f"JSON extraction failed on {char_count} chars of assistant text",
+            raw_text=raw_text,
+            metadata={"char_count": char_count},
+        )
+
+    async def json_retry_started(self) -> None:
+        await self._log("json_retry_started", "Spawning JSON retry subprocess")
+
+    async def json_retry_failed(self, raw_text: str) -> None:
+        await self._log(
+            "json_retry_failed",
+            "JSON retry also failed to produce valid JSON",
+            raw_text=raw_text,
+        )
+
+    async def fallback_triggered(
+        self, primary_model: str, fallback_model: str, error: str
+    ) -> None:
+        await self._log(
+            "fallback_triggered",
+            f"Falling back from {primary_model} to {fallback_model}: {error[:200]}",
+            metadata={
+                "primary_model": primary_model,
+                "fallback_model": fallback_model,
+                "error": error[:500],
+            },
+        )
+
+    async def agent_completed(
+        self, tokens_in: int, tokens_out: int, cost: float, duration: float
+    ) -> None:
+        await self._log(
+            "agent_completed",
+            f"Agent completed ({tokens_in} in / {tokens_out} out, ${cost:.4f}, {duration:.1f}s)",
+            metadata={
+                "tokens_in": tokens_in,
+                "tokens_out": tokens_out,
+                "cost": cost,
+                "duration": duration,
+            },
+        )
+
+    async def agent_error(self, error_message: str, error_category: str = "") -> None:
+        await self._log(
+            "agent_error",
+            f"Agent error: {error_message[:200]}",
+            metadata={
+                "error_message": error_message[:500],
+                "error_category": error_category,
+            },
+        )

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -574,7 +574,11 @@ class PIAgentBase:
                 tool = event.get("toolName", "?")
                 logger.debug("%s: tool call → %s", self.agent_name, tool)
                 if review_logger:
-                    tool_file = event.get("input", {}).get("path") if isinstance(event.get("input"), dict) else None
+                    tool_file = (
+                        event.get("input", {}).get("path")
+                        if isinstance(event.get("input"), dict)
+                        else None
+                    )
                     await review_logger.tool_use(tool_name=tool, file_path=tool_file)
 
             elif etype == "agent_end":

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -212,7 +212,7 @@ class PIAgentBase:
     # Main query interface
     # -----------------------------------------------------------------
 
-    async def run_query(self, query: str) -> tuple[Any, dict[str, Any]]:
+    async def run_query(self, query: str, review_logger: Any = None) -> tuple[Any, dict[str, Any]]:
         """Run a query through the PI agent and return structured output + metadata.
 
         Returns:
@@ -221,6 +221,15 @@ class PIAgentBase:
         settings = get_settings()
         start_time = time.time()
         result = PIRunResult()
+
+        from baloo.agent.logger import ReviewLogger
+
+        if review_logger is None:
+            review_logger = ReviewLogger(review_id=None)
+
+        await review_logger.agent_started(
+            model=self.options.model, thinking_level=self.options.thinking_level
+        )
 
         pi_binary = settings.pi_binary_path or "pi"
         cwd = self.options.cwd or None
@@ -259,7 +268,7 @@ class PIAgentBase:
         )
 
         try:
-            result = await self._drive_session(proc, query, start_time)
+            result = await self._drive_session(proc, query, start_time, review_logger)
         except Exception as exc:
             logger.error("%s: PI session error: %s", self.agent_name, exc)
             result.is_error = True
@@ -335,7 +344,11 @@ class PIAgentBase:
                 len(result.assistant_text),
                 result.assistant_text[:1000].replace("\n", " "),
             )
+            await review_logger.json_parse_failed(
+                raw_text=result.assistant_text, char_count=len(result.assistant_text)
+            )
             logger.info("%s: requesting JSON retry", self.agent_name)
+            await review_logger.json_retry_started()
             structured_output, retry_metadata = await self._retry_json(proc_cwd=cwd)
             if retry_metadata:
                 # Accumulate retry costs into the main metadata
@@ -344,6 +357,21 @@ class PIAgentBase:
                 metadata["cost_usd"] += retry_metadata.get("cost_usd", 0)
                 metadata["num_turns"] += retry_metadata.get("num_turns", 0)
                 metadata["json_retry"] = True
+                if structured_output is None:
+                    await review_logger.json_retry_failed(raw_text=result.assistant_text)
+
+        if result.is_error:
+            await review_logger.agent_error(
+                error_message=result.error_message,
+                error_category="agent_error",
+            )
+        else:
+            await review_logger.agent_completed(
+                tokens_in=metadata.get("input_tokens", 0),
+                tokens_out=metadata.get("output_tokens", 0),
+                cost=metadata.get("cost_usd", 0),
+                duration=metadata.get("duration_seconds", 0),
+            )
 
         return structured_output, metadata
 
@@ -436,6 +464,7 @@ class PIAgentBase:
         proc: asyncio.subprocess.Process,
         query: str,
         start_time: float,
+        review_logger: Any = None,
     ) -> PIRunResult:
         """Drive the RPC session: configure → prompt → collect events."""
         assert proc.stdin is not None
@@ -490,6 +519,12 @@ class PIAgentBase:
 
             if etype == "turn_end":
                 turn_count += 1
+                if review_logger:
+                    await review_logger.turn_completed(
+                        turn_number=turn_count,
+                        tokens_in=result.input_tokens,
+                        tokens_out=result.output_tokens,
+                    )
                 # Enforce max turns
                 if turn_count >= self.options.max_turns:
                     logger.warning(
@@ -538,6 +573,9 @@ class PIAgentBase:
             elif etype == "tool_execution_start":
                 tool = event.get("toolName", "?")
                 logger.debug("%s: tool call → %s", self.agent_name, tool)
+                if review_logger:
+                    tool_file = event.get("input", {}).get("path") if isinstance(event.get("input"), dict) else None
+                    await review_logger.tool_use(tool_name=tool, file_path=tool_file)
 
             elif etype == "agent_end":
                 break

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -62,7 +62,8 @@ def _extract_json_from_text(text: str) -> dict | None:
     fences or surrounding text.  We try multiple strategies:
     1. Direct JSON parse
     2. Extract from ```json ... ``` fences
-    3. Find the outermost { ... } block
+    3. Reverse-scan: find the last complete JSON object from the tail
+    4. Outermost { ... } block (last resort)
     """
     stripped = text.strip()
 
@@ -80,7 +81,12 @@ def _extract_json_from_text(text: str) -> dict | None:
         except (json.JSONDecodeError, ValueError):
             pass
 
-    # Strategy 3: find outermost braces
+    # Strategy 3: reverse-scan — find the last complete JSON object
+    result = _reverse_scan_json(stripped)
+    if result is not None:
+        return result
+
+    # Strategy 4: outermost braces (last resort)
     first_brace = stripped.find("{")
     last_brace = stripped.rfind("}")
     if first_brace != -1 and last_brace > first_brace:
@@ -88,6 +94,61 @@ def _extract_json_from_text(text: str) -> dict | None:
             return json.loads(stripped[first_brace : last_brace + 1])
         except (json.JSONDecodeError, ValueError):
             pass
+
+    return None
+
+
+def _reverse_scan_json(text: str) -> dict | None:
+    """Scan backwards from the end of text to find the last complete JSON object.
+
+    Walks backwards from the last '}', counting brace depth while respecting
+    string literals, to find the matching '{'. This handles the common pattern
+    where the model emits a long reasoning preamble before the JSON output.
+    """
+    # Find the last closing brace
+    end = len(text) - 1
+    while end >= 0 and text[end] != "}":
+        end -= 1
+    if end < 0:
+        return None
+
+    # Walk backwards counting brace depth, respecting strings
+    depth = 0
+    i = end
+    in_string = False
+    escape = False
+
+    while i >= 0:
+        ch = text[i]
+
+        if escape:
+            escape = False
+            i -= 1
+            continue
+
+        if in_string:
+            if ch == '"':
+                in_string = False
+            elif ch == "\\" and i > 0 and text[i - 1] == "\\":
+                escape = True
+            i -= 1
+            continue
+
+        if ch == '"':
+            in_string = True
+        elif ch == "}":
+            depth += 1
+        elif ch == "{":
+            depth -= 1
+            if depth == 0:
+                # Found the matching opening brace
+                candidate = text[i : end + 1]
+                try:
+                    return json.loads(candidate)
+                except (json.JSONDecodeError, ValueError):
+                    return None
+
+        i -= 1
 
     return None
 

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -67,7 +67,9 @@ Only flag a violation if the target repo's guidelines explicitly require a diffe
 
 {REVIEW_SEVERITY_GUIDELINES}
 Be specific (file:line), constructive, balanced.
-You MUST return ONLY valid JSON matching the Output Schema above. No markdown fences, no commentary — just the raw JSON object."""
+You MUST return ONLY valid JSON matching the Output Schema above. No markdown fences, no commentary — just the raw JSON object.
+
+REMINDER: Your final message MUST be ONLY the JSON object. Do not include any reasoning, analysis, or text before or after the JSON."""
 
 
 def _ctx_get(pr_context: PRContext | dict[str, Any], key: str, default: Any = None) -> Any:
@@ -371,7 +373,9 @@ If YES: This PR may be fixing a constraint or addressing feedback. Understand WH
 
 **Output immediately**: After reading and analyzing, provide your findings as JSON matching the schema.
 You MUST return ONLY valid JSON matching the Output Schema. No markdown fences, no commentary — just the raw JSON object.
-If no issues found, return empty findings array. Be practical and focus on real risks."""
+If no issues found, return empty findings array. Be practical and focus on real risks.
+
+REMINDER: Your final message MUST be ONLY the JSON object. Do not include any reasoning, analysis, or text before or after the JSON."""
 
 
 def build_pr_review_prompt(pr_context: PRContext | dict[str, Any]) -> str:
@@ -491,4 +495,6 @@ For each issue you identify:
 4. Suggest a specific fix with code examples
 
 Focus on issues that truly matter for security, correctness, and maintainability. Be thorough but practical.
+
+REMINDER: Your final message MUST be ONLY the JSON object. Do not include any reasoning, analysis, or text before or after the JSON.
 """

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -86,6 +86,9 @@ class Settings(BaseSettings):
     dashboard_enabled: bool = Field(default=True, description="Enable the review history dashboard")
     dashboard_username: str = Field(default="", description="Dashboard basic auth username")
     dashboard_password: str = Field(default="", description="Dashboard basic auth password")
+    log_retention_days: int = Field(
+        default=30, description="Days to retain execution logs (0 to disable cleanup)"
+    )
 
     # FP Verification Configuration
     fp_verification_enabled: bool = Field(

--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from baloo.config.settings import get_settings
 from baloo.db.engine import get_session_factory
-from baloo.db.models import Finding, Review
+from baloo.db.models import Finding, Review, ReviewLog
 
 
 class DashboardService:
@@ -215,6 +215,19 @@ class DashboardService:
                 select(Review).options(selectinload(Review.findings)).where(Review.id == review_id)
             )
             return result.scalars().first()
+
+    @staticmethod
+    async def get_review_logs(review_id: int) -> list[ReviewLog]:
+        settings = get_settings()
+        factory = get_session_factory(settings.database_url)
+
+        async with factory() as session:
+            result = await session.execute(
+                select(ReviewLog)
+                .where(ReviewLog.review_id == review_id)
+                .order_by(ReviewLog.created_at.asc())
+            )
+            return result.scalars().all()
 
     @staticmethod
     async def get_analytics_data(days: int = 30) -> dict:

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -70,6 +70,16 @@ async def review_detail(request: Request, review_id: int):
     )
 
 
+@router.get("/reviews/{review_id}/logs", response_class=HTMLResponse)
+async def review_logs(request: Request, review_id: int):
+    logs = await DashboardService.get_review_logs(review_id)
+    return templates.TemplateResponse(
+        request=request,
+        name="partials/review_logs.html",
+        context={"logs": logs, "review_id": review_id},
+    )
+
+
 @router.get("/analytics", response_class=HTMLResponse)
 async def analytics(
     request: Request,

--- a/baloo/dashboard/templates/partials/review_logs.html
+++ b/baloo/dashboard/templates/partials/review_logs.html
@@ -1,0 +1,36 @@
+{% if logs %}
+<div class="space-y-3">
+  {% for log in logs %}
+  <div class="flex items-start gap-3">
+    <!-- Timestamp -->
+    <span class="text-xs text-gray-400 font-mono whitespace-nowrap mt-0.5">
+      {{ log.created_at.strftime("%H:%M:%S") }}
+    </span>
+
+    <!-- Event badge -->
+    {% if log.event_type in ["agent_error", "json_parse_failed", "json_retry_failed"] %}
+      <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 whitespace-nowrap">{{ log.event_type }}</span>
+    {% elif log.event_type in ["fallback_triggered", "json_retry_started"] %}
+      <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 whitespace-nowrap">{{ log.event_type }}</span>
+    {% elif log.event_type == "agent_completed" %}
+      <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 whitespace-nowrap">{{ log.event_type }}</span>
+    {% else %}
+      <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700 whitespace-nowrap">{{ log.event_type }}</span>
+    {% endif %}
+
+    <!-- Message -->
+    <div class="flex-1 min-w-0">
+      <p class="text-sm text-gray-700">{{ log.message }}</p>
+      {% if log.raw_text %}
+      <details class="mt-1">
+        <summary class="text-xs text-indigo-600 cursor-pointer hover:underline">Show raw response ({{ log.raw_text | length }} chars)</summary>
+        <pre class="mt-1 text-xs text-gray-600 bg-gray-50 border rounded p-2 overflow-x-auto max-h-96 overflow-y-auto whitespace-pre-wrap">{{ log.raw_text }}</pre>
+      </details>
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<p class="text-sm text-gray-400 text-center py-4">No execution logs for this review</p>
+{% endif %}

--- a/baloo/dashboard/templates/review_detail.html
+++ b/baloo/dashboard/templates/review_detail.html
@@ -178,4 +178,17 @@
   <p class="px-5 py-8 text-center text-gray-400">No findings for this review</p>
   {% endif %}
 </div>
+
+<!-- Execution Log -->
+<div class="bg-white rounded-lg shadow overflow-hidden mt-8">
+  <div class="px-5 py-4 border-b border-gray-200">
+    <h2 class="text-lg font-semibold text-gray-900">Execution Log</h2>
+  </div>
+  <div class="px-5 py-4"
+       hx-get="/dashboard/reviews/{{ review.id }}/logs"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+    <p class="text-sm text-gray-400 text-center py-4">Loading logs...</p>
+  </div>
+</div>
 {% endblock %}

--- a/baloo/db/engine.py
+++ b/baloo/db/engine.py
@@ -106,6 +106,41 @@ async def init_db(database_url: str) -> None:
             await conn.run_sync(Base.metadata.create_all)
         logger.info("Database tables initialized via create_all")
 
+    # Clean up old execution logs
+    from baloo.config.settings import get_settings
+
+    settings = get_settings()
+    if settings.log_retention_days > 0:
+        await _cleanup_old_logs(engine, settings.log_retention_days)
+
+
+async def _cleanup_old_logs(engine, retention_days: int) -> None:
+    """Delete review_logs older than retention_days."""
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import delete
+
+    from baloo.db.models import ReviewLog
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    try:
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with factory() as session:
+            async with session.begin():
+                result = await session.execute(
+                    delete(ReviewLog).where(ReviewLog.created_at < cutoff)
+                )
+                deleted = result.rowcount
+                if deleted:
+                    logger.info(
+                        "Cleaned up %d review log entries older than %d days",
+                        deleted,
+                        retention_days,
+                    )
+    except Exception as exc:
+        # Table may not exist yet on first run
+        logger.debug("Log cleanup skipped: %s", exc)
+
 
 async def close_db() -> None:
     """Dispose of the engine connection pool."""

--- a/baloo/db/migrations/versions/003_add_review_logs.py
+++ b/baloo/db/migrations/versions/003_add_review_logs.py
@@ -1,0 +1,49 @@
+"""Add review_logs table for execution logging.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-04-20
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003"
+down_revision: str = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "review_logs" not in existing_tables:
+        op.create_table(
+            "review_logs",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column(
+                "review_id",
+                sa.Integer,
+                sa.ForeignKey("reviews.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("event_type", sa.String(50), nullable=False),
+            sa.Column("message", sa.Text, nullable=False),
+            sa.Column("raw_text", sa.Text, nullable=True),
+            sa.Column("metadata_json", sa.Text, nullable=True),
+        )
+        op.create_index(
+            "ix_review_logs_review_created", "review_logs", ["review_id", "created_at"]
+        )
+        op.create_index("ix_review_logs_created_at", "review_logs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_review_logs_created_at", table_name="review_logs")
+    op.drop_index("ix_review_logs_review_created", table_name="review_logs")
+    op.drop_table("review_logs")

--- a/baloo/db/migrations/versions/003_add_review_logs.py
+++ b/baloo/db/migrations/versions/003_add_review_logs.py
@@ -37,9 +37,7 @@ def upgrade() -> None:
             sa.Column("raw_text", sa.Text, nullable=True),
             sa.Column("metadata_json", sa.Text, nullable=True),
         )
-        op.create_index(
-            "ix_review_logs_review_created", "review_logs", ["review_id", "created_at"]
-        )
+        op.create_index("ix_review_logs_review_created", "review_logs", ["review_id", "created_at"])
         op.create_index("ix_review_logs_created_at", "review_logs", ["created_at"])
 
 

--- a/baloo/db/models.py
+++ b/baloo/db/models.py
@@ -1,6 +1,6 @@
 """SQLAlchemy ORM models for review persistence."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     Boolean,
@@ -50,6 +50,9 @@ class Review(Base):
     findings: Mapped[list["Finding"]] = relationship(
         "Finding", back_populates="review", cascade="all, delete-orphan"
     )
+    logs: Mapped[list["ReviewLog"]] = relationship(
+        "ReviewLog", back_populates="review", cascade="all, delete-orphan"
+    )
 
     __table_args__ = (
         Index("ix_reviews_repo_pr", "repo_full_name", "pr_number"),
@@ -74,3 +77,26 @@ class Finding(Base):
     review: Mapped["Review"] = relationship("Review", back_populates="findings")
 
     __table_args__ = (Index("ix_findings_review_id", "review_id"),)
+
+
+class ReviewLog(Base):
+    __tablename__ = "review_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    review_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("reviews.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)
+    )
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    raw_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metadata_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    review: Mapped["Review"] = relationship("Review", back_populates="logs")
+
+    __table_args__ = (
+        Index("ix_review_logs_review_created", "review_id", "created_at"),
+        Index("ix_review_logs_created_at", "created_at"),
+    )

--- a/docs/superpowers/specs/2026-04-20-execution-logs-and-json-fix-design.md
+++ b/docs/superpowers/specs/2026-04-20-execution-logs-and-json-fix-design.md
@@ -1,0 +1,143 @@
+# Execution Logs & JSON Parsing Fix
+
+## Problem
+
+1. **JSON parsing failures**: The agent model sometimes emits a long reasoning preamble before the JSON output. The current 3-strategy extractor fails on mixed text+JSON (14K+ chars), and the retry subprocess also fails. Different models have different compliance levels with output format instructions — we can't rely on prompting alone.
+
+2. **No visibility into task execution**: Diagnosing failures requires reading Docker logs, which is noisy and inconvenient. There's no way to see what happened during a review from the dashboard.
+
+## Solution
+
+Structured execution logging per review stored in the database and surfaced in the dashboard, combined with improved JSON extraction and prompt reinforcement.
+
+## Database Schema
+
+New `review_log` table:
+
+| Column      | Type                | Notes                                              |
+|-------------|---------------------|----------------------------------------------------|
+| id          | UUID                | Primary key                                        |
+| review_id   | UUID                | FK → reviews.id, CASCADE delete                    |
+| created_at  | timestamp           | Indexed for retention cleanup                      |
+| event_type  | varchar             | One of the known event types below                 |
+| message     | text                | Human-readable summary                             |
+| raw_text    | text, nullable      | Full assistant response — populated only on failure |
+| metadata    | jsonb, nullable     | Structured extras (tokens, turn number, model)     |
+
+**Indexes:**
+- `(review_id, created_at)` — fast per-review timeline queries
+- `(created_at)` — retention cleanup
+
+**Event types:**
+- `agent_started` — review kicked off (model name in metadata)
+- `turn_completed` — one agent turn finished (turn number, tokens in metadata)
+- `tool_use` — agent invoked a tool (tool name, file path in metadata)
+- `json_parse_failed` — extraction failed, raw_text populated
+- `json_retry_started` — retry subprocess spawned
+- `json_retry_failed` — retry also failed, raw_text populated
+- `fallback_triggered` — switching to fallback model
+- `agent_completed` — finished successfully (total tokens, cost, duration in metadata)
+- `agent_error` — unrecoverable error (exception message)
+
+**Retention:** `DELETE FROM review_log WHERE created_at < NOW() - INTERVAL '30 days'` — configurable via `LOG_RETENTION_DAYS` setting. Runs on app startup.
+
+## ReviewLogger
+
+A class that the runtime uses to emit events during execution.
+
+```
+ReviewLogger
+├── __init__(review_id, db_session)
+├── async log(event_type, message, raw_text=None, metadata=None)
+│   └── Inserts a ReviewLog row immediately (no buffering — crash-safe)
+├── async agent_started(model, thinking_level)
+├── async turn_completed(turn_number, tokens_in, tokens_out)
+├── async tool_use(tool_name, file_path=None)
+├── async json_parse_failed(raw_text, char_count)
+├── async json_retry_started()
+├── async json_retry_failed(raw_text)
+├── async fallback_triggered(primary_model, fallback_model, error)
+├── async agent_completed(tokens_in, tokens_out, cost, duration)
+├── async agent_error(error_message, error_category)
+```
+
+**When DB is disabled:** ReviewLogger becomes a no-op (methods return immediately).
+
+### Runtime Integration Points
+
+In `pi_runtime.py`:
+- `run_query()` — receives a `ReviewLogger`, calls `agent_started` at top
+- `_drive_session()` — calls `turn_completed` after each `turn_end` event, `tool_use` on tool events
+- After `_extract_json_from_text()` fails — calls `json_parse_failed` with raw text
+- `_retry_json()` — calls `json_retry_started`/`json_retry_failed`
+- `run_query()` exit — calls `agent_completed` or `agent_error`
+
+In `client.py`:
+- `_run_with_fallback()` — calls `fallback_triggered` when switching models
+- Creates the `ReviewLogger` and passes it down to the runtime
+
+## JSON Extraction Improvements
+
+### New reverse-scan strategy
+
+The model consistently puts JSON at the end after reasoning. Scan backwards from the end of the text to find the last `}`, then walk backwards counting brace depth (respecting string literals) to find its matching `{`. Parse that substring.
+
+### Updated strategy order
+
+1. **Direct JSON parse** — entire text is valid JSON
+2. **Markdown fence extraction** — ```json ... ``` blocks
+3. **Reverse-scan** (new) — find the last complete JSON object from the tail
+4. **Outermost braces** (demoted) — first `{` to last `}`, last-resort fallback
+
+### Prompt reinforcement
+
+Add closing instruction to the system prompt, after tool definitions:
+
+```
+REMINDER: Your final message MUST be ONLY the JSON object.
+Do not include any text before or after the JSON.
+```
+
+## Dashboard UI
+
+New "Execution Log" section on the review detail page (`review_detail.html`).
+
+### Layout
+
+- Sits below the existing findings table
+- Vertical timeline: each event shows timestamp, color-coded event type badge, and message
+- `json_parse_failed` and `json_retry_failed` events get an expandable "Show raw response" toggle revealing raw_text in a scrollable `<pre>` block
+- Error events in red, warnings in amber, info in neutral
+
+### New endpoint
+
+```
+GET /dashboard/reviews/{review_id}/logs
+```
+
+Returns partial HTML (HTMX-compatible) of the log timeline. Loaded asynchronously so the main detail page isn't slowed by large log sets.
+
+### New query
+
+```python
+DashboardService.get_review_logs(review_id) → list[ReviewLog]
+```
+
+## Files to Create/Modify
+
+**New files:**
+- `baloo/db/migrations/003_add_review_logs.py` — Alembic migration
+- `baloo/agent/logger.py` — ReviewLogger class
+
+**Modified files:**
+- `baloo/db/models.py` — ReviewLog model
+- `baloo/agent/pi_runtime.py` — emit log events, add reverse-scan extraction strategy
+- `baloo/agent/client.py` — create ReviewLogger, pass to runtime, emit fallback events
+- `baloo/agent/prompts.py` — add JSON reminder to system prompt
+- `baloo/config/settings.py` — add `LOG_RETENTION_DAYS` setting
+- `baloo/dashboard/router.py` — add logs endpoint
+- `baloo/dashboard/queries.py` — add `get_review_logs` query
+- `baloo/dashboard/templates/review_detail.html` — add execution log section
+- `baloo/dashboard/templates/partials/review_logs.html` — log timeline partial
+- `tests/agent/test_runtime.py` — tests for reverse-scan extraction
+- `tests/agent/test_logger.py` — tests for ReviewLogger

--- a/tests/agent/test_json_extraction.py
+++ b/tests/agent/test_json_extraction.py
@@ -1,0 +1,85 @@
+"""Tests for improved JSON extraction — specifically the reverse-scan strategy."""
+
+from baloo.agent.pi_runtime import _extract_json_from_text
+
+
+class TestReverseScanExtraction:
+    """Test JSON extraction when a long preamble precedes the JSON."""
+
+    def test_long_preamble_then_json(self):
+        """The exact failure pattern from production logs."""
+        preamble = (
+            "Based on my thorough analysis of the diff, I now have enough context "
+            "to compile the review. Let me check one more specific pattern from the diff:\n\n"
+            'The key things I need to verify from the diff code:\n\n'
+            '1. In `openrouter/model.py`, `_build_prediction(self, severity, labels, '
+            'confidence, reason)` - the `reason` parameter is accepted but the return '
+            'dict {"result": result, "score": confidence, "model_version": config.OPENAI_MODEL} '
+            "never includes it.\n\n"
+            "2. Some other analysis text with braces { and } in it.\n\n"
+        )
+        json_part = '{"findings": [{"file": "a.py", "line": 10, "severity": "HIGH"}], "summary": {"total_issues": 1}}'
+        text = preamble + json_part
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["findings"][0]["file"] == "a.py"
+        assert result["summary"]["total_issues"] == 1
+
+    def test_preamble_with_code_blocks_and_braces(self):
+        """Preamble containing code examples with braces."""
+        preamble = (
+            'Looking at the function:\n'
+            '```python\ndef foo():\n    return {"key": "value"}\n```\n\n'
+            'The issue is clear.\n\n'
+        )
+        json_part = '{"findings": [], "summary": {"total_issues": 0}}'
+        text = preamble + json_part
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["findings"] == []
+
+    def test_preamble_with_inline_json_fragments(self):
+        """Preamble containing JSON-like fragments that aren't the real output."""
+        preamble = (
+            'The return dict {"result": result, "score": confidence} never includes '
+            'the reason field. Also {"key": broken is not valid JSON.\n\n'
+        )
+        json_part = '{"findings": [{"file": "b.py", "line": 5}], "summary": {}}'
+        text = preamble + json_part
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["findings"][0]["file"] == "b.py"
+
+    def test_json_at_end_with_trailing_whitespace(self):
+        """JSON at end with trailing newlines."""
+        text = 'Some text\n\n{"findings": [], "summary": {}}\n\n'
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["findings"] == []
+
+    def test_plain_json_still_works(self):
+        """Direct JSON parse strategy still takes priority."""
+        text = '{"findings": [{"file": "c.py"}], "summary": {}}'
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["findings"][0]["file"] == "c.py"
+
+    def test_markdown_fence_still_works(self):
+        """Markdown fence strategy still takes priority over reverse-scan."""
+        text = 'Here is the result:\n```json\n{"findings": [], "summary": {}}\n```\nDone.'
+        result = _extract_json_from_text(text)
+        assert result is not None
+
+    def test_deeply_nested_json_at_end(self):
+        """Reverse scan handles nested braces correctly."""
+        json_part = '{"findings": [{"file": "a.py", "details": {"nested": {"deep": true}}}], "summary": {}}'
+        text = "Preamble with { braces }\n\n" + json_part
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["findings"][0]["details"]["nested"]["deep"] is True
+
+    def test_no_json_at_all(self):
+        """Still returns None when there's no JSON."""
+        text = "This is just a text response with no JSON at all."
+        result = _extract_json_from_text(text)
+        assert result is None

--- a/tests/agent/test_json_extraction.py
+++ b/tests/agent/test_json_extraction.py
@@ -11,9 +11,9 @@ class TestReverseScanExtraction:
         preamble = (
             "Based on my thorough analysis of the diff, I now have enough context "
             "to compile the review. Let me check one more specific pattern from the diff:\n\n"
-            'The key things I need to verify from the diff code:\n\n'
-            '1. In `openrouter/model.py`, `_build_prediction(self, severity, labels, '
-            'confidence, reason)` - the `reason` parameter is accepted but the return '
+            "The key things I need to verify from the diff code:\n\n"
+            "1. In `openrouter/model.py`, `_build_prediction(self, severity, labels, "
+            "confidence, reason)` - the `reason` parameter is accepted but the return "
             'dict {"result": result, "score": confidence, "model_version": config.OPENAI_MODEL} '
             "never includes it.\n\n"
             "2. Some other analysis text with braces { and } in it.\n\n"
@@ -28,9 +28,9 @@ class TestReverseScanExtraction:
     def test_preamble_with_code_blocks_and_braces(self):
         """Preamble containing code examples with braces."""
         preamble = (
-            'Looking at the function:\n'
+            "Looking at the function:\n"
             '```python\ndef foo():\n    return {"key": "value"}\n```\n\n'
-            'The issue is clear.\n\n'
+            "The issue is clear.\n\n"
         )
         json_part = '{"findings": [], "summary": {"total_issues": 0}}'
         text = preamble + json_part
@@ -72,7 +72,9 @@ class TestReverseScanExtraction:
 
     def test_deeply_nested_json_at_end(self):
         """Reverse scan handles nested braces correctly."""
-        json_part = '{"findings": [{"file": "a.py", "details": {"nested": {"deep": true}}}], "summary": {}}'
+        json_part = (
+            '{"findings": [{"file": "a.py", "details": {"nested": {"deep": true}}}], "summary": {}}'
+        )
         text = "Preamble with { braces }\n\n" + json_part
         result = _extract_json_from_text(text)
         assert result is not None

--- a/tests/agent/test_logger.py
+++ b/tests/agent/test_logger.py
@@ -1,8 +1,7 @@
 """Tests for ReviewLogger."""
 
 import json
-from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -62,9 +61,7 @@ class TestReviewLoggerEvents:
         mock_session.add = MagicMock()
 
         logger = ReviewLogger(review_id=42, session=mock_session)
-        await logger.agent_completed(
-            tokens_in=1000, tokens_out=500, cost=0.05, duration=12.3
-        )
+        await logger.agent_completed(tokens_in=1000, tokens_out=500, cost=0.05, duration=12.3)
 
         log_row = mock_session.add.call_args[0][0]
         assert log_row.event_type == "agent_completed"

--- a/tests/agent/test_logger.py
+++ b/tests/agent/test_logger.py
@@ -1,0 +1,84 @@
+"""Tests for ReviewLogger."""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from baloo.agent.logger import ReviewLogger
+
+
+class TestReviewLoggerNoOp:
+    """When review_id is None, logger is a no-op."""
+
+    @pytest.mark.asyncio
+    async def test_noop_does_not_write(self):
+        logger = ReviewLogger(review_id=None)
+        # Should not raise
+        await logger.agent_started(model="test", thinking_level="medium")
+        await logger.turn_completed(turn_number=1, tokens_in=100, tokens_out=50)
+        await logger.json_parse_failed(raw_text="bad", char_count=3)
+        await logger.agent_error(error_message="boom", error_category="test")
+
+
+class TestReviewLoggerEvents:
+    """Test that events produce correct ReviewLog rows."""
+
+    @pytest.mark.asyncio
+    async def test_agent_started_creates_log(self):
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+
+        logger = ReviewLogger(review_id=42, session=mock_session)
+        await logger.agent_started(model="claude-sonnet-4-6", thinking_level="medium")
+
+        mock_session.add.assert_called_once()
+        log_row = mock_session.add.call_args[0][0]
+        assert log_row.review_id == 42
+        assert log_row.event_type == "agent_started"
+        assert "claude-sonnet-4-6" in log_row.message
+        assert log_row.raw_text is None
+
+        meta = json.loads(log_row.metadata_json)
+        assert meta["model"] == "claude-sonnet-4-6"
+        assert meta["thinking_level"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failed_stores_raw_text(self):
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+
+        logger = ReviewLogger(review_id=42, session=mock_session)
+        await logger.json_parse_failed(raw_text="some bad text", char_count=13)
+
+        log_row = mock_session.add.call_args[0][0]
+        assert log_row.event_type == "json_parse_failed"
+        assert log_row.raw_text == "some bad text"
+
+    @pytest.mark.asyncio
+    async def test_agent_completed_metadata(self):
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+
+        logger = ReviewLogger(review_id=42, session=mock_session)
+        await logger.agent_completed(
+            tokens_in=1000, tokens_out=500, cost=0.05, duration=12.3
+        )
+
+        log_row = mock_session.add.call_args[0][0]
+        assert log_row.event_type == "agent_completed"
+        meta = json.loads(log_row.metadata_json)
+        assert meta["tokens_in"] == 1000
+        assert meta["cost"] == 0.05
+        assert meta["duration"] == 12.3
+
+    @pytest.mark.asyncio
+    async def test_log_exception_is_swallowed(self):
+        """Logger errors must not crash the review."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock(side_effect=Exception("DB down"))
+
+        logger = ReviewLogger(review_id=42, session=mock_session)
+        # Should not raise
+        await logger.agent_started(model="test", thinking_level="off")

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -149,8 +149,13 @@ def test_review_log_model_fields():
     mapper = inspect(ReviewLog)
     columns = {c.key for c in mapper.columns}
     assert columns == {
-        "id", "review_id", "created_at", "event_type",
-        "message", "raw_text", "metadata_json",
+        "id",
+        "review_id",
+        "created_at",
+        "event_type",
+        "message",
+        "raw_text",
+        "metadata_json",
     }
 
 

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from baloo.db.models import Base, Finding, Review
+from baloo.db.models import Base, Finding, Review, ReviewLog
 
 
 @pytest.fixture
@@ -140,6 +140,18 @@ async def test_cascade_delete(async_session: AsyncSession):
 
     result = await async_session.execute(select(Finding).where(Finding.review_id == review_id))
     assert result.scalars().all() == []
+
+
+def test_review_log_model_fields():
+    """ReviewLog has all expected columns."""
+    from sqlalchemy import inspect
+
+    mapper = inspect(ReviewLog)
+    columns = {c.key for c in mapper.columns}
+    assert columns == {
+        "id", "review_id", "created_at", "event_type",
+        "message", "raw_text", "metadata_json",
+    }
 
 
 async def test_review_optional_fields(async_session: AsyncSession):


### PR DESCRIPTION
## Summary

Fix agent JSON parsing failures and surface execution logs in the dashboard.

### Problem

1. **JSON parsing failures**: Models sometimes emit long reasoning preambles before JSON output. The existing 3-strategy extractor fails on mixed text+JSON (14K+ chars), and the retry subprocess also fails.
2. **No visibility into task execution**: Diagnosing failures requires reading Docker logs — noisy and inconvenient.

### Solution

**JSON Extraction Fix**
- New reverse-scan extraction strategy that finds JSON at the tail of the response by scanning backwards from the last `}`, handling brace depth and string literals
- Updated strategy order: direct parse → markdown fence → reverse-scan → outermost braces (last resort)
- Added JSON-only reminder to all review prompts

**Execution Logging**
- New `review_logs` table with structured events per review (agent_started, turn_completed, tool_use, json_parse_failed, json_retry_started/failed, fallback_triggered, agent_completed, agent_error)
- `ReviewLogger` class integrated into PI runtime — emits events as they happen (crash-safe), no-op when DB is disabled
- Raw assistant text stored only on failures (keeps storage lean)
- Configurable retention via `LOG_RETENTION_DAYS` (default 30), cleanup runs on startup

**Dashboard UI**
- Execution log timeline on review detail page, loaded via HTMX partial
- Color-coded event badges (red for errors, amber for warnings, green for completion)
- Expandable raw response viewer for parse failures

### Files Changed

- `baloo/agent/pi_runtime.py` — reverse-scan extraction + logger integration
- `baloo/agent/client.py` — logger creation + fallback event emission
- `baloo/agent/logger.py` — new ReviewLogger class
- `baloo/agent/prompts.py` — JSON reminder in all prompts
- `baloo/db/models.py` — ReviewLog model
- `baloo/db/migrations/versions/003_add_review_logs.py` — migration
- `baloo/db/engine.py` — log retention cleanup
- `baloo/config/settings.py` — log_retention_days setting
- `baloo/dashboard/router.py` — logs endpoint
- `baloo/dashboard/queries.py` — get_review_logs query
- `baloo/dashboard/templates/` — log timeline UI

### Testing

283 tests passing. New tests cover:
- Reverse-scan extraction (8 cases including production failure pattern)
- ReviewLogger events and no-op behavior (5 cases)
- ReviewLog model fields