### PR TITLE
feat: rule-based severity enforcement to override LLM severity

### DIFF
--- a/baloo/agent/schemas.py
+++ b/baloo/agent/schemas.py
@@ -179,10 +179,11 @@ def findings_to_comments(data: dict) -> list[ReviewComment]:
 
     comments: list[ReviewComment] = []
     for finding in output.findings:
+        enforced_severity = enforce_severity(finding)
         body_parts = [
             f"**{finding.title}**",
             f"**Category:** {finding.category}",
-            f"**Severity:** {finding.severity.upper()}",
+            f"**Severity:** {enforced_severity}",
             "",
             finding.description,
         ]
@@ -195,8 +196,6 @@ def findings_to_comments(data: dict) -> list[ReviewComment]:
 
         if finding.code_example:
             body_parts.extend(["", "```python", finding.code_example, "```"])
-
-        enforced_severity = enforce_severity(finding)
         comments.append(
             ReviewComment(
                 path=finding.file or "unknown",

--- a/baloo/agent/schemas.py
+++ b/baloo/agent/schemas.py
@@ -35,6 +35,18 @@ def _normalize_severity(raw: str) -> str:
     return _SEVERITY_LOOKUP.get(raw.upper().strip(), ReviewSeverity.MEDIUM.value)
 
 
+_SEVERITY_ORDER = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+
+# Category → fixed severity. Quality is special (capped, not fixed).
+_CATEGORY_SEVERITY: dict[str, str] = {
+    "SECURITY": "CRITICAL",
+    "BUGS": "HIGH",
+    "SILENT FAILURES": "HIGH",
+    "GUIDELINES": "HIGH",
+    "PERFORMANCE": "MEDIUM",
+}
+
+
 class ReviewFinding(BaseModel):
     """A single review finding from the agent.
 
@@ -107,6 +119,26 @@ class ReviewOutput(BaseModel):
         return super().model_validate(obj, **kwargs)
 
 
+def enforce_severity(finding: ReviewFinding) -> str:
+    """Derive severity from category using deterministic rules.
+
+    Security → CRITICAL, Bugs/Silent Failures/Guidelines → HIGH,
+    Performance → MEDIUM, Quality → capped at MEDIUM (keeps LOW if LOW).
+    Unknown categories → MEDIUM.
+    """
+    category = _normalize_category(finding.category).upper()
+    fixed = _CATEGORY_SEVERITY.get(category)
+    if fixed:
+        return fixed
+    # Quality: cap at MEDIUM, but don't escalate LOW
+    if category == "QUALITY":
+        llm_rank = _SEVERITY_ORDER.get(finding.severity.upper(), 2)
+        cap_rank = _SEVERITY_ORDER["MEDIUM"]
+        return finding.severity.upper() if llm_rank <= cap_rank else "MEDIUM"
+    # Unknown category
+    return "MEDIUM"
+
+
 def review_output_schema() -> dict:
     """Return the JSON schema for review output validation."""
     return {"type": "json_schema", "schema": ReviewOutput.model_json_schema()}
@@ -164,12 +196,13 @@ def findings_to_comments(data: dict) -> list[ReviewComment]:
         if finding.code_example:
             body_parts.extend(["", "```python", finding.code_example, "```"])
 
+        enforced_severity = enforce_severity(finding)
         comments.append(
             ReviewComment(
                 path=finding.file or "unknown",
                 line=finding.get_line(),
                 body="\n".join(body_parts),
-                severity=_normalize_severity(finding.severity),
+                severity=_normalize_severity(enforced_severity),
                 category=_normalize_category(finding.category),
             )
         )

--- a/tests/agent/test_client_integration.py
+++ b/tests/agent/test_client_integration.py
@@ -197,8 +197,8 @@ class TestBalooAgentSuccessPath:
 
             assert len(result.comments) == 1
             assert result.comments[0].path == "test.py"
-            assert result.comments[0].severity == "HIGH"
-            assert result.approve is False  # HIGH severity = request changes
+            assert result.comments[0].severity == "CRITICAL"  # Security enforced to CRITICAL
+            assert result.approve is False  # CRITICAL severity = request changes
             assert result.request_changes is True
 
     @pytest.mark.asyncio
@@ -338,7 +338,13 @@ class TestBalooAgentSeveritySummary:
         """Test that CRITICAL severity is included in summary."""
         structured = {
             "findings": [
-                {"file": "test.py", "line": 1, "severity": "CRITICAL", "title": "Critical issue"}
+                {
+                    "file": "test.py",
+                    "line": 1,
+                    "severity": "CRITICAL",
+                    "category": "Security",
+                    "title": "Critical issue",
+                }
             ],
         }
         events = _make_pi_events(structured)

--- a/tests/agent/test_schemas.py
+++ b/tests/agent/test_schemas.py
@@ -1,8 +1,10 @@
 """Tests for schemas module (Pydantic models and conversion logic)."""
 
 from baloo.agent.schemas import (
+    ReviewFinding,
     ReviewOutput,
     _normalize_category,
+    enforce_severity,
     findings_to_comments,
     review_output_schema,
 )
@@ -189,7 +191,7 @@ class TestFindingsToComments:
         assert len(comments) == 1
         assert comments[0].path == "test.py"
         assert comments[0].line == 10
-        assert comments[0].severity == "HIGH"
+        assert comments[0].severity == "CRITICAL"  # Security enforced to CRITICAL
         assert comments[0].category == "Security"
         assert "SQL Injection Risk" in comments[0].body
         assert "Data breach possible" in comments[0].body
@@ -217,16 +219,16 @@ class TestFindingsToComments:
         assert comments == []
 
     def test_severity_normalization(self):
-        """Test that severity is uppercased."""
+        """Test that severity is normalized and enforcement is applied."""
         data = {
             "findings": [
-                {"file": "a.py", "severity": "critical"},
-                {"file": "b.py", "severity": "MeDiUm"},
+                {"file": "a.py", "severity": "critical", "category": "Security"},
+                {"file": "b.py", "severity": "MeDiUm", "category": "Quality"},
             ]
         }
         comments = findings_to_comments(data)
-        assert comments[0].severity == "CRITICAL"
-        assert comments[1].severity == "MEDIUM"
+        assert comments[0].severity == "CRITICAL"  # Security → CRITICAL
+        assert comments[1].severity == "MEDIUM"  # Quality MEDIUM stays MEDIUM
 
     def test_optional_fields_missing(self):
         """Test that missing optional fields don't appear in body."""
@@ -384,6 +386,82 @@ class TestNormalizeCategory:
         assert comments[1].category == "Bugs"
         assert comments[2].category == "Silent Failures"
         assert comments[3].category == "Performance"
+
+
+class TestEnforceSeverity:
+    """Tests for rule-based severity enforcement by category."""
+
+    def test_security_always_critical(self):
+        """Security findings should always be CRITICAL regardless of LLM severity."""
+        finding = ReviewFinding(file="a.py", line=1, severity="MEDIUM", category="Security")
+        assert enforce_severity(finding) == "CRITICAL"
+
+    def test_security_low_escalated(self):
+        finding = ReviewFinding(file="a.py", line=1, severity="LOW", category="Security")
+        assert enforce_severity(finding) == "CRITICAL"
+
+    def test_bugs_enforced_to_high(self):
+        """Bugs category should be enforced to HIGH."""
+        finding = ReviewFinding(file="a.py", line=1, severity="CRITICAL", category="Bugs")
+        assert enforce_severity(finding) == "HIGH"
+
+    def test_silent_failures_enforced_to_high(self):
+        finding = ReviewFinding(file="a.py", line=1, severity="LOW", category="Silent Failures")
+        assert enforce_severity(finding) == "HIGH"
+
+    def test_guidelines_enforced_to_high(self):
+        finding = ReviewFinding(file="a.py", line=1, severity="MEDIUM", category="Guidelines")
+        assert enforce_severity(finding) == "HIGH"
+
+    def test_performance_enforced_to_medium(self):
+        finding = ReviewFinding(file="a.py", line=1, severity="HIGH", category="Performance")
+        assert enforce_severity(finding) == "MEDIUM"
+
+    def test_quality_capped_at_medium(self):
+        """Quality findings should be capped at MEDIUM even if LLM says CRITICAL."""
+        finding = ReviewFinding(file="a.py", line=1, severity="CRITICAL", category="Quality")
+        assert enforce_severity(finding) == "MEDIUM"
+
+    def test_quality_low_stays_low(self):
+        """Quality LOW should stay LOW (cap, not floor)."""
+        finding = ReviewFinding(file="a.py", line=1, severity="LOW", category="Quality")
+        assert enforce_severity(finding) == "LOW"
+
+    def test_quality_medium_stays_medium(self):
+        finding = ReviewFinding(file="a.py", line=1, severity="MEDIUM", category="Quality")
+        assert enforce_severity(finding) == "MEDIUM"
+
+    def test_unknown_category_defaults_medium(self):
+        finding = ReviewFinding(file="a.py", line=1, severity="HIGH", category="Unknown")
+        assert enforce_severity(finding) == "MEDIUM"
+
+    def test_findings_to_comments_uses_enforcement(self):
+        """End-to-end: findings_to_comments should apply severity enforcement."""
+        data = {
+            "findings": [
+                {
+                    "file": "a.py",
+                    "line": 1,
+                    "severity": "MEDIUM",
+                    "category": "Security",
+                    "title": "SQL Injection",
+                    "description": "Unsafe query",
+                },
+                {
+                    "file": "b.py",
+                    "line": 2,
+                    "severity": "CRITICAL",
+                    "category": "Quality",
+                    "title": "Naming",
+                    "description": "Bad name",
+                },
+            ]
+        }
+        comments = findings_to_comments(data)
+        # Security MEDIUM should be escalated to CRITICAL
+        assert comments[0].severity == "CRITICAL"
+        # Quality CRITICAL should be capped to MEDIUM
+        assert comments[1].severity == "MEDIUM"
 
 
 class TestFidelityOutput:


### PR DESCRIPTION
## Summary

- Adds `enforce_severity()` function that derives severity deterministically from finding category, replacing unreliable LLM-assigned severity
- Security → CRITICAL, Bugs/Silent Failures/Guidelines → HIGH, Performance → MEDIUM, Quality → capped at MEDIUM
- Wired into `findings_to_comments()` so all downstream consumers (decision engine, severity router, checks API) get corrected values

## Problem

The LLM frequently over-escalated severity — marking Quality nits as CRITICAL, which blocked PRs via the decision engine. Since the entire approve/reject decision hinges on severity, this caused unnecessary friction.

## Approach

Category is a classification task (LLM does well); severity is a calibration task (LLM does poorly). So we let the LLM pick category, then derive severity from deterministic rules.

## Test plan

- [x] 11 new unit tests covering every category→severity mapping
- [x] End-to-end test through `findings_to_comments` pipeline
- [x] Updated existing tests that assumed old LLM-pass-through behavior
- [x] Full suite: 294 tests passing
- [x] Lint and formatting clean