### PR TITLE
fix: wire up execution logging and fix JSON escape handling

### DIFF
--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -25,7 +25,9 @@ class BalooAgent(PIAgentBase):
         super().__init__(options)
         logger.info(f"Initialized BalooAgent with {self.options.model}")
 
-    async def review_pr(self, pr_context: PRContext, model_override: str = None, review_id: int | None = None) -> ReviewResult:
+    async def review_pr(
+        self, pr_context: PRContext, model_override: str = None, review_id: int | None = None
+    ) -> ReviewResult:
         """
         Perform a full code review for a pull request.
 

--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -25,7 +25,7 @@ class BalooAgent(PIAgentBase):
         super().__init__(options)
         logger.info(f"Initialized BalooAgent with {self.options.model}")
 
-    async def review_pr(self, pr_context: PRContext, model_override: str = None) -> ReviewResult:
+    async def review_pr(self, pr_context: PRContext, model_override: str = None, review_id: int | None = None) -> ReviewResult:
         """
         Perform a full code review for a pull request.
 
@@ -43,14 +43,14 @@ class BalooAgent(PIAgentBase):
             f"Starting review for {pr_context.repo_full_name}#{pr_context.pr_number} using {self.options.model}"
         )
 
+        review_logger = None
+        logger_session = None
+
         try:
             # Build review prompt
             review_query = build_pr_review_prompt(pr_context)
 
             # Create execution logger if database is enabled
-            review_logger = None
-            logger_session = None
-            review_id = getattr(pr_context, "_review_id", None)
             if review_id:
                 from baloo.agent.logger import ReviewLogger
                 from baloo.config.settings import get_settings
@@ -89,23 +89,13 @@ class BalooAgent(PIAgentBase):
             # Make approval decision using centralized engine
             approve, request_changes = DecisionEngine.make_decision(comments)
 
-            result = ReviewResult(
+            return ReviewResult(
                 summary=summary,
                 comments=comments,
                 approve=approve,
                 request_changes=request_changes,
                 metadata=metadata,
             )
-
-            # Flush and close the logger session
-            if logger_session is not None:
-                try:
-                    await logger_session.commit()
-                    await logger_session.close()
-                except Exception:
-                    pass
-
-            return result
 
         except Exception as e:
             logger.error(f"Error during review: {e}", exc_info=True)
@@ -121,6 +111,16 @@ class BalooAgent(PIAgentBase):
                 request_changes=False,
                 metadata=metadata,
             )
+        finally:
+            if logger_session is not None:
+                try:
+                    await logger_session.commit()
+                except Exception as exc:
+                    logger.debug("Failed to commit review log session: %s", exc)
+                try:
+                    await logger_session.close()
+                except Exception:
+                    pass
 
     @staticmethod
     def _classify_error(error_msg: str) -> str:

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -128,9 +128,14 @@ def _reverse_scan_json(text: str) -> dict | None:
 
         if in_string:
             if ch == '"':
-                in_string = False
-            elif ch == "\\" and i > 0 and text[i - 1] == "\\":
-                escape = True
+                # Count preceding backslashes to check if quote is escaped
+                bs = 0
+                j = i - 1
+                while j >= 0 and text[j] == "\\":
+                    bs += 1
+                    j -= 1
+                if bs % 2 == 0:  # even backslashes = quote is not escaped
+                    in_string = False
             i -= 1
             continue
 

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -202,7 +202,7 @@ class GitHubAPIClient:
                     {
                         "path": comment.path,
                         "line": comment.line,
-                        "body": f"**[{comment.severity}] {comment.category}** - {comment.body}",
+                        "body": f"**[{comment.severity.value}] {comment.category.value}** - {comment.body}",
                     }
                     for comment in review_result.comments
                 ],
@@ -235,7 +235,7 @@ class GitHubAPIClient:
                     # Post each finding as a separate comment
                     for i, comment in enumerate(review_result.comments):
                         comment_body = (
-                            f"**[{comment.severity}] {comment.category}** - {comment.path}:{comment.line}\n\n"
+                            f"**[{comment.severity.value}] {comment.category.value}** - {comment.path}:{comment.line}\n\n"
                             f"{comment.body}"
                         )
                         await self.post_comment(repo_full_name, pr_number, comment_body)

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -489,7 +489,7 @@ async def process_pr_review(
             from baloo.agent.client import BalooAgent
 
             agent = BalooAgent()
-            agent_result = await agent.review_pr(pr_context)
+            agent_result = await agent.review_pr(pr_context, review_id=db_review_id)
             agent_metadata = agent_result.metadata
             review_result = agent_result
 

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -656,7 +656,7 @@ async def process_pr_review(
                     logger.warning("Falling back to posting MEDIUM findings as issue comments")
                     for finding in routed["checks"]:
                         comment_body = (
-                            f"**[{finding.severity}] {finding.category}** - {finding.path}:{finding.line}\n\n"
+                            f"**[{finding.severity.value}] {finding.category.value}** - {finding.path}:{finding.line}\n\n"
                             f"{finding.body}"
                         )
                         await github_client.post_comment(repo_full_name, pr_number, comment_body)

--- a/baloo/processor/formatter.py
+++ b/baloo/processor/formatter.py
@@ -29,7 +29,8 @@ class CommentFormatter:
         """
         severity_counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
         for comment in comments:
-            severity_counts[comment.severity] = severity_counts.get(comment.severity, 0) + 1
+            sev = comment.severity.value if hasattr(comment.severity, "value") else comment.severity
+            severity_counts[sev] = severity_counts.get(sev, 0) + 1
 
         critical = severity_counts["CRITICAL"]
         high = severity_counts["HIGH"]

--- a/baloo/processor/fp_prompts.py
+++ b/baloo/processor/fp_prompts.py
@@ -49,8 +49,8 @@ def build_verification_prompt(
     parts = [
         "## Finding to verify",
         f"**File**: {comment.path}, line {comment.line}",
-        f"**Severity**: {comment.severity}",
-        f"**Category**: {comment.category}",
+        f"**Severity**: {comment.severity.value}",
+        f"**Category**: {comment.category.value}",
         "",
         comment.body,
         "",

--- a/tests/agent/test_json_extraction.py
+++ b/tests/agent/test_json_extraction.py
@@ -80,6 +80,23 @@ class TestReverseScanExtraction:
         assert result is not None
         assert result["findings"][0]["details"]["nested"]["deep"] is True
 
+    def test_escaped_quotes_in_json_strings(self):
+        """Reverse scan handles escaped quotes inside JSON string values."""
+        json_part = '{"findings": [{"file": "a.py", "body": "said \\"hello\\" world"}], "summary": {}}'
+        text = "Some preamble text\n\n" + json_part
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["findings"][0]["body"] == 'said "hello" world'
+
+    def test_escaped_backslash_before_quote(self):
+        """Reverse scan distinguishes escaped backslash from escaped quote."""
+        # String value ends with a literal backslash: "path\\"
+        json_part = '{"findings": [], "summary": {"path": "C:\\\\"}}'
+        text = "Preamble\n" + json_part
+        result = _extract_json_from_text(text)
+        assert result is not None
+        assert result["summary"]["path"] == "C:\\"
+
     def test_no_json_at_all(self):
         """Still returns None when there's no JSON."""
         text = "This is just a text response with no JSON at all."

--- a/tests/agent/test_json_extraction.py
+++ b/tests/agent/test_json_extraction.py
@@ -82,7 +82,9 @@ class TestReverseScanExtraction:
 
     def test_escaped_quotes_in_json_strings(self):
         """Reverse scan handles escaped quotes inside JSON string values."""
-        json_part = '{"findings": [{"file": "a.py", "body": "said \\"hello\\" world"}], "summary": {}}'
+        json_part = (
+            '{"findings": [{"file": "a.py", "body": "said \\"hello\\" world"}], "summary": {}}'
+        )
         text = "Some preamble text\n\n" + json_part
         result = _extract_json_from_text(text)
         assert result is not None


### PR DESCRIPTION
## Summary

Addresses issues found by Baloo's review on PR #9 (all 4 inline comments):

- **Execution logging was always no-op**: `db_review_id` existed in `webhook_handler.py` but was never passed to `BalooAgent.review_pr()`. Added `review_id` parameter and wired it through.
- **Session leak on error**: `logger_session` cleanup was inside the `try` block after `_run_with_fallback`, so exceptions skipped it. Moved to `finally`.
- **Silent exception swallowing**: Bare `except Exception: pass` on session commit now logs at debug level.
- **Reverse JSON scanner escape bug**: `_reverse_scan_json` toggled `in_string` on escaped quotes (`\"`). Now counts preceding backslashes to determine if a quote is actually escaped.

## Test plan

- [x] All 283 existing tests pass
- [x] Added 2 new test cases for escaped quotes in JSON reverse scanner
- [ ] Verify execution logs appear in dashboard after a real review (requires deployed env)