### PR TITLE
fix: exhaustive findings in single pass + enable FP verification by default

### DIFF
--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -66,7 +66,19 @@ Only flag a violation if the target repo's guidelines explicitly require a diffe
 {REVIEW_JSON_RESPONSE_SCHEMA}
 
 {REVIEW_SEVERITY_GUIDELINES}
-Be specific (file:line), constructive, balanced.
+Be specific (file:line) and constructive.
+
+## Exhaustive Reporting
+Report **ALL** findings you discover in a single pass. Do not self-limit for brevity or "balance".
+A reviewer that surfaces 10 issues in one pass is far better than one that drip-feeds 3 issues
+across 4 review rounds. Developers should never push a fix only to discover that Baloo found
+additional issues that were present all along but weren't reported earlier.
+- If you find 2 issues or 20, report them all.
+- Group by severity so the developer can prioritize, but do not omit lower-severity findings
+  just because higher-severity ones exist.
+- After compiling your findings, do a completeness check: review your analysis notes and verify
+  you haven't left out any issues you noticed during file reads or grep searches.
+
 You MUST return ONLY valid JSON matching the Output Schema above. No markdown fences, no commentary — just the raw JSON object.
 
 REMINDER: Your final message MUST be ONLY the JSON object. Do not include any reasoning, analysis, or text before or after the JSON."""
@@ -371,6 +383,10 @@ If YES: This PR may be fixing a constraint or addressing feedback. Understand WH
 
 **Keep it focused**: Review only what's relevant to these specific changes.
 
+**Be exhaustive**: Report ALL issues you find in this single pass. Do not hold back findings for brevity.
+Before emitting JSON, do a completeness check — re-read your analysis notes and verify you haven't
+omitted any issues you noticed. The developer should not discover new pre-existing issues in a follow-up review.
+
 **Output immediately**: After reading and analyzing, provide your findings as JSON matching the schema.
 You MUST return ONLY valid JSON matching the Output Schema. No markdown fences, no commentary — just the raw JSON object.
 If no issues found, return empty findings array. Be practical and focus on real risks.
@@ -495,6 +511,13 @@ For each issue you identify:
 4. Suggest a specific fix with code examples
 
 Focus on issues that truly matter for security, correctness, and maintainability. Be thorough but practical.
+
+### Step 6: Completeness Check (REQUIRED)
+Before emitting your final JSON, review your analysis:
+- Re-read your notes from Steps 1-4. Did you notice any issues that you haven't included in your findings?
+- Check every file you read — did you skip any findings because you already had "enough"?
+- If you found issues of different severities, make sure ALL of them are included, not just the top few.
+- Report everything in this single pass. The developer should not discover new pre-existing issues in a follow-up review.
 
 REMINDER: Your final message MUST be ONLY the JSON object. Do not include any reasoning, analysis, or text before or after the JSON.
 """

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -92,7 +92,7 @@ class Settings(BaseSettings):
 
     # FP Verification Configuration
     fp_verification_enabled: bool = Field(
-        default=False,
+        default=True,
         description="Enable LLM-powered false-positive verification pass",
     )
     fp_verification_model: str = Field(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -206,3 +206,50 @@ def test_no_special_notice_for_regular_pr():
 
     assert "🔒 SECURITY PATCH DETECTED" not in prompt
     assert "🤖 DEPENDABOT PR DETECTED" not in prompt
+
+
+def test_exhaustive_reporting_in_system_prompt():
+    """System prompt instructs the model to report all findings in a single pass."""
+    from baloo.agent.prompts import REVIEW_SYSTEM_PROMPT
+
+    assert "Exhaustive Reporting" in REVIEW_SYSTEM_PROMPT
+    assert "drip-feeds" in REVIEW_SYSTEM_PROMPT
+    assert "completeness check" in REVIEW_SYSTEM_PROMPT
+    # "balanced" was removed to avoid self-limiting
+    assert "balanced" not in REVIEW_SYSTEM_PROMPT
+
+
+def test_exhaustive_reporting_in_code_review_prompt():
+    """Full code review prompt includes completeness check step."""
+    pr_context = {
+        "title": "Add auth module",
+        "author": "dev",
+        "description": "New auth",
+        "base_branch": "main",
+        "head_branch": "feat/auth",
+        "files_changed": [{"filename": "auth.py"}],
+        "changed_file_paths": ["auth.py"],
+        "diff": "--- a\n+++ b\n@@\n-old\n+new",
+    }
+
+    prompt = build_pr_review_prompt(pr_context)
+
+    assert "Step 6: Completeness Check" in prompt
+    assert 'skip any findings because you already had "enough"' in prompt
+
+
+def test_exhaustive_reporting_in_simple_pr_prompt():
+    """Simple PR prompt also includes exhaustive reporting instruction."""
+    pr_context = {
+        "title": "Update deps",
+        "author": "dev",
+        "description": "Dep update",
+        "files_changed": [{"filename": "requirements.txt"}],
+        "changed_file_paths": ["requirements.txt"],
+        "diff": "--- a\n+++ b\n@@\n-old\n+new",
+    }
+
+    prompt = build_pr_review_prompt(pr_context)
+
+    assert "Be exhaustive" in prompt
+    assert "completeness check" in prompt


### PR DESCRIPTION
## Problem

Baloo drip-feeds findings across multiple review rounds. Issues present in the original code are only surfaced after earlier findings are fixed, creating frustrating fix-push-discover loops.

## Root Cause

The system prompt said "balanced" which nudged the LLM to self-limit findings count. No explicit instruction to be exhaustive.

## Changes

### 1. Exhaustive reporting prompts (`baloo/agent/prompts.py`)
- Removed "balanced" from system prompt
- Added **"Exhaustive Reporting"** section: report ALL findings in one pass, not drip-feed
- Added **"Step 6: Completeness Check"** to full review prompt — model must re-check its notes before emitting JSON
- Added exhaustive instruction to simple PR prompt
- 3 new tests asserting the language is present

### 2. FP verification on by default (`baloo/config/settings.py`)
- Changed `fp_verification_enabled` default from `false` → `true`
- With more findings per review, FP filtering is essential to maintain quality
- Set `FP_VERIFICATION_ENABLED=false` to opt out

## How They Work Together

```
Agent (exhaustive) → FP Verifier (drop false positives) → FindingsFilter (severity threshold)
```

Report everything, then filter out the noise.

## Tests

All 299 tests pass.