### PR TITLE
feat: track finding outcomes on PR merge

### DIFF
--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -504,7 +504,13 @@ class DashboardService:
             week_map: dict[str, dict] = {}
             for week, outcome, cnt in weekly_rows:
                 if week not in week_map:
-                    week_map[week] = {"total": 0, "actioned": 0, "disputed": 0, "ignored": 0}
+                    week_map[week] = {
+                        "total": 0,
+                        "actioned": 0,
+                        "acknowledged": 0,
+                        "disputed": 0,
+                        "ignored": 0,
+                    }
                 week_map[week]["total"] += cnt
                 if outcome in week_map[week]:
                     week_map[week][outcome] += cnt

--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from baloo.config.settings import get_settings
 from baloo.db.engine import get_session_factory
-from baloo.db.models import Finding, Review, ReviewLog
+from baloo.db.models import Finding, FindingOutcome, Review, ReviewLog
 
 
 class DashboardService:
@@ -382,4 +382,166 @@ class DashboardService:
             "prev_error_total": prev_error_total,
             "total_in_period": total_in_period,
             "prev_total_in_period": prev_total_in_period,
+        }
+
+    @staticmethod
+    async def get_outcomes_data(days: int = 90, repo_filter: str | None = None) -> dict:
+        settings = get_settings()
+        factory = get_session_factory(settings.database_url)
+
+        async with factory() as session:
+            now = datetime.now(timezone.utc)
+            since = now - timedelta(days=days)
+
+            def _base_filters():
+                filters = [FindingOutcome.labeled_at >= since]
+                if repo_filter:
+                    filters.append(FindingOutcome.repo_full_name == repo_filter)
+                return filters
+
+            # --- Totals and rates ---
+            total = (
+                await session.execute(select(func.count(FindingOutcome.id)).where(*_base_filters()))
+            ).scalar() or 0
+
+            outcome_rows = (
+                await session.execute(
+                    select(FindingOutcome.outcome, func.count(FindingOutcome.id))
+                    .where(*_base_filters())
+                    .group_by(FindingOutcome.outcome)
+                )
+            ).all()
+            outcomes = {r[0]: r[1] for r in outcome_rows}
+
+            actioned = outcomes.get("actioned", 0)
+            disputed = outcomes.get("disputed", 0)
+            ignored = outcomes.get("ignored", 0)
+
+            hit_rate = round(actioned / total * 100, 1) if total else 0.0
+            noise_rate = round((disputed + ignored) / total * 100, 1) if total else 0.0
+
+            # --- By severity ---
+            severity_rows = (
+                await session.execute(
+                    select(
+                        Finding.severity,
+                        FindingOutcome.outcome,
+                        func.count(FindingOutcome.id),
+                    )
+                    .join(Finding, FindingOutcome.finding_id == Finding.id)
+                    .where(*_base_filters())
+                    .group_by(Finding.severity, FindingOutcome.outcome)
+                )
+            ).all()
+
+            sev_map: dict[str, dict] = {}
+            for sev, outcome, cnt in severity_rows:
+                if sev not in sev_map:
+                    sev_map[sev] = {"total": 0, "actioned": 0}
+                sev_map[sev]["total"] += cnt
+                if outcome == "actioned":
+                    sev_map[sev]["actioned"] += cnt
+            severity_data = {
+                sev: {
+                    "total": v["total"],
+                    "actioned": v["actioned"],
+                    "hit_rate": round(v["actioned"] / v["total"] * 100, 1) if v["total"] else 0.0,
+                }
+                for sev, v in sev_map.items()
+            }
+
+            # --- By category ---
+            category_rows = (
+                await session.execute(
+                    select(
+                        Finding.category,
+                        FindingOutcome.outcome,
+                        func.count(FindingOutcome.id),
+                    )
+                    .join(Finding, FindingOutcome.finding_id == Finding.id)
+                    .where(*_base_filters())
+                    .group_by(Finding.category, FindingOutcome.outcome)
+                )
+            ).all()
+
+            cat_map: dict[str, dict] = {}
+            for cat, outcome, cnt in category_rows:
+                if cat not in cat_map:
+                    cat_map[cat] = {"total": 0, "actioned": 0}
+                cat_map[cat]["total"] += cnt
+                if outcome == "actioned":
+                    cat_map[cat]["actioned"] += cnt
+            category_data = {
+                cat: {
+                    "total": v["total"],
+                    "actioned": v["actioned"],
+                    "hit_rate": round(v["actioned"] / v["total"] * 100, 1) if v["total"] else 0.0,
+                }
+                for cat, v in cat_map.items()
+            }
+
+            # --- Weekly trends (dialect-aware) ---
+            if "postgres" in settings.database_url:
+                week_label = func.to_char(
+                    func.date_trunc("week", FindingOutcome.labeled_at), "IYYY-IW"
+                )
+            else:
+                week_label = func.strftime("%Y-%W", FindingOutcome.labeled_at)
+
+            weekly_rows = (
+                await session.execute(
+                    select(
+                        week_label.label("week"),
+                        FindingOutcome.outcome,
+                        func.count(FindingOutcome.id),
+                    )
+                    .where(*_base_filters())
+                    .group_by("week", FindingOutcome.outcome)
+                    .order_by("week")
+                )
+            ).all()
+
+            week_map: dict[str, dict] = {}
+            for week, outcome, cnt in weekly_rows:
+                if week not in week_map:
+                    week_map[week] = {"total": 0, "actioned": 0, "disputed": 0, "ignored": 0}
+                week_map[week]["total"] += cnt
+                if outcome in week_map[week]:
+                    week_map[week][outcome] += cnt
+            trends = [
+                {
+                    "week": w,
+                    "total": v["total"],
+                    "hit_rate": round(v["actioned"] / v["total"] * 100, 1) if v["total"] else 0.0,
+                    "noise_rate": (
+                        round((v["disputed"] + v["ignored"]) / v["total"] * 100, 1)
+                        if v["total"]
+                        else 0.0
+                    ),
+                }
+                for w, v in week_map.items()
+            ]
+
+            # --- Repos for filter dropdown ---
+            repos = (
+                (
+                    await session.execute(
+                        select(FindingOutcome.repo_full_name)
+                        .distinct()
+                        .order_by(FindingOutcome.repo_full_name)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        return {
+            "total": total,
+            "outcomes": outcomes,
+            "hit_rate": hit_rate,
+            "noise_rate": noise_rate,
+            "severity_data": severity_data,
+            "category_data": category_data,
+            "trends": trends,
+            "repos": repos,
         }

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -91,3 +91,17 @@ async def analytics(
         name="analytics.html",
         context={"days": days, **data},
     )
+
+
+@router.get("/outcomes", response_class=HTMLResponse)
+async def outcomes(
+    request: Request,
+    days: int = Query(90, ge=1, le=365),
+    repo: str | None = Query(None),
+):
+    data = await DashboardService.get_outcomes_data(days=days, repo_filter=repo)
+    return templates.TemplateResponse(
+        request=request,
+        name="outcomes.html",
+        context={"days": days, "repo": repo, **data},
+    )

--- a/baloo/dashboard/templates/base.html
+++ b/baloo/dashboard/templates/base.html
@@ -29,6 +29,11 @@
                     {% if active_page == 'analytics' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{% endif %}">
             Analytics
           </a>
+          <a href="/dashboard/outcomes"
+             class="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium
+                    {% if active_page == 'outcomes' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{% endif %}">
+            Outcomes
+          </a>
         </div>
       </div>
     </div>

--- a/baloo/dashboard/templates/outcomes.html
+++ b/baloo/dashboard/templates/outcomes.html
@@ -1,0 +1,218 @@
+{% extends "base.html" %}
+{% set active_page = "outcomes" %}
+
+{% block title %}Finding Outcomes - Baloo Dashboard{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">Finding Outcomes</h1>
+
+  <div class="flex items-center space-x-4">
+    <!-- Repo filter -->
+    <form class="flex items-center space-x-2">
+      <label class="text-sm text-gray-500">Repo:</label>
+      <select name="repo" onchange="this.form.submit()"
+              class="text-sm border border-gray-300 rounded px-2 py-1">
+        <option value="">All repos</option>
+        {% for r in repos %}
+        <option value="{{ r }}" {% if repo == r %}selected{% endif %}>{{ r }}</option>
+        {% endfor %}
+      </select>
+      <input type="hidden" name="days" value="{{ days }}">
+    </form>
+
+    <!-- Day range selector -->
+    <div class="flex items-center space-x-2">
+      <label class="text-sm text-gray-500">Range:</label>
+      {% for d in [30, 60, 90, 180, 365] %}
+      <a href="/dashboard/outcomes?days={{ d }}{% if repo %}&repo={{ repo }}{% endif %}"
+         class="px-3 py-1 text-sm rounded border {% if days == d %}bg-indigo-600 text-white border-indigo-600{% else %}hover:bg-gray-50{% endif %}">
+        {{ d }}d
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+
+<!-- Summary cards -->
+<div class="grid grid-cols-1 sm:grid-cols-4 gap-4 mb-6">
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Total Findings</p>
+    <p class="text-3xl font-bold text-gray-900">{{ total }}</p>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Hit Rate</p>
+    <p class="text-3xl font-bold {% if hit_rate >= 50 %}text-green-600{% elif hit_rate >= 25 %}text-yellow-600{% else %}text-red-600{% endif %}">{{ hit_rate }}%</p>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Noise Rate</p>
+    <p class="text-3xl font-bold {% if noise_rate <= 30 %}text-green-600{% elif noise_rate <= 60 %}text-yellow-600{% else %}text-red-600{% endif %}">{{ noise_rate }}%</p>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Outcome Breakdown</p>
+    <div class="flex flex-wrap gap-2 mt-2">
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">actioned: {{ outcomes.actioned }}</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">acknowledged: {{ outcomes.acknowledged }}</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">disputed: {{ outcomes.disputed }}</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">ignored: {{ outcomes.ignored }}</span>
+    </div>
+  </div>
+</div>
+
+<!-- Charts grid -->
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Hit Rate by Severity</h2>
+    <canvas id="severityChart" height="250"></canvas>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Hit Rate by Category</h2>
+    <canvas id="categoryChart" height="250"></canvas>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5 lg:col-span-2">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Weekly Trends</h2>
+    <canvas id="trendsChart" height="250"></canvas>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Outcome Distribution</h2>
+    <canvas id="outcomeChart" height="250"></canvas>
+  </div>
+</div>
+
+<!-- Category table -->
+<div class="bg-white rounded-lg shadow p-5">
+  <h2 class="text-lg font-semibold text-gray-900 mb-4">Category Breakdown</h2>
+  <table class="min-w-full divide-y divide-gray-200">
+    <thead>
+      <tr>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Total</th>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Actioned</th>
+        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Hit Rate</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-gray-100">
+      {% for cat, info in category_data.items() | sort(attribute='1.hit_rate', reverse=true) %}
+      <tr>
+        <td class="px-4 py-2 text-sm text-gray-900">{{ cat }}</td>
+        <td class="px-4 py-2 text-sm text-gray-600">{{ info.total }}</td>
+        <td class="px-4 py-2 text-sm text-gray-600">{{ info.actioned }}</td>
+        <td class="px-4 py-2 text-sm font-medium {% if info.hit_rate >= 50 %}text-green-600{% elif info.hit_rate >= 25 %}text-yellow-600{% else %}text-red-600{% endif %}">{{ info.hit_rate }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script>
+  const severityData = {{ (severity_data or {}) | tojson }};
+  const categoryData = {{ (category_data or {}) | tojson }};
+  const trends = {{ (trends or []) | tojson }};
+  const outcomes = {{ (outcomes or {}) | tojson }};
+
+  // Hit Rate by Severity - bar chart
+  const sevOrder = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
+  const sevColors = { CRITICAL: '#dc2626', HIGH: '#f97316', MEDIUM: '#eab308', LOW: '#3b82f6' };
+  new Chart(document.getElementById('severityChart'), {
+    type: 'bar',
+    data: {
+      labels: sevOrder,
+      datasets: [{
+        label: 'Hit Rate %',
+        data: sevOrder.map(s => severityData[s] ? severityData[s].hit_rate : 0),
+        backgroundColor: sevOrder.map(s => sevColors[s]),
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: { y: { min: 0, max: 100, ticks: { callback: v => v + '%' } } }
+    }
+  });
+
+  // Hit Rate by Category - horizontal bar chart
+  const catLabels = Object.keys(categoryData);
+  const catHitRates = catLabels.map(c => categoryData[c].hit_rate);
+  new Chart(document.getElementById('categoryChart'), {
+    type: 'bar',
+    data: {
+      labels: catLabels,
+      datasets: [{
+        label: 'Hit Rate %',
+        data: catHitRates,
+        backgroundColor: '#6366f1',
+      }]
+    },
+    options: {
+      responsive: true,
+      indexAxis: 'y',
+      plugins: { legend: { display: false } },
+      scales: { x: { min: 0, max: 100, ticks: { callback: v => v + '%' } } }
+    }
+  });
+
+  // Weekly Trends - line chart with dual y-axis
+  new Chart(document.getElementById('trendsChart'), {
+    type: 'line',
+    data: {
+      labels: trends.map(t => t.week),
+      datasets: [
+        {
+          label: 'Hit Rate %',
+          data: trends.map(t => t.hit_rate),
+          borderColor: '#22c55e',
+          backgroundColor: 'rgba(34,197,94,0.1)',
+          fill: false,
+          tension: 0.3,
+          yAxisID: 'y',
+        },
+        {
+          label: 'Noise Rate %',
+          data: trends.map(t => t.noise_rate),
+          borderColor: '#ef4444',
+          backgroundColor: 'rgba(239,68,68,0.1)',
+          fill: false,
+          tension: 0.3,
+          yAxisID: 'y',
+        },
+        {
+          label: 'Volume',
+          data: trends.map(t => t.total),
+          borderColor: '#6366f1',
+          borderDash: [5, 5],
+          fill: false,
+          tension: 0.3,
+          yAxisID: 'y1',
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: { position: 'left', min: 0, max: 100, ticks: { callback: v => v + '%' } },
+        y1: { position: 'right', min: 0, grid: { drawOnChartArea: false } }
+      }
+    }
+  });
+
+  // Outcome Distribution - doughnut
+  const outcomeColors = {
+    actioned: '#22c55e',
+    acknowledged: '#3b82f6',
+    disputed: '#ef4444',
+    ignored: '#9ca3af'
+  };
+  new Chart(document.getElementById('outcomeChart'), {
+    type: 'doughnut',
+    data: {
+      labels: Object.keys(outcomes),
+      datasets: [{
+        data: Object.values(outcomes),
+        backgroundColor: Object.keys(outcomes).map(k => outcomeColors[k] || '#94a3b8'),
+      }]
+    },
+    options: { responsive: true }
+  });
+</script>
+{% endblock %}

--- a/baloo/dashboard/templates/outcomes.html
+++ b/baloo/dashboard/templates/outcomes.html
@@ -203,13 +203,17 @@
     disputed: '#ef4444',
     ignored: '#9ca3af'
   };
+  const KNOWN_OUTCOMES = ['actioned', 'acknowledged', 'disputed', 'ignored'];
+  const normalizedOutcomes = Object.fromEntries(
+    KNOWN_OUTCOMES.map(k => [k, outcomes[k] ?? 0])
+  );
   new Chart(document.getElementById('outcomeChart'), {
     type: 'doughnut',
     data: {
-      labels: Object.keys(outcomes),
+      labels: Object.keys(normalizedOutcomes),
       datasets: [{
-        data: Object.values(outcomes),
-        backgroundColor: Object.keys(outcomes).map(k => outcomeColors[k] || '#94a3b8'),
+        data: Object.values(normalizedOutcomes),
+        backgroundColor: Object.keys(normalizedOutcomes).map(k => outcomeColors[k] || '#94a3b8'),
       }]
     },
     options: { responsive: true }

--- a/baloo/dashboard/templates/outcomes.html
+++ b/baloo/dashboard/templates/outcomes.html
@@ -51,10 +51,10 @@
   <div class="bg-white rounded-lg shadow p-5">
     <p class="text-sm text-gray-500">Outcome Breakdown</p>
     <div class="flex flex-wrap gap-2 mt-2">
-      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">actioned: {{ outcomes.actioned }}</span>
-      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">acknowledged: {{ outcomes.acknowledged }}</span>
-      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">disputed: {{ outcomes.disputed }}</span>
-      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">ignored: {{ outcomes.ignored }}</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">actioned: {{ outcomes.get('actioned', 0) }}</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">acknowledged: {{ outcomes.get('acknowledged', 0) }}</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">disputed: {{ outcomes.get('disputed', 0) }}</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">ignored: {{ outcomes.get('ignored', 0) }}</span>
     </div>
   </div>
 </div>

--- a/baloo/db/migrations/versions/004_add_finding_outcomes.py
+++ b/baloo/db/migrations/versions/004_add_finding_outcomes.py
@@ -1,0 +1,59 @@
+"""Add finding_outcomes table for tracking review quality.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-04-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: str = "003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "finding_outcomes" not in existing_tables:
+        op.create_table(
+            "finding_outcomes",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column(
+                "finding_id",
+                sa.Integer,
+                sa.ForeignKey("findings.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "review_id",
+                sa.Integer,
+                sa.ForeignKey("reviews.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("repo_full_name", sa.String(255), nullable=False),
+            sa.Column("pr_number", sa.Integer, nullable=False),
+            sa.Column("outcome", sa.String(20), nullable=False),
+            sa.Column("signals", sa.JSON, nullable=True),
+            sa.Column("labeled_at", sa.DateTime(timezone=True), nullable=False),
+        )
+        op.create_index(
+            "ix_finding_outcomes_finding_id", "finding_outcomes", ["finding_id"], unique=True
+        )
+        op.create_index("ix_finding_outcomes_review_id", "finding_outcomes", ["review_id"])
+        op.create_index("ix_finding_outcomes_repo", "finding_outcomes", ["repo_full_name"])
+        op.create_index("ix_finding_outcomes_outcome", "finding_outcomes", ["outcome"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_finding_outcomes_outcome", table_name="finding_outcomes")
+    op.drop_index("ix_finding_outcomes_repo", table_name="finding_outcomes")
+    op.drop_index("ix_finding_outcomes_review_id", table_name="finding_outcomes")
+    op.drop_index("ix_finding_outcomes_finding_id", table_name="finding_outcomes")
+    op.drop_table("finding_outcomes")

--- a/baloo/db/models.py
+++ b/baloo/db/models.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 
 from sqlalchemy import (
+    JSON,
     Boolean,
     DateTime,
     Float,
@@ -99,4 +100,33 @@ class ReviewLog(Base):
     __table_args__ = (
         Index("ix_review_logs_review_created", "review_id", "created_at"),
         Index("ix_review_logs_created_at", "created_at"),
+    )
+
+
+class FindingOutcome(Base):
+    __tablename__ = "finding_outcomes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    finding_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("findings.id", ondelete="CASCADE"), nullable=False
+    )
+    review_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("reviews.id", ondelete="CASCADE"), nullable=False
+    )
+    repo_full_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    outcome: Mapped[str] = mapped_column(String(20), nullable=False)
+    signals: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    labeled_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)
+    )
+
+    finding: Mapped["Finding"] = relationship("Finding")
+    review: Mapped["Review"] = relationship("Review")
+
+    __table_args__ = (
+        Index("ix_finding_outcomes_finding_id", "finding_id", unique=True),
+        Index("ix_finding_outcomes_review_id", "review_id"),
+        Index("ix_finding_outcomes_repo", "repo_full_name"),
+        Index("ix_finding_outcomes_outcome", "outcome"),
     )

--- a/baloo/github/discussions.py
+++ b/baloo/github/discussions.py
@@ -17,6 +17,14 @@ RESOLUTION_KEYWORDS = (
     "thanks, fixed",
     "lgtm",
     "applied",
+    # Decline keywords — the human addressed the finding by disagreeing
+    "declined",
+    "won't fix",
+    "wontfix",
+    "not a bug",
+    "by design",
+    "intentional",
+    "false positive",
 )
 
 

--- a/baloo/github/discussions.py
+++ b/baloo/github/discussions.py
@@ -17,14 +17,6 @@ RESOLUTION_KEYWORDS = (
     "thanks, fixed",
     "lgtm",
     "applied",
-    # Decline keywords — the human addressed the finding by disagreeing
-    "declined",
-    "won't fix",
-    "wontfix",
-    "not a bug",
-    "by design",
-    "intentional",
-    "false positive",
 )
 
 

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -31,6 +31,7 @@ from baloo.github.models import (
     ReviewComment,
     ReviewResult,
 )
+from baloo.outcomes.labeler import label_pr_outcomes
 from baloo.processor.decision_engine import DecisionEngine
 from baloo.processor.findings_filter import FindingsFilter
 from baloo.processor.severity_router import (
@@ -381,6 +382,17 @@ async def handle_webhook(
                 background_tasks.add_task(lambda: None)
 
                 return {"status": "queued", "queue_depth": waiting}
+            elif action == "closed":
+                if webhook_payload.pull_request.merged:
+                    logger.info(f"PR merged: {repo_name}#{pr_number} — triggering outcome labeling")
+                    asyncio.create_task(
+                        label_pr_outcomes(repo_name, pr_number, webhook_payload.installation.id)
+                    )
+                    background_tasks.add_task(lambda: None)
+                    return {"status": "labeling_outcomes", "pr": pr_number}
+                else:
+                    logger.info(f"PR closed without merge: {repo_name}#{pr_number} — skipping")
+                    return {"status": "ignored", "action": "closed", "reason": "not merged"}
             else:
                 # Log ignored actions for visibility
                 logger.info(

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -613,9 +613,12 @@ async def process_pr_review(
             all_threads.extend(_threads_from_issue_comments(pr_context.issue_comments))
             thread_lookup = _build_thread_lookup(all_threads)
             fresh_comments: list[ReviewComment] = []
-            follow_up_comments: list[tuple[DiscussionThread, ReviewComment]] = []
+            follow_up_comments: list[tuple[DiscussionThread, ReviewComment]] = (
+                []
+            )  # reserved for future conversational thread agent
             skipped_duplicates = 0
             skipped_resolved = 0
+            skipped_responded = 0
 
             for comment in filtered_comments:
                 thread = _match_thread(thread_lookup, comment)
@@ -640,7 +643,11 @@ async def process_pr_review(
                     skipped_duplicates += 1
                     continue
 
-                follow_up_comments.append((thread, comment))
+                # Developer responded (not resolved, not awaiting) — they've
+                # addressed the finding (fixed, declined, or discussed).
+                # Don't re-litigate; just note these threads exist.
+                skipped_responded += 1
+                continue
 
             decision_comments = fresh_comments + [comment for _, comment in follow_up_comments]
 
@@ -657,8 +664,8 @@ async def process_pr_review(
             summary_text = agent_result.summary
             summary_text = f"{summary_text}\n\n{decision_summary}"
 
-            if follow_up_comments:
-                summary_text += f"\n\n↪️ Baloo added follow-ups to {len(follow_up_comments)} existing thread(s)."
+            if skipped_responded:
+                summary_text += f"\n\n💬 Skipped {skipped_responded} thread(s) with developer responses (not re-reviewed)."
             if skipped_duplicates:
                 summary_text += f"\n\n↪️ Skipped {skipped_duplicates} existing Baloo thread(s) already awaiting a response."
             if skipped_resolved:
@@ -684,8 +691,8 @@ async def process_pr_review(
                 f"High: {severity_counts.get(ReviewSeverity.HIGH.value, 0)}, "
                 f"Medium: {severity_counts.get(ReviewSeverity.MEDIUM.value, 0)}, "
                 f"Low: {severity_counts.get(ReviewSeverity.LOW.value, 0)}), "
-                f"follow_ups={len(follow_up_comments)}, skipped_duplicates={skipped_duplicates}, "
-                f"skipped_resolved={skipped_resolved}, "
+                f"follow_ups={len(follow_up_comments)}, skipped_responded={skipped_responded}, "
+                f"skipped_duplicates={skipped_duplicates}, skipped_resolved={skipped_resolved}, "
                 f"approve={approve}, request_changes={request_changes}"
             )
 

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -385,8 +385,15 @@ async def handle_webhook(
             elif action == "closed":
                 if webhook_payload.pull_request.merged:
                     logger.info(f"PR merged: {repo_name}#{pr_number} — triggering outcome labeling")
-                    asyncio.create_task(
+                    task = asyncio.create_task(
                         label_pr_outcomes(repo_name, pr_number, webhook_payload.installation.id)
+                    )
+                    task.add_done_callback(
+                        lambda t: (
+                            logger.error("label_pr_outcomes failed", exc_info=t.exception())
+                            if not t.cancelled() and t.exception()
+                            else None
+                        )
                     )
                     background_tasks.add_task(lambda: None)
                     return {"status": "labeling_outcomes", "pr": pr_number}

--- a/baloo/outcomes/labeler.py
+++ b/baloo/outcomes/labeler.py
@@ -111,35 +111,47 @@ async def label_pr_outcomes(repo_full_name: str, pr_number: int, installation_id
     2. Fetch merge signals (diff + threads)
     3. For each finding, determine outcome and persist
     """
-    settings = get_settings()
-    session_factory = get_session_factory(settings.database_url)
+    try:
+        settings = get_settings()
+        session_factory = get_session_factory(settings.database_url)
 
-    async with session_factory() as session:
-        # Find all findings for this PR
-        stmt = (
-            select(Finding)
-            .join(Review, Finding.review_id == Review.id)
-            .where(Review.repo_full_name == repo_full_name, Review.pr_number == pr_number)
-        )
-        result = await session.execute(stmt)
-        findings = result.scalars().all()
-
-        if not findings:
-            logger.info(
-                "No findings for %s#%d, skipping outcome labeling",
-                repo_full_name,
-                pr_number,
+        # Snapshot finding data from DB
+        async with session_factory() as session:
+            stmt = (
+                select(Finding)
+                .join(Review, Finding.review_id == Review.id)
+                .where(Review.repo_full_name == repo_full_name, Review.pr_number == pr_number)
             )
-            return
+            result = await session.execute(stmt)
+            findings = result.scalars().all()
 
-        # Check which findings already have outcomes (idempotency)
-        existing_stmt = select(FindingOutcome.finding_id).where(
-            FindingOutcome.finding_id.in_([f.id for f in findings])
-        )
-        existing_result = await session.execute(existing_stmt)
-        existing_finding_ids = set(existing_result.scalars().all())
+            if not findings:
+                logger.info(
+                    "No findings for %s#%d, skipping outcome labeling",
+                    repo_full_name,
+                    pr_number,
+                )
+                return
 
-        findings_to_label = [f for f in findings if f.id not in existing_finding_ids]
+            # Check which findings already have outcomes (idempotency)
+            existing_stmt = select(FindingOutcome.finding_id).where(
+                FindingOutcome.finding_id.in_([f.id for f in findings])
+            )
+            existing_result = await session.execute(existing_stmt)
+            existing_finding_ids = set(existing_result.scalars().all())
+
+            # Snapshot scalar data before session closes
+            findings_to_label = [
+                {
+                    "id": f.id,
+                    "review_id": f.review_id,
+                    "file_path": f.file_path,
+                    "line_number": f.line_number,
+                }
+                for f in findings
+                if f.id not in existing_finding_ids
+            ]
+
         if not findings_to_label:
             logger.info(
                 "All %d findings for %s#%d already labeled, skipping",
@@ -149,53 +161,60 @@ async def label_pr_outcomes(repo_full_name: str, pr_number: int, installation_id
             )
             return
 
-    # Fetch signals from GitHub (outside DB session)
-    diff_text, threads = await fetch_merge_signals(repo_full_name, pr_number, installation_id)
+        # Fetch signals from GitHub (outside DB session)
+        diff_text, threads = await fetch_merge_signals(repo_full_name, pr_number, installation_id)
 
-    # Label each finding
-    async with session_factory() as session:
-        async with session.begin():
-            for finding in findings_to_label:
-                # Detect code change near the finding
-                code_changed = detect_code_change(finding.file_path, finding.line_number, diff_text)
+        # Label each finding
+        async with session_factory() as session:
+            async with session.begin():
+                for finding in findings_to_label:
+                    code_changed = detect_code_change(
+                        finding["file_path"], finding["line_number"], diff_text
+                    )
 
-                # Match finding to a thread (±5 line tolerance)
-                matched_thread = None
-                for t in threads:
-                    if t["path"] == finding.file_path:
-                        t_line = t.get("line")
-                        if (
-                            t_line is not None
-                            and finding.line_number is not None
-                            and abs(t_line - finding.line_number) <= 5
-                        ):
-                            matched_thread = t
-                            break
+                    # Match finding to a thread (±5 line tolerance)
+                    matched_thread = None
+                    for t in threads:
+                        if t["path"] == finding["file_path"]:
+                            t_line = t.get("line")
+                            if (
+                                t_line is not None
+                                and finding["line_number"] is not None
+                                and abs(t_line - finding["line_number"]) <= 5
+                            ):
+                                matched_thread = t
+                                break
 
-                # Collect thread signals
-                thread_signals = collect_thread_signals(matched_thread)
+                    thread_signals = collect_thread_signals(matched_thread)
+                    signals = {
+                        "code_changed_near_line": code_changed,
+                        **thread_signals,
+                    }
+                    outcome = determine_outcome(signals)
 
-                # Combine all signals
-                signals = {
-                    "code_changed_near_line": code_changed,
-                    **thread_signals,
-                }
+                    session.add(
+                        FindingOutcome(
+                            finding_id=finding["id"],
+                            review_id=finding["review_id"],
+                            repo_full_name=repo_full_name,
+                            pr_number=pr_number,
+                            outcome=outcome,
+                            signals=signals,
+                        )
+                    )
 
-                outcome = determine_outcome(signals)
-
-                finding_outcome = FindingOutcome(
-                    finding_id=finding.id,
-                    review_id=finding.review_id,
-                    repo_full_name=repo_full_name,
-                    pr_number=pr_number,
-                    outcome=outcome,
-                    signals=signals,
+                logger.info(
+                    "Labeled %d findings for %s#%d",
+                    len(findings_to_label),
+                    repo_full_name,
+                    pr_number,
                 )
-                session.add(finding_outcome)
 
-            logger.info(
-                "Labeled %d findings for %s#%d",
-                len(findings_to_label),
-                repo_full_name,
-                pr_number,
-            )
+    except Exception as exc:
+        logger.error(
+            "Outcome labeling failed for %s#%d: %s",
+            repo_full_name,
+            pr_number,
+            exc,
+            exc_info=True,
+        )

--- a/baloo/outcomes/labeler.py
+++ b/baloo/outcomes/labeler.py
@@ -1,0 +1,201 @@
+"""Outcome labeler: determines what happened to each finding after PR merge."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from sqlalchemy import select
+
+from baloo.config.settings import get_settings
+from baloo.db.engine import get_session_factory
+from baloo.db.models import Finding, FindingOutcome, Review
+from baloo.github.api_client import GitHubAPIClient
+from baloo.outcomes.signals import collect_thread_signals, detect_code_change
+
+logger = logging.getLogger(__name__)
+
+
+def determine_outcome(signals: dict) -> str:
+    """Apply priority logic to signals and return an outcome label.
+
+    Priority order:
+    1. code_changed_near_line → "actioned"
+    2. reply_sentiment == "negative" → "disputed"
+    3. developer_replied AND (reply_sentiment == "positive" OR thread_resolved) → "acknowledged"
+    4. Otherwise → "ignored"
+    """
+    if signals.get("code_changed_near_line"):
+        return "actioned"
+
+    if signals.get("reply_sentiment") == "negative":
+        return "disputed"
+
+    if signals.get("developer_replied") and (
+        signals.get("reply_sentiment") == "positive" or signals.get("thread_resolved")
+    ):
+        return "acknowledged"
+
+    return "ignored"
+
+
+async def fetch_merge_signals(
+    repo_full_name: str, pr_number: int, installation_id: int
+) -> tuple[str, list[dict]]:
+    """Fetch diff and review threads for a merged PR from GitHub API.
+
+    Returns:
+        (diff_text, threads_list) where each thread is a dict with keys:
+        path, line, is_resolved, comments: [{author, body, is_baloo}]
+    """
+    client = GitHubAPIClient(installation_id)
+    headers = client._get_headers()
+
+    async with httpx.AsyncClient() as http:
+        # Fetch PR diff
+        pr_url = f"{client.base_url}/repos/{repo_full_name}/pulls/{pr_number}"
+        diff_resp = await http.get(
+            pr_url,
+            headers={**headers, "Accept": "application/vnd.github.v3.diff"},
+        )
+        diff_resp.raise_for_status()
+        diff_text = diff_resp.text
+
+        # Fetch review comments (paginated)
+        comments_url = f"{client.base_url}/repos/{repo_full_name}/pulls/{pr_number}/comments"
+        raw_comments = await client._fetch_paginated_json(http, comments_url, headers=headers)
+
+    # Fetch resolved thread IDs via GraphQL
+    resolved_ids = await client.fetch_resolved_thread_ids(repo_full_name, pr_number)
+
+    # Group comments into threads by in_reply_to_id
+    # Root comments have in_reply_to_id == None
+    root_comments: dict[int, dict] = {}  # comment_id -> thread dict
+    child_comments: dict[int, list[dict]] = {}  # root_id -> list of child comment dicts
+
+    for c in raw_comments:
+        comment_id = c["id"]
+        reply_to = c.get("in_reply_to_id")
+        login = c.get("user", {}).get("login", "")
+        is_baloo = "baloo" in login.lower()
+        comment_dict = {
+            "author": login,
+            "body": c.get("body", ""),
+            "is_baloo": is_baloo,
+        }
+
+        if reply_to is None:
+            # Root comment
+            root_comments[comment_id] = {
+                "path": c.get("path", ""),
+                "line": c.get("original_line") or c.get("line"),
+                "is_resolved": comment_id in resolved_ids,
+                "comments": [comment_dict],
+            }
+        else:
+            child_comments.setdefault(reply_to, []).append(comment_dict)
+
+    # Attach children to their root threads
+    for root_id, thread in root_comments.items():
+        if root_id in child_comments:
+            thread["comments"].extend(child_comments[root_id])
+
+    threads = list(root_comments.values())
+    return diff_text, threads
+
+
+async def label_pr_outcomes(repo_full_name: str, pr_number: int, installation_id: int) -> None:
+    """Label all findings for a merged PR with outcomes.
+
+    1. Query findings from DB
+    2. Fetch merge signals (diff + threads)
+    3. For each finding, determine outcome and persist
+    """
+    settings = get_settings()
+    session_factory = get_session_factory(settings.database_url)
+
+    async with session_factory() as session:
+        # Find all findings for this PR
+        stmt = (
+            select(Finding)
+            .join(Review, Finding.review_id == Review.id)
+            .where(Review.repo_full_name == repo_full_name, Review.pr_number == pr_number)
+        )
+        result = await session.execute(stmt)
+        findings = result.scalars().all()
+
+        if not findings:
+            logger.info(
+                "No findings for %s#%d, skipping outcome labeling",
+                repo_full_name,
+                pr_number,
+            )
+            return
+
+        # Check which findings already have outcomes (idempotency)
+        existing_stmt = select(FindingOutcome.finding_id).where(
+            FindingOutcome.finding_id.in_([f.id for f in findings])
+        )
+        existing_result = await session.execute(existing_stmt)
+        existing_finding_ids = set(existing_result.scalars().all())
+
+        findings_to_label = [f for f in findings if f.id not in existing_finding_ids]
+        if not findings_to_label:
+            logger.info(
+                "All %d findings for %s#%d already labeled, skipping",
+                len(findings),
+                repo_full_name,
+                pr_number,
+            )
+            return
+
+    # Fetch signals from GitHub (outside DB session)
+    diff_text, threads = await fetch_merge_signals(repo_full_name, pr_number, installation_id)
+
+    # Label each finding
+    async with session_factory() as session:
+        async with session.begin():
+            for finding in findings_to_label:
+                # Detect code change near the finding
+                code_changed = detect_code_change(finding.file_path, finding.line_number, diff_text)
+
+                # Match finding to a thread (±5 line tolerance)
+                matched_thread = None
+                for t in threads:
+                    if t["path"] == finding.file_path:
+                        t_line = t.get("line")
+                        if (
+                            t_line is not None
+                            and finding.line_number is not None
+                            and abs(t_line - finding.line_number) <= 5
+                        ):
+                            matched_thread = t
+                            break
+
+                # Collect thread signals
+                thread_signals = collect_thread_signals(matched_thread)
+
+                # Combine all signals
+                signals = {
+                    "code_changed_near_line": code_changed,
+                    **thread_signals,
+                }
+
+                outcome = determine_outcome(signals)
+
+                finding_outcome = FindingOutcome(
+                    finding_id=finding.id,
+                    review_id=finding.review_id,
+                    repo_full_name=repo_full_name,
+                    pr_number=pr_number,
+                    outcome=outcome,
+                    signals=signals,
+                )
+                session.add(finding_outcome)
+
+            logger.info(
+                "Labeled %d findings for %s#%d",
+                len(findings_to_label),
+                repo_full_name,
+                pr_number,
+            )

--- a/baloo/outcomes/labeler.py
+++ b/baloo/outcomes/labeler.py
@@ -58,8 +58,16 @@ async def fetch_merge_signals(
             pr_url,
             headers={**headers, "Accept": "application/vnd.github.v3.diff"},
         )
-        diff_resp.raise_for_status()
-        diff_text = diff_resp.text
+        if diff_resp.status_code == 406:
+            logger.warning(
+                "PR %s#%d diff too large (406), code-change detection will be skipped",
+                repo_full_name,
+                pr_number,
+            )
+            diff_text = ""
+        else:
+            diff_resp.raise_for_status()
+            diff_text = diff_resp.text
 
         # Fetch review comments (paginated)
         comments_url = f"{client.base_url}/repos/{repo_full_name}/pulls/{pr_number}/comments"
@@ -172,18 +180,17 @@ async def label_pr_outcomes(repo_full_name: str, pr_number: int, installation_id
                         finding["file_path"], finding["line_number"], diff_text
                     )
 
-                    # Match finding to a thread (±5 line tolerance)
+                    # Match finding to closest thread (±5 line tolerance)
                     matched_thread = None
+                    best_distance = float("inf")
                     for t in threads:
                         if t["path"] == finding["file_path"]:
                             t_line = t.get("line")
-                            if (
-                                t_line is not None
-                                and finding["line_number"] is not None
-                                and abs(t_line - finding["line_number"]) <= 5
-                            ):
-                                matched_thread = t
-                                break
+                            if t_line is not None and finding["line_number"] is not None:
+                                dist = abs(t_line - finding["line_number"])
+                                if dist <= 5 and dist < best_distance:
+                                    best_distance = dist
+                                    matched_thread = t
 
                     thread_signals = collect_thread_signals(matched_thread)
                     signals = {

--- a/baloo/outcomes/signals.py
+++ b/baloo/outcomes/signals.py
@@ -1,0 +1,117 @@
+"""Signal collection for finding outcomes."""
+
+from __future__ import annotations
+
+import re
+
+NEGATIVE_KEYWORDS = ["false positive", "intentional", "disagree", "not a bug", "by design"]
+POSITIVE_KEYWORDS = ["fixed", "good catch", "thanks", "done", "resolved"]
+
+
+def classify_sentiment(text: str | None) -> str | None:
+    """Classify reply sentiment using keyword matching.
+
+    Returns "positive", "negative", "neutral", or None if no text.
+    Negative keywords take priority over positive keywords.
+    """
+    if not text or not text.strip():
+        return None
+
+    lower = text.lower()
+
+    for kw in NEGATIVE_KEYWORDS:
+        if kw in lower:
+            return "negative"
+
+    for kw in POSITIVE_KEYWORDS:
+        if kw in lower:
+            return "positive"
+
+    return "neutral"
+
+
+def detect_code_change(file_path: str, line_number: int | None, diff: str | None) -> bool:
+    """Parse unified diff to check if lines within ±5 of line_number were modified.
+
+    Returns True if a '+' line in the diff for the target file lands within 5
+    lines of line_number in the new-file numbering.
+    """
+    if not diff or line_number is None:
+        return False
+
+    file_header_re = re.compile(r"^diff --git a/.+ b/(.+)$")
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+    current_file: str | None = None
+    new_line: int = 0
+    in_target_file = False
+
+    for raw_line in diff.splitlines():
+        # File header
+        m = file_header_re.match(raw_line)
+        if m:
+            current_file = m.group(1)
+            in_target_file = current_file == file_path
+            new_line = 0
+            continue
+
+        # Skip --- and +++ metadata lines
+        if raw_line.startswith("---") or raw_line.startswith("+++"):
+            continue
+
+        # Hunk header
+        m = hunk_re.match(raw_line)
+        if m:
+            new_line = int(m.group(1))
+            continue
+
+        if not in_target_file:
+            continue
+
+        if raw_line.startswith("+"):
+            if abs(new_line - line_number) <= 5:
+                return True
+            new_line += 1
+        elif raw_line.startswith("-"):
+            # Deleted lines don't advance new-file counter
+            pass
+        else:
+            # Context line
+            new_line += 1
+
+    return False
+
+
+def collect_thread_signals(thread: dict | None) -> dict:
+    """Extract signals from a PR review thread.
+
+    Returns dict with keys:
+        thread_resolved, developer_replied, reply_sentiment, reply_text
+    """
+    empty: dict = {
+        "thread_resolved": False,
+        "developer_replied": False,
+        "reply_sentiment": None,
+        "reply_text": None,
+    }
+
+    if thread is None:
+        return empty
+
+    thread_resolved: bool = bool(thread.get("is_resolved", False))
+    comments: list[dict] = thread.get("comments", [])
+
+    dev_comment = next((c for c in comments if not c.get("is_baloo", True)), None)
+
+    if dev_comment is None:
+        return {**empty, "thread_resolved": thread_resolved}
+
+    reply_text: str = (dev_comment.get("body") or "")[:500]
+    reply_sentiment = classify_sentiment(reply_text)
+
+    return {
+        "thread_resolved": thread_resolved,
+        "developer_replied": True,
+        "reply_sentiment": reply_sentiment,
+        "reply_text": reply_text,
+    }

--- a/baloo/outcomes/signals.py
+++ b/baloo/outcomes/signals.py
@@ -75,6 +75,9 @@ def detect_code_change(file_path: str, line_number: int | None, diff: str | None
         elif raw_line.startswith("-"):
             # Deleted lines don't advance new-file counter
             pass
+        elif raw_line.startswith("\\"):
+            # "\ No newline at end of file" — not a real diff line
+            pass
         else:
             # Context line
             new_line += 1

--- a/docs/superpowers/plans/2026-04-25-finding-outcomes.md
+++ b/docs/superpowers/plans/2026-04-25-finding-outcomes.md
@@ -1,0 +1,1899 @@
+# Finding Outcomes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track finding outcomes on PR merge to measure Baloo's review quality over time.
+
+**Architecture:** On PR merge, a background task labels each finding with an outcome (actioned/disputed/acknowledged/ignored) based on code changes and thread interactions. A new dashboard page visualizes hit rate, noise rate, and trends. All data stored in a new `finding_outcomes` table with Alembic migration.
+
+**Tech Stack:** Python 3.10+, SQLAlchemy async ORM, Alembic, FastAPI, Jinja2/HTMX/Chart.js, pytest
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `baloo/db/migrations/versions/004_add_finding_outcomes.py` | Alembic migration for `finding_outcomes` table |
+| Modify | `baloo/db/models.py` | Add `FindingOutcome` model |
+| Create | `baloo/outcomes/__init__.py` | Package init |
+| Create | `baloo/outcomes/signals.py` | Signal collection (code change detection, thread matching, sentiment) |
+| Create | `baloo/outcomes/labeler.py` | Outcome labeling orchestrator (called on PR merge) |
+| Modify | `baloo/github/webhook_handler.py` | Add `closed`+merged handler |
+| Modify | `baloo/dashboard/queries.py` | Add outcome queries to `DashboardService` |
+| Modify | `baloo/dashboard/router.py` | Add `/dashboard/outcomes` route |
+| Modify | `baloo/dashboard/templates/base.html` | Add "Outcomes" nav link |
+| Create | `baloo/dashboard/templates/outcomes.html` | Outcomes dashboard page |
+| Create | `tests/outcomes/__init__.py` | Test package init |
+| Create | `tests/outcomes/test_signals.py` | Tests for signal collection |
+| Create | `tests/outcomes/test_labeler.py` | Tests for labeling orchestrator |
+| Create | `tests/outcomes/test_webhook_merge.py` | Tests for merge webhook handling |
+| Create | `tests/dashboard/test_outcomes_page.py` | Tests for outcomes dashboard |
+
+---
+
+### Task 1: FindingOutcome Model + Migration
+
+**Files:**
+- Modify: `baloo/db/models.py`
+- Create: `baloo/db/migrations/versions/004_add_finding_outcomes.py`
+- Modify: `tests/db/test_models.py`
+
+- [ ] **Step 1: Write failing test for FindingOutcome model**
+
+Add to `tests/db/test_models.py`:
+
+```python
+from baloo.db.models import FindingOutcome
+
+
+def test_finding_outcome_model_exists():
+    """FindingOutcome has expected columns."""
+    outcome = FindingOutcome(
+        finding_id=1,
+        review_id=1,
+        repo_full_name="owner/repo",
+        pr_number=42,
+        outcome="actioned",
+        signals={"code_changed_near_line": True},
+    )
+    assert outcome.outcome == "actioned"
+    assert outcome.signals == {"code_changed_near_line": True}
+    assert outcome.repo_full_name == "owner/repo"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/db/test_models.py::test_finding_outcome_model_exists -v`
+Expected: FAIL with `ImportError: cannot import name 'FindingOutcome'`
+
+- [ ] **Step 3: Add FindingOutcome model**
+
+Add to `baloo/db/models.py`, after the `ReviewLog` class:
+
+```python
+from sqlalchemy import JSON
+
+
+class FindingOutcome(Base):
+    __tablename__ = "finding_outcomes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    finding_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("findings.id", ondelete="CASCADE"), nullable=False
+    )
+    review_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("reviews.id", ondelete="CASCADE"), nullable=False
+    )
+    repo_full_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    outcome: Mapped[str] = mapped_column(String(20), nullable=False)
+    signals: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    labeled_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc)
+    )
+
+    finding: Mapped["Finding"] = relationship("Finding")
+    review: Mapped["Review"] = relationship("Review")
+
+    __table_args__ = (
+        Index("ix_finding_outcomes_finding_id", "finding_id", unique=True),
+        Index("ix_finding_outcomes_review_id", "review_id"),
+        Index("ix_finding_outcomes_repo", "repo_full_name"),
+        Index("ix_finding_outcomes_outcome", "outcome"),
+    )
+```
+
+Add `JSON` to the imports from `sqlalchemy` at the top of the file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/db/test_models.py::test_finding_outcome_model_exists -v`
+Expected: PASS
+
+- [ ] **Step 5: Create Alembic migration**
+
+Create `baloo/db/migrations/versions/004_add_finding_outcomes.py`:
+
+```python
+"""Add finding_outcomes table for tracking review quality.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-04-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: str = "003"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "finding_outcomes" not in existing_tables:
+        op.create_table(
+            "finding_outcomes",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column(
+                "finding_id",
+                sa.Integer,
+                sa.ForeignKey("findings.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "review_id",
+                sa.Integer,
+                sa.ForeignKey("reviews.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("repo_full_name", sa.String(255), nullable=False),
+            sa.Column("pr_number", sa.Integer, nullable=False),
+            sa.Column("outcome", sa.String(20), nullable=False),
+            sa.Column("signals", sa.JSON, nullable=True),
+            sa.Column("labeled_at", sa.DateTime(timezone=True), nullable=False),
+        )
+        op.create_index(
+            "ix_finding_outcomes_finding_id", "finding_outcomes", ["finding_id"], unique=True
+        )
+        op.create_index("ix_finding_outcomes_review_id", "finding_outcomes", ["review_id"])
+        op.create_index("ix_finding_outcomes_repo", "finding_outcomes", ["repo_full_name"])
+        op.create_index("ix_finding_outcomes_outcome", "finding_outcomes", ["outcome"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_finding_outcomes_outcome", table_name="finding_outcomes")
+    op.drop_index("ix_finding_outcomes_repo", table_name="finding_outcomes")
+    op.drop_index("ix_finding_outcomes_review_id", table_name="finding_outcomes")
+    op.drop_index("ix_finding_outcomes_finding_id", table_name="finding_outcomes")
+    op.drop_table("finding_outcomes")
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add baloo/db/models.py baloo/db/migrations/versions/004_add_finding_outcomes.py tests/db/test_models.py
+git commit -m "feat: add FindingOutcome model and migration"
+```
+
+---
+
+### Task 2: Signal Collection
+
+**Files:**
+- Create: `baloo/outcomes/__init__.py`
+- Create: `baloo/outcomes/signals.py`
+- Create: `tests/outcomes/__init__.py`
+- Create: `tests/outcomes/test_signals.py`
+
+- [ ] **Step 1: Create package init files**
+
+Create empty `baloo/outcomes/__init__.py` and `tests/outcomes/__init__.py`.
+
+- [ ] **Step 2: Write failing test for reply sentiment**
+
+Create `tests/outcomes/test_signals.py`:
+
+```python
+"""Tests for outcome signal collection."""
+
+from baloo.outcomes.signals import classify_sentiment
+
+
+def test_positive_sentiment():
+    assert classify_sentiment("good catch, I'll fix this") == "positive"
+
+
+def test_negative_sentiment():
+    assert classify_sentiment("this is a false positive") == "negative"
+
+
+def test_neutral_sentiment():
+    assert classify_sentiment("I see what you mean, let me think about it") == "neutral"
+
+
+def test_no_text_returns_none():
+    assert classify_sentiment(None) is None
+    assert classify_sentiment("") is None
+
+
+def test_positive_keywords():
+    for text in ["fixed", "good catch", "thanks", "done", "resolved"]:
+        assert classify_sentiment(text) == "positive", f"Expected positive for: {text}"
+
+
+def test_negative_keywords():
+    for text in ["false positive", "intentional", "disagree", "not a bug", "by design"]:
+        assert classify_sentiment(text) == "negative", f"Expected negative for: {text}"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `uv run pytest tests/outcomes/test_signals.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'baloo.outcomes.signals'`
+
+- [ ] **Step 4: Implement classify_sentiment**
+
+Create `baloo/outcomes/signals.py`:
+
+```python
+"""Signal collection for finding outcome labeling."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+POSITIVE_KEYWORDS = ["fixed", "good catch", "thanks", "done", "resolved"]
+NEGATIVE_KEYWORDS = ["false positive", "intentional", "disagree", "not a bug", "by design"]
+
+
+def classify_sentiment(text: str | None) -> str | None:
+    """Classify reply sentiment using keyword matching.
+
+    Returns "positive", "negative", "neutral", or None if no text.
+    """
+    if not text:
+        return None
+
+    lower = text.lower()
+    for kw in NEGATIVE_KEYWORDS:
+        if kw in lower:
+            return "negative"
+    for kw in POSITIVE_KEYWORDS:
+        if kw in lower:
+            return "positive"
+    return "neutral"
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/outcomes/test_signals.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Write failing test for code change detection**
+
+Add to `tests/outcomes/test_signals.py`:
+
+```python
+from baloo.outcomes.signals import detect_code_change
+
+
+def test_code_changed_near_line():
+    """Detects changes within ±5 lines of the flagged line."""
+    # Unified diff showing lines 10-15 changed
+    diff = """diff --git a/src/auth.py b/src/auth.py
+--- a/src/auth.py
++++ b/src/auth.py
+@@ -8,7 +8,7 @@ class Auth:
+     def validate(self):
+-        old_code()
++        new_code()
+         return True"""
+    assert detect_code_change("src/auth.py", 12, diff) is True
+
+
+def test_code_not_changed_near_line():
+    """No changes near the flagged line."""
+    diff = """diff --git a/src/auth.py b/src/auth.py
+--- a/src/auth.py
++++ b/src/auth.py
+@@ -100,3 +100,3 @@ class Auth:
+-    old_line()
++    new_line()"""
+    assert detect_code_change("src/auth.py", 12, diff) is False
+
+
+def test_code_change_different_file():
+    """Changes in a different file don't count."""
+    diff = """diff --git a/src/other.py b/src/other.py
+--- a/src/other.py
++++ b/src/other.py
+@@ -10,3 +10,3 @@
+-    old()
++    new()"""
+    assert detect_code_change("src/auth.py", 12, diff) is False
+
+
+def test_code_change_no_diff():
+    assert detect_code_change("src/auth.py", 12, "") is False
+    assert detect_code_change("src/auth.py", 12, None) is False
+```
+
+- [ ] **Step 7: Run test to verify it fails**
+
+Run: `uv run pytest tests/outcomes/test_signals.py::test_code_changed_near_line -v`
+Expected: FAIL with `ImportError: cannot import name 'detect_code_change'`
+
+- [ ] **Step 8: Implement detect_code_change**
+
+Add to `baloo/outcomes/signals.py`:
+
+```python
+import re
+
+LINE_TOLERANCE = 5
+
+_HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+_DIFF_FILE = re.compile(r"^diff --git a/.+ b/(.+)$")
+
+
+def detect_code_change(
+    file_path: str, line_number: int | None, diff: str | None
+) -> bool:
+    """Check if lines near line_number were modified in the diff.
+
+    Parses unified diff to find added/removed lines within ±LINE_TOLERANCE
+    of the target line in the specified file.
+    """
+    if not diff or line_number is None:
+        return False
+
+    in_target_file = False
+    current_line = 0
+
+    for raw_line in diff.splitlines():
+        # Track which file we're in
+        file_match = _DIFF_FILE.match(raw_line)
+        if file_match:
+            in_target_file = file_match.group(1) == file_path
+            continue
+
+        if not in_target_file:
+            continue
+
+        # Parse hunk headers for line numbers
+        hunk_match = _HUNK_HEADER.match(raw_line)
+        if hunk_match:
+            current_line = int(hunk_match.group(1))
+            continue
+
+        # Skip diff metadata lines
+        if raw_line.startswith("---") or raw_line.startswith("+++"):
+            continue
+
+        # Track line numbers and check for changes
+        if raw_line.startswith("-"):
+            # Removed lines don't advance the new-file line counter
+            continue
+
+        if raw_line.startswith("+"):
+            if abs(current_line - line_number) <= LINE_TOLERANCE:
+                return True
+            current_line += 1
+        else:
+            # Context line
+            current_line += 1
+
+    return False
+```
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `uv run pytest tests/outcomes/test_signals.py -v`
+Expected: All PASS
+
+- [ ] **Step 10: Write failing test for thread signal collection**
+
+Add to `tests/outcomes/test_signals.py`:
+
+```python
+from baloo.outcomes.signals import collect_thread_signals
+
+
+def test_collect_thread_signals_with_reply():
+    """Extracts signals from a thread where developer replied."""
+    thread = {
+        "path": "src/auth.py",
+        "line": 42,
+        "is_resolved": True,
+        "comments": [
+            {"author": "baloo[bot]", "body": "SQL injection risk", "is_baloo": True},
+            {"author": "dev", "body": "good catch, fixed", "is_baloo": False},
+        ],
+    }
+    signals = collect_thread_signals(thread)
+    assert signals["thread_resolved"] is True
+    assert signals["developer_replied"] is True
+    assert signals["reply_sentiment"] == "positive"
+    assert signals["reply_text"] == "good catch, fixed"
+
+
+def test_collect_thread_signals_no_reply():
+    """Thread with only Baloo's comment — no developer reply."""
+    thread = {
+        "path": "src/auth.py",
+        "line": 42,
+        "is_resolved": False,
+        "comments": [
+            {"author": "baloo[bot]", "body": "SQL injection risk", "is_baloo": True},
+        ],
+    }
+    signals = collect_thread_signals(thread)
+    assert signals["thread_resolved"] is False
+    assert signals["developer_replied"] is False
+    assert signals["reply_sentiment"] is None
+    assert signals["reply_text"] is None
+
+
+def test_collect_thread_signals_disputed():
+    thread = {
+        "path": "src/auth.py",
+        "line": 42,
+        "is_resolved": False,
+        "comments": [
+            {"author": "baloo[bot]", "body": "Possible bug", "is_baloo": True},
+            {"author": "dev", "body": "this is intentional", "is_baloo": False},
+        ],
+    }
+    signals = collect_thread_signals(thread)
+    assert signals["reply_sentiment"] == "negative"
+
+
+def test_collect_thread_signals_none():
+    assert collect_thread_signals(None) == {
+        "thread_resolved": False,
+        "developer_replied": False,
+        "reply_sentiment": None,
+        "reply_text": None,
+    }
+```
+
+- [ ] **Step 11: Run test to verify it fails**
+
+Run: `uv run pytest tests/outcomes/test_signals.py::test_collect_thread_signals_with_reply -v`
+Expected: FAIL with `ImportError: cannot import name 'collect_thread_signals'`
+
+- [ ] **Step 12: Implement collect_thread_signals**
+
+Add to `baloo/outcomes/signals.py`:
+
+```python
+def collect_thread_signals(thread: dict | None) -> dict:
+    """Extract signals from a PR review thread.
+
+    Args:
+        thread: Dict with keys: is_resolved, comments (list of dicts
+                with author, body, is_baloo).
+
+    Returns:
+        Dict with thread_resolved, developer_replied, reply_sentiment, reply_text.
+    """
+    empty = {
+        "thread_resolved": False,
+        "developer_replied": False,
+        "reply_sentiment": None,
+        "reply_text": None,
+    }
+    if not thread:
+        return empty
+
+    comments = thread.get("comments", [])
+
+    # Find first non-Baloo reply
+    developer_reply = None
+    for comment in comments:
+        if not comment.get("is_baloo", False):
+            developer_reply = comment
+            break
+
+    if not developer_reply:
+        return {**empty, "thread_resolved": bool(thread.get("is_resolved", False))}
+
+    reply_text = developer_reply.get("body", "")
+    return {
+        "thread_resolved": bool(thread.get("is_resolved", False)),
+        "developer_replied": True,
+        "reply_sentiment": classify_sentiment(reply_text),
+        "reply_text": reply_text[:500] if reply_text else None,
+    }
+```
+
+- [ ] **Step 13: Run all signal tests**
+
+Run: `uv run pytest tests/outcomes/test_signals.py -v`
+Expected: All PASS
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add baloo/outcomes/ tests/outcomes/
+git commit -m "feat: add signal collection for finding outcomes"
+```
+
+---
+
+### Task 3: Outcome Labeler
+
+**Files:**
+- Create: `baloo/outcomes/labeler.py`
+- Create: `tests/outcomes/test_labeler.py`
+
+- [ ] **Step 1: Write failing test for determine_outcome**
+
+Create `tests/outcomes/test_labeler.py`:
+
+```python
+"""Tests for outcome labeling logic."""
+
+from baloo.outcomes.labeler import determine_outcome
+
+
+def test_actioned_wins_over_all():
+    """Code change is highest priority."""
+    signals = {
+        "code_changed_near_line": True,
+        "thread_resolved": True,
+        "developer_replied": True,
+        "reply_sentiment": "positive",
+        "reply_text": "fixed",
+    }
+    assert determine_outcome(signals) == "actioned"
+
+
+def test_disputed_when_negative_reply_no_code_change():
+    signals = {
+        "code_changed_near_line": False,
+        "thread_resolved": False,
+        "developer_replied": True,
+        "reply_sentiment": "negative",
+        "reply_text": "false positive",
+    }
+    assert determine_outcome(signals) == "disputed"
+
+
+def test_acknowledged_when_positive_reply_no_code_change():
+    signals = {
+        "code_changed_near_line": False,
+        "thread_resolved": True,
+        "developer_replied": True,
+        "reply_sentiment": "positive",
+        "reply_text": "good catch",
+    }
+    assert determine_outcome(signals) == "acknowledged"
+
+
+def test_acknowledged_when_neutral_reply_and_resolved():
+    signals = {
+        "code_changed_near_line": False,
+        "thread_resolved": True,
+        "developer_replied": True,
+        "reply_sentiment": "neutral",
+        "reply_text": "ok",
+    }
+    assert determine_outcome(signals) == "acknowledged"
+
+
+def test_ignored_when_no_signals():
+    signals = {
+        "code_changed_near_line": False,
+        "thread_resolved": False,
+        "developer_replied": False,
+        "reply_sentiment": None,
+        "reply_text": None,
+    }
+    assert determine_outcome(signals) == "ignored"
+
+
+def test_ignored_when_neutral_reply_not_resolved():
+    """Neutral reply without resolution is still ignored."""
+    signals = {
+        "code_changed_near_line": False,
+        "thread_resolved": False,
+        "developer_replied": True,
+        "reply_sentiment": "neutral",
+        "reply_text": "hmm",
+    }
+    assert determine_outcome(signals) == "ignored"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/outcomes/test_labeler.py -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement determine_outcome**
+
+Create `baloo/outcomes/labeler.py`:
+
+```python
+"""Outcome labeling for Baloo findings."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+
+from baloo.config.settings import get_settings
+from baloo.db.engine import get_session_factory
+from baloo.db.models import Finding, FindingOutcome, Review
+from baloo.outcomes.signals import (
+    classify_sentiment,
+    collect_thread_signals,
+    detect_code_change,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def determine_outcome(signals: dict) -> str:
+    """Apply priority logic to determine the outcome label.
+
+    Priority: actioned > disputed > acknowledged > ignored.
+    """
+    if signals.get("code_changed_near_line"):
+        return "actioned"
+    if signals.get("reply_sentiment") == "negative":
+        return "disputed"
+    if signals.get("developer_replied") and (
+        signals.get("reply_sentiment") == "positive"
+        or signals.get("thread_resolved")
+    ):
+        return "acknowledged"
+    return "ignored"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/outcomes/test_labeler.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Write failing test for label_pr_outcomes**
+
+Add to `tests/outcomes/test_labeler.py`:
+
+```python
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from baloo.db.engine import reset_engine
+from baloo.db.models import Base, Finding, FindingOutcome, Review
+from baloo.outcomes.labeler import label_pr_outcomes
+
+
+@pytest.fixture
+async def db_factory():
+    """In-memory SQLite DB with all tables."""
+    reset_engine()
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    with patch("baloo.outcomes.labeler.get_session_factory", return_value=factory):
+        yield factory
+    await engine.dispose()
+    reset_engine()
+
+
+@pytest.fixture
+async def seeded_db(db_factory):
+    """DB with a review and two findings."""
+    async with db_factory() as session:
+        async with session.begin():
+            review = Review(
+                repo_full_name="owner/repo",
+                pr_number=10,
+                pr_title="Fix auth",
+                review_status="approved",
+                started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                commit_sha="abc123",
+            )
+            session.add(review)
+            await session.flush()
+            session.add(Finding(
+                review_id=review.id,
+                file_path="src/auth.py",
+                line_number=42,
+                severity="HIGH",
+                category="Security",
+                body="SQL injection risk",
+            ))
+            session.add(Finding(
+                review_id=review.id,
+                file_path="src/utils.py",
+                line_number=10,
+                severity="MEDIUM",
+                category="Style",
+                body="Naming convention",
+            ))
+    return db_factory
+
+
+async def test_label_pr_outcomes_creates_rows(seeded_db):
+    """Labels findings and writes outcome rows."""
+    mock_diff = """diff --git a/src/auth.py b/src/auth.py
+--- a/src/auth.py
++++ b/src/auth.py
+@@ -40,5 +40,5 @@ class Auth:
+-    old_vulnerable_code()
++    new_safe_code()"""
+
+    mock_threads = [
+        {
+            "path": "src/auth.py",
+            "line": 42,
+            "is_resolved": True,
+            "comments": [
+                {"author": "baloo[bot]", "body": "SQL injection", "is_baloo": True},
+                {"author": "dev", "body": "fixed, thanks", "is_baloo": False},
+            ],
+        },
+    ]
+
+    with patch(
+        "baloo.outcomes.labeler.fetch_merge_signals",
+        new=AsyncMock(return_value=(mock_diff, mock_threads)),
+    ):
+        await label_pr_outcomes("owner/repo", 10, 12345)
+
+    async with seeded_db() as session:
+        outcomes = (
+            await session.execute(select(FindingOutcome).order_by(FindingOutcome.id))
+        ).scalars().all()
+
+    assert len(outcomes) == 2
+    auth_outcome = next(o for o in outcomes if o.finding_id and "auth" in str(
+        (await _get_finding(seeded_db, o.finding_id))
+    ) or o.outcome == "actioned")
+    # The auth.py finding should be actioned (code changed near line 42)
+    actioned = [o for o in outcomes if o.outcome == "actioned"]
+    ignored = [o for o in outcomes if o.outcome == "ignored"]
+    assert len(actioned) == 1
+    assert len(ignored) == 1
+```
+
+Wait — that test got messy. Let me simplify:
+
+Replace the `test_label_pr_outcomes_creates_rows` test above with:
+
+```python
+async def test_label_pr_outcomes_creates_rows(seeded_db):
+    """Labels findings and writes outcome rows."""
+    mock_diff = """diff --git a/src/auth.py b/src/auth.py
+--- a/src/auth.py
++++ b/src/auth.py
+@@ -40,5 +40,5 @@ class Auth:
+-    old_vulnerable_code()
++    new_safe_code()"""
+
+    mock_threads = [
+        {
+            "path": "src/auth.py",
+            "line": 42,
+            "is_resolved": True,
+            "comments": [
+                {"author": "baloo[bot]", "body": "SQL injection", "is_baloo": True},
+                {"author": "dev", "body": "fixed, thanks", "is_baloo": False},
+            ],
+        },
+    ]
+
+    with patch(
+        "baloo.outcomes.labeler.fetch_merge_signals",
+        new=AsyncMock(return_value=(mock_diff, mock_threads)),
+    ):
+        await label_pr_outcomes("owner/repo", 10, 12345)
+
+    async with seeded_db() as session:
+        outcomes = (
+            await session.execute(
+                select(FindingOutcome).order_by(FindingOutcome.id)
+            )
+        ).scalars().all()
+
+    assert len(outcomes) == 2
+    outcomes_by_label = {o.outcome for o in outcomes}
+    assert "actioned" in outcomes_by_label  # auth.py — code changed near line 42
+    assert "ignored" in outcomes_by_label   # utils.py — no thread, no code change
+
+
+async def test_label_pr_outcomes_skips_when_no_findings(db_factory):
+    """No-op when PR has no findings."""
+    with patch(
+        "baloo.outcomes.labeler.fetch_merge_signals",
+        new=AsyncMock(),
+    ) as mock_fetch:
+        await label_pr_outcomes("owner/repo", 999, 12345)
+
+    mock_fetch.assert_not_called()
+
+
+async def test_label_pr_outcomes_is_idempotent(seeded_db):
+    """Running twice doesn't duplicate rows."""
+    mock_diff = ""
+    mock_threads = []
+
+    with patch(
+        "baloo.outcomes.labeler.fetch_merge_signals",
+        new=AsyncMock(return_value=(mock_diff, mock_threads)),
+    ):
+        await label_pr_outcomes("owner/repo", 10, 12345)
+        await label_pr_outcomes("owner/repo", 10, 12345)
+
+    async with seeded_db() as session:
+        count = (
+            await session.execute(
+                select(func.count(FindingOutcome.id))
+            )
+        ).scalar()
+
+    assert count == 2  # Still 2, not 4
+```
+
+Add this import at the top of the test file:
+
+```python
+from sqlalchemy import func
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `uv run pytest tests/outcomes/test_labeler.py::test_label_pr_outcomes_creates_rows -v`
+Expected: FAIL with `ImportError: cannot import name 'label_pr_outcomes'`
+
+- [ ] **Step 7: Implement label_pr_outcomes and fetch_merge_signals**
+
+Add to `baloo/outcomes/labeler.py`:
+
+```python
+from sqlalchemy import func
+
+from baloo.github.api_client import GitHubAPIClient
+
+
+async def fetch_merge_signals(
+    repo_full_name: str, pr_number: int, installation_id: int
+) -> tuple[str, list[dict]]:
+    """Fetch the diff and review threads for a merged PR.
+
+    Returns:
+        Tuple of (compare_diff, threads) where threads is a list of dicts
+        with keys: path, line, is_resolved, comments.
+    """
+    client = GitHubAPIClient(installation_id)
+
+    # Fetch PR review comments (threads)
+    headers = await client._get_headers()
+    raw_comments = await client._fetch_paginated_json(
+        f"{client.base_url}/repos/{repo_full_name}/pulls/{pr_number}/comments",
+        headers,
+    )
+
+    # Fetch PR diff
+    async with client._http_client() as http:
+        diff_resp = await http.get(
+            f"{client.base_url}/repos/{repo_full_name}/pulls/{pr_number}",
+            headers={**headers, "Accept": "application/vnd.github.v3.diff"},
+        )
+        diff = diff_resp.text if diff_resp.status_code == 200 else ""
+
+    # Fetch resolved thread IDs
+    resolved_ids = await client.fetch_resolved_thread_ids(repo_full_name, pr_number)
+
+    # Group comments into threads (simplified: group by path+line of root comment)
+    threads = []
+    root_comments = {}
+    for c in raw_comments:
+        root_id = c.get("in_reply_to_id") or c["id"]
+        if root_id not in root_comments:
+            root_comments[root_id] = {
+                "path": c.get("path", ""),
+                "line": c.get("original_line") or c.get("line") or 0,
+                "is_resolved": root_id in resolved_ids,
+                "comments": [],
+            }
+        is_baloo = "baloo" in (c.get("user", {}).get("login", "")).lower()
+        root_comments[root_id]["comments"].append({
+            "author": c.get("user", {}).get("login", ""),
+            "body": c.get("body", ""),
+            "is_baloo": is_baloo,
+        })
+
+    threads = list(root_comments.values())
+    return diff, threads
+
+
+def _match_finding_to_thread(
+    finding: Finding, threads: list[dict]
+) -> dict | None:
+    """Find the review thread that matches a finding by file path and line."""
+    for thread in threads:
+        if thread["path"] != finding.file_path:
+            continue
+        if finding.line_number is None:
+            continue
+        if abs(thread["line"] - finding.line_number) <= 5:
+            return thread
+    return None
+
+
+async def label_pr_outcomes(
+    repo_full_name: str, pr_number: int, installation_id: int
+) -> None:
+    """Label all findings for a merged PR with outcome data.
+
+    Fetches the PR diff and threads, then for each finding:
+    1. Checks if code changed near the flagged line
+    2. Checks thread interaction (replies, resolution, sentiment)
+    3. Applies priority logic to determine outcome
+    4. Writes FindingOutcome row (upsert)
+    """
+    settings = get_settings()
+    factory = get_session_factory(settings.database_url)
+
+    # Get all findings for this PR
+    async with factory() as session:
+        result = await session.execute(
+            select(Finding)
+            .join(Review)
+            .where(
+                Review.repo_full_name == repo_full_name,
+                Review.pr_number == pr_number,
+            )
+        )
+        findings = result.scalars().all()
+
+    if not findings:
+        logger.info(f"No findings for {repo_full_name}#{pr_number}, skipping outcome labeling")
+        return
+
+    # Fetch signals from GitHub
+    diff, threads = await fetch_merge_signals(repo_full_name, pr_number, installation_id)
+
+    logger.info(
+        f"Labeling {len(findings)} findings for {repo_full_name}#{pr_number} "
+        f"({len(threads)} threads)"
+    )
+
+    # Label each finding
+    async with factory() as session:
+        async with session.begin():
+            for finding in findings:
+                # Check if outcome already exists (idempotency)
+                existing = (
+                    await session.execute(
+                        select(FindingOutcome).where(
+                            FindingOutcome.finding_id == finding.id
+                        )
+                    )
+                ).scalars().first()
+                if existing:
+                    continue
+
+                # Collect signals
+                code_changed = detect_code_change(
+                    finding.file_path, finding.line_number, diff
+                )
+                thread = _match_finding_to_thread(finding, threads)
+                thread_signals = collect_thread_signals(thread)
+
+                signals = {
+                    "code_changed_near_line": code_changed,
+                    **thread_signals,
+                }
+
+                outcome = determine_outcome(signals)
+
+                session.add(FindingOutcome(
+                    finding_id=finding.id,
+                    review_id=finding.review_id,
+                    repo_full_name=repo_full_name,
+                    pr_number=pr_number,
+                    outcome=outcome,
+                    signals=signals,
+                    labeled_at=datetime.now(timezone.utc),
+                ))
+
+    logger.info(f"Outcome labeling complete for {repo_full_name}#{pr_number}")
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `uv run pytest tests/outcomes/test_labeler.py -v`
+Expected: All PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add baloo/outcomes/labeler.py tests/outcomes/test_labeler.py
+git commit -m "feat: add outcome labeler with priority logic and DB persistence"
+```
+
+---
+
+### Task 4: Webhook Merge Handler
+
+**Files:**
+- Modify: `baloo/github/webhook_handler.py`
+- Create: `tests/outcomes/test_webhook_merge.py`
+
+- [ ] **Step 1: Write failing test for merge event handling**
+
+Create `tests/outcomes/test_webhook_merge.py`:
+
+```python
+"""Tests for PR merge webhook triggering outcome labeling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from baloo.github.webhook_handler import app
+
+
+@pytest.fixture
+def client():
+    test_app = FastAPI()
+    test_app.include_router(app)
+    return TestClient(test_app)
+
+
+def _make_pr_payload(action: str, merged: bool = False) -> dict:
+    return {
+        "action": action,
+        "number": 42,
+        "pull_request": {
+            "number": 42,
+            "title": "Fix auth",
+            "body": "",
+            "state": "closed",
+            "html_url": "https://github.com/owner/repo/pull/42",
+            "user": {"login": "dev", "id": 1},
+            "head": {"sha": "abc123", "ref": "fix/auth"},
+            "base": {"ref": "main"},
+            "merged": merged,
+            "draft": False,
+        },
+        "repository": {"full_name": "owner/repo"},
+        "installation": {"id": 12345},
+        "sender": {"login": "dev", "id": 1},
+    }
+
+
+@patch("baloo.github.webhook_handler.verify_webhook_signature", return_value=True)
+@patch("baloo.github.webhook_handler.label_pr_outcomes", new_callable=AsyncMock)
+def test_merged_pr_triggers_labeling(mock_label, mock_sig, client):
+    """Merged PR triggers outcome labeling."""
+    payload = _make_pr_payload("closed", merged=True)
+    response = client.post(
+        "/webhook",
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request", "X-Hub-Signature-256": "sha256=test"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "labeling_outcomes"
+    mock_label.assert_called_once_with("owner/repo", 42, 12345)
+
+
+@patch("baloo.github.webhook_handler.verify_webhook_signature", return_value=True)
+@patch("baloo.github.webhook_handler.label_pr_outcomes", new_callable=AsyncMock)
+def test_closed_not_merged_skips_labeling(mock_label, mock_sig, client):
+    """Closed but not merged PR does not trigger labeling."""
+    payload = _make_pr_payload("closed", merged=False)
+    response = client.post(
+        "/webhook",
+        json=payload,
+        headers={"X-GitHub-Event": "pull_request", "X-Hub-Signature-256": "sha256=test"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+    mock_label.assert_not_called()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/outcomes/test_webhook_merge.py -v`
+Expected: FAIL (either import error for `label_pr_outcomes` in webhook handler or assertion error)
+
+- [ ] **Step 3: Add merge handler to webhook_handler.py**
+
+In `baloo/github/webhook_handler.py`, add import at the top:
+
+```python
+from baloo.outcomes.labeler import label_pr_outcomes
+```
+
+Then add a new branch inside the `if event == "pull_request":` block, after the existing `if action in [...]` block and before the `else` at line 384. Insert between lines 383 and 384:
+
+```python
+            elif action == "closed":
+                if webhook_payload.pull_request.merged:
+                    logger.info(
+                        f"PR merged: {repo_name}#{pr_number}, triggering outcome labeling"
+                    )
+                    asyncio.create_task(
+                        label_pr_outcomes(repo_name, pr_number, webhook_payload.installation.id)
+                    )
+                    background_tasks.add_task(lambda: None)
+                    return {"status": "labeling_outcomes", "pr": pr_number}
+                else:
+                    logger.info(f"PR closed without merge: {repo_name}#{pr_number}")
+                    return {"status": "ignored", "action": "closed", "reason": "not merged"}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/outcomes/test_webhook_merge.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run existing webhook tests to check for regressions**
+
+Run: `uv run pytest tests/github/test_webhook_handler.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add baloo/github/webhook_handler.py tests/outcomes/test_webhook_merge.py
+git commit -m "feat: trigger outcome labeling on PR merge"
+```
+
+---
+
+### Task 5: Dashboard Queries
+
+**Files:**
+- Modify: `baloo/dashboard/queries.py`
+
+- [ ] **Step 1: Write failing test for get_outcomes_data**
+
+Create `tests/dashboard/test_outcomes_page.py`:
+
+```python
+"""Tests for the outcomes dashboard page."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from baloo.dashboard.auth import verify_credentials
+from baloo.dashboard.queries import DashboardService
+from baloo.dashboard.router import router
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[verify_credentials] = lambda: "tester"
+    return app
+
+
+async def test_get_outcomes_data_returns_expected_keys():
+    """DashboardService.get_outcomes_data returns all required keys."""
+    data = None
+    with patch(
+        "baloo.dashboard.queries.get_session_factory",
+    ) as mock_factory:
+        # We'll test the actual query in integration; here just check it exists
+        try:
+            data = await DashboardService.get_outcomes_data()
+        except Exception:
+            pass
+
+    # If we got here without ImportError/AttributeError, the method exists
+    # Full query testing happens against a real DB
+    assert hasattr(DashboardService, "get_outcomes_data")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/dashboard/test_outcomes_page.py::test_get_outcomes_data_returns_expected_keys -v`
+Expected: FAIL with `AttributeError: type object 'DashboardService' has no attribute 'get_outcomes_data'`
+
+- [ ] **Step 3: Implement get_outcomes_data**
+
+Add to `baloo/dashboard/queries.py`:
+
+Import `FindingOutcome` at the top:
+```python
+from baloo.db.models import Finding, FindingOutcome, Review, ReviewLog
+```
+
+Add this method to `DashboardService`:
+
+```python
+    @staticmethod
+    async def get_outcomes_data(
+        days: int = 90,
+        repo_filter: str | None = None,
+    ) -> dict:
+        settings = get_settings()
+        factory = get_session_factory(settings.database_url)
+
+        async with factory() as session:
+            since = datetime.now(timezone.utc) - timedelta(days=days)
+
+            # Base filter
+            base_filter = [FindingOutcome.labeled_at >= since]
+            if repo_filter:
+                base_filter.append(FindingOutcome.repo_full_name == repo_filter)
+
+            # Total outcomes by label
+            outcome_rows = (
+                await session.execute(
+                    select(FindingOutcome.outcome, func.count(FindingOutcome.id))
+                    .where(*base_filter)
+                    .group_by(FindingOutcome.outcome)
+                )
+            ).all()
+            outcomes = {r[0]: r[1] for r in outcome_rows}
+            total = sum(outcomes.values())
+
+            actioned = outcomes.get("actioned", 0)
+            disputed = outcomes.get("disputed", 0)
+            ignored = outcomes.get("ignored", 0)
+            hit_rate = round(actioned / total * 100, 1) if total else 0.0
+            noise_rate = round((disputed + ignored) / total * 100, 1) if total else 0.0
+
+            # By severity
+            severity_rows = (
+                await session.execute(
+                    select(
+                        Finding.severity,
+                        FindingOutcome.outcome,
+                        func.count(FindingOutcome.id),
+                    )
+                    .join(Finding, FindingOutcome.finding_id == Finding.id)
+                    .where(*base_filter)
+                    .group_by(Finding.severity, FindingOutcome.outcome)
+                )
+            ).all()
+            severity_data = {}
+            for sev, outcome, count in severity_rows:
+                if sev not in severity_data:
+                    severity_data[sev] = {"total": 0, "actioned": 0}
+                severity_data[sev]["total"] += count
+                if outcome == "actioned":
+                    severity_data[sev]["actioned"] += count
+            for sev in severity_data:
+                t = severity_data[sev]["total"]
+                a = severity_data[sev]["actioned"]
+                severity_data[sev]["hit_rate"] = round(a / t * 100, 1) if t else 0.0
+
+            # By category
+            category_rows = (
+                await session.execute(
+                    select(
+                        Finding.category,
+                        FindingOutcome.outcome,
+                        func.count(FindingOutcome.id),
+                    )
+                    .join(Finding, FindingOutcome.finding_id == Finding.id)
+                    .where(*base_filter)
+                    .group_by(Finding.category, FindingOutcome.outcome)
+                )
+            ).all()
+            category_data = {}
+            for cat, outcome, count in category_rows:
+                if cat not in category_data:
+                    category_data[cat] = {"total": 0, "actioned": 0}
+                category_data[cat]["total"] += count
+                if outcome == "actioned":
+                    category_data[cat]["actioned"] += count
+            for cat in category_data:
+                t = category_data[cat]["total"]
+                a = category_data[cat]["actioned"]
+                category_data[cat]["hit_rate"] = round(a / t * 100, 1) if t else 0.0
+
+            # Weekly trends
+            if "postgres" in settings.database_url:
+                week_label = func.to_char(
+                    func.date_trunc("week", FindingOutcome.labeled_at), "YYYY-MM-DD"
+                )
+            else:
+                week_label = func.strftime("%Y-%W", FindingOutcome.labeled_at)
+
+            weekly_rows = (
+                await session.execute(
+                    select(
+                        week_label.label("week"),
+                        FindingOutcome.outcome,
+                        func.count(FindingOutcome.id),
+                    )
+                    .where(*base_filter)
+                    .group_by("week", FindingOutcome.outcome)
+                    .order_by("week")
+                )
+            ).all()
+            weekly = {}
+            for week, outcome, count in weekly_rows:
+                if week not in weekly:
+                    weekly[week] = {"total": 0, "actioned": 0, "disputed": 0, "ignored": 0}
+                weekly[week]["total"] += count
+                if outcome in weekly[week]:
+                    weekly[week][outcome] += count
+            trends = []
+            for week, data in weekly.items():
+                t = data["total"]
+                trends.append({
+                    "week": week,
+                    "total": t,
+                    "hit_rate": round(data["actioned"] / t * 100, 1) if t else 0.0,
+                    "noise_rate": round(
+                        (data["disputed"] + data["ignored"]) / t * 100, 1
+                    ) if t else 0.0,
+                })
+
+            # Repos for filter dropdown
+            repos = (
+                (
+                    await session.execute(
+                        select(FindingOutcome.repo_full_name)
+                        .distinct()
+                        .order_by(FindingOutcome.repo_full_name)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        return {
+            "total": total,
+            "outcomes": outcomes,
+            "hit_rate": hit_rate,
+            "noise_rate": noise_rate,
+            "severity_data": severity_data,
+            "category_data": category_data,
+            "trends": trends,
+            "repos": repos,
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/dashboard/test_outcomes_page.py::test_get_outcomes_data_returns_expected_keys -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add baloo/dashboard/queries.py tests/dashboard/test_outcomes_page.py
+git commit -m "feat: add outcomes queries to DashboardService"
+```
+
+---
+
+### Task 6: Dashboard Route + Template
+
+**Files:**
+- Modify: `baloo/dashboard/router.py`
+- Modify: `baloo/dashboard/templates/base.html`
+- Create: `baloo/dashboard/templates/outcomes.html`
+- Modify: `tests/dashboard/test_outcomes_page.py`
+
+- [ ] **Step 1: Write failing test for outcomes route**
+
+Add to `tests/dashboard/test_outcomes_page.py`:
+
+```python
+def test_outcomes_page_renders():
+    app = _build_app()
+    mock_data = {
+        "total": 50,
+        "outcomes": {"actioned": 20, "disputed": 5, "acknowledged": 10, "ignored": 15},
+        "hit_rate": 40.0,
+        "noise_rate": 40.0,
+        "severity_data": {
+            "HIGH": {"total": 20, "actioned": 15, "hit_rate": 75.0},
+            "MEDIUM": {"total": 30, "actioned": 5, "hit_rate": 16.7},
+        },
+        "category_data": {
+            "Security": {"total": 15, "actioned": 12, "hit_rate": 80.0},
+            "Style": {"total": 20, "actioned": 2, "hit_rate": 10.0},
+        },
+        "trends": [
+            {"week": "2026-16", "total": 25, "hit_rate": 44.0, "noise_rate": 36.0},
+            {"week": "2026-17", "total": 25, "hit_rate": 36.0, "noise_rate": 44.0},
+        ],
+        "repos": ["owner/repo-a", "owner/repo-b"],
+    }
+
+    with patch(
+        "baloo.dashboard.router.DashboardService.get_outcomes_data",
+        new=AsyncMock(return_value=mock_data),
+    ):
+        client = TestClient(app)
+        response = client.get("/dashboard/outcomes")
+
+    assert response.status_code == 200
+    assert "Outcomes" in response.text
+    assert "40.0" in response.text  # hit_rate
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/dashboard/test_outcomes_page.py::test_outcomes_page_renders -v`
+Expected: FAIL (404 — route doesn't exist yet)
+
+- [ ] **Step 3: Add route to router.py**
+
+Add to `baloo/dashboard/router.py`:
+
+```python
+@router.get("/outcomes", response_class=HTMLResponse)
+async def outcomes(
+    request: Request,
+    days: int = Query(90, ge=1, le=365),
+    repo: str | None = Query(None),
+):
+    data = await DashboardService.get_outcomes_data(days=days, repo_filter=repo)
+    return templates.TemplateResponse(
+        request=request,
+        name="outcomes.html",
+        context={"days": days, "repo": repo, **data},
+    )
+```
+
+- [ ] **Step 4: Add nav link to base.html**
+
+In `baloo/dashboard/templates/base.html`, after the Analytics nav link (line 31), add:
+
+```html
+          <a href="/dashboard/outcomes"
+             class="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium
+                    {% if active_page == 'outcomes' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{% endif %}">
+            Outcomes
+          </a>
+```
+
+- [ ] **Step 5: Create outcomes.html template**
+
+Create `baloo/dashboard/templates/outcomes.html`:
+
+```html
+{% extends "base.html" %}
+{% set active_page = "outcomes" %}
+
+{% block title %}Outcomes - Baloo Dashboard{% endblock %}
+
+{% block content %}
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold text-gray-900">Finding Outcomes</h1>
+
+  <div class="flex items-center space-x-4">
+    <!-- Repo filter -->
+    <form class="flex items-center space-x-2">
+      <input type="hidden" name="days" value="{{ days }}">
+      <select name="repo" onchange="this.form.submit()"
+              class="text-sm border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500">
+        <option value="">All repos</option>
+        {% for r in repos %}
+        <option value="{{ r }}" {% if repo == r %}selected{% endif %}>{{ r }}</option>
+        {% endfor %}
+      </select>
+    </form>
+
+    <!-- Day range selector -->
+    <div class="flex items-center space-x-2">
+      <label class="text-sm text-gray-500">Range:</label>
+      {% for d in [30, 60, 90, 180, 365] %}
+      <a href="/dashboard/outcomes?days={{ d }}{% if repo %}&repo={{ repo }}{% endif %}"
+         class="px-3 py-1 text-sm rounded border {% if days == d %}bg-indigo-600 text-white border-indigo-600{% else %}hover:bg-gray-50{% endif %}">
+        {{ d }}d
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+
+<!-- Summary cards -->
+<div class="grid grid-cols-1 sm:grid-cols-4 gap-4 mb-6">
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Total Findings</p>
+    <p class="text-3xl font-bold text-gray-900">{{ total }}</p>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Hit Rate</p>
+    <p class="text-3xl font-bold {% if hit_rate >= 50 %}text-green-600{% elif hit_rate >= 25 %}text-yellow-600{% else %}text-red-600{% endif %}">{{ hit_rate }}%</p>
+    <p class="text-xs text-gray-400">actioned / total</p>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Noise Rate</p>
+    <p class="text-3xl font-bold {% if noise_rate <= 30 %}text-green-600{% elif noise_rate <= 60 %}text-yellow-600{% else %}text-red-600{% endif %}">{{ noise_rate }}%</p>
+    <p class="text-xs text-gray-400">(disputed + ignored) / total</p>
+  </div>
+  <div class="bg-white rounded-lg shadow p-5">
+    <p class="text-sm text-gray-500">Outcome Breakdown</p>
+    <div class="flex items-center space-x-2 mt-1">
+      <span class="text-xs px-2 py-0.5 rounded bg-green-100 text-green-800">{{ outcomes.get('actioned', 0) }} actioned</span>
+      <span class="text-xs px-2 py-0.5 rounded bg-blue-100 text-blue-800">{{ outcomes.get('acknowledged', 0) }} ack'd</span>
+    </div>
+    <div class="flex items-center space-x-2 mt-1">
+      <span class="text-xs px-2 py-0.5 rounded bg-red-100 text-red-800">{{ outcomes.get('disputed', 0) }} disputed</span>
+      <span class="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-800">{{ outcomes.get('ignored', 0) }} ignored</span>
+    </div>
+  </div>
+</div>
+
+<!-- Charts + Tables -->
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+  <!-- Hit rate by severity -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Hit Rate by Severity</h2>
+    <canvas id="severityHitChart" height="250"></canvas>
+  </div>
+
+  <!-- Hit rate by category -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Hit Rate by Category</h2>
+    <canvas id="categoryHitChart" height="250"></canvas>
+  </div>
+
+  <!-- Trends chart -->
+  <div class="bg-white rounded-lg shadow p-5 lg:col-span-2">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Weekly Trends</h2>
+    <canvas id="trendsChart" height="200"></canvas>
+  </div>
+</div>
+
+<!-- Outcome distribution doughnut -->
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Outcome Distribution</h2>
+    <canvas id="outcomeChart" height="250"></canvas>
+  </div>
+
+  <!-- Category table -->
+  <div class="bg-white rounded-lg shadow p-5">
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Category Details</h2>
+    <table class="min-w-full text-sm">
+      <thead>
+        <tr class="border-b">
+          <th class="text-left py-2">Category</th>
+          <th class="text-right py-2">Total</th>
+          <th class="text-right py-2">Actioned</th>
+          <th class="text-right py-2">Hit Rate</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for cat, data in category_data.items() | sort(attribute='1.hit_rate', reverse=true) %}
+        <tr class="border-b">
+          <td class="py-2">{{ cat }}</td>
+          <td class="text-right">{{ data.total }}</td>
+          <td class="text-right">{{ data.actioned }}</td>
+          <td class="text-right font-medium {% if data.hit_rate >= 50 %}text-green-600{% elif data.hit_rate >= 25 %}text-yellow-600{% else %}text-red-600{% endif %}">
+            {{ data.hit_rate }}%
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script>
+  const outcomes = {{ (outcomes or {}) | tojson }};
+  const severityData = {{ (severity_data or {}) | tojson }};
+  const categoryData = {{ (category_data or {}) | tojson }};
+  const trends = {{ (trends or []) | tojson }};
+
+  // Outcome doughnut
+  const outcomeColors = {
+    actioned: '#22c55e', acknowledged: '#3b82f6',
+    disputed: '#ef4444', ignored: '#9ca3af'
+  };
+  new Chart(document.getElementById('outcomeChart'), {
+    type: 'doughnut',
+    data: {
+      labels: Object.keys(outcomes),
+      datasets: [{
+        data: Object.values(outcomes),
+        backgroundColor: Object.keys(outcomes).map(k => outcomeColors[k] || '#6b7280'),
+      }]
+    },
+    options: { responsive: true }
+  });
+
+  // Severity hit rate bar
+  const sevOrder = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'];
+  const sevColors = { CRITICAL: '#dc2626', HIGH: '#f97316', MEDIUM: '#eab308', LOW: '#3b82f6' };
+  new Chart(document.getElementById('severityHitChart'), {
+    type: 'bar',
+    data: {
+      labels: sevOrder.filter(s => severityData[s]),
+      datasets: [{
+        label: 'Hit Rate %',
+        data: sevOrder.filter(s => severityData[s]).map(s => severityData[s].hit_rate),
+        backgroundColor: sevOrder.filter(s => severityData[s]).map(s => sevColors[s]),
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: { y: { beginAtZero: true, max: 100 } }
+    }
+  });
+
+  // Category hit rate horizontal bar
+  const catNames = Object.keys(categoryData).sort((a, b) => categoryData[b].hit_rate - categoryData[a].hit_rate);
+  new Chart(document.getElementById('categoryHitChart'), {
+    type: 'bar',
+    data: {
+      labels: catNames,
+      datasets: [{
+        label: 'Hit Rate %',
+        data: catNames.map(c => categoryData[c].hit_rate),
+        backgroundColor: '#6366f1',
+      }]
+    },
+    options: {
+      responsive: true,
+      indexAxis: 'y',
+      plugins: { legend: { display: false } },
+      scales: { x: { beginAtZero: true, max: 100 } }
+    }
+  });
+
+  // Weekly trends line chart
+  new Chart(document.getElementById('trendsChart'), {
+    type: 'line',
+    data: {
+      labels: trends.map(t => t.week),
+      datasets: [
+        {
+          label: 'Hit Rate %',
+          data: trends.map(t => t.hit_rate),
+          borderColor: '#22c55e',
+          backgroundColor: 'rgba(34,197,94,0.1)',
+          fill: true,
+          tension: 0.3,
+        },
+        {
+          label: 'Noise Rate %',
+          data: trends.map(t => t.noise_rate),
+          borderColor: '#ef4444',
+          backgroundColor: 'rgba(239,68,68,0.1)',
+          fill: true,
+          tension: 0.3,
+        },
+        {
+          label: 'Volume',
+          data: trends.map(t => t.total),
+          borderColor: '#6366f1',
+          borderDash: [5, 5],
+          fill: false,
+          tension: 0.3,
+          yAxisID: 'y1',
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: { beginAtZero: true, max: 100, title: { display: true, text: '%' } },
+        y1: { beginAtZero: true, position: 'right', grid: { drawOnChartArea: false }, title: { display: true, text: 'Findings' } }
+      }
+    }
+  });
+</script>
+{% endblock %}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `uv run pytest tests/dashboard/test_outcomes_page.py::test_outcomes_page_renders -v`
+Expected: PASS
+
+- [ ] **Step 7: Run all dashboard tests**
+
+Run: `uv run pytest tests/dashboard/ -v`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add baloo/dashboard/router.py baloo/dashboard/templates/base.html baloo/dashboard/templates/outcomes.html tests/dashboard/test_outcomes_page.py
+git commit -m "feat: add outcomes dashboard page with charts and filters"
+```
+
+---
+
+### Task 7: Integration Test + Full Suite
+
+**Files:**
+- All test files
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `uv run pytest --cov=baloo -v`
+Expected: All tests PASS, no regressions
+
+- [ ] **Step 2: Run linter and formatter**
+
+Run: `uv run ruff check baloo tests && uv run black baloo tests`
+Expected: Clean output (or auto-fixed formatting)
+
+- [ ] **Step 3: Fix any issues found**
+
+Address any linting or test failures.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: fix lint and formatting for outcomes feature"
+```
+
+---
+
+### Task 8: Backfill Script (separate branch, not merged)
+
+**Files:**
+- Create: `scripts/backfill_outcomes.py`
+
+- [ ] **Step 1: Create a new branch**
+
+```bash
+git checkout -b tool/backfill-outcomes
+```
+
+- [ ] **Step 2: Write the backfill script**
+
+Create `scripts/backfill_outcomes.py`:
+
+```python
+"""One-time backfill script to label outcomes for already-merged PRs.
+
+Usage:
+    uv run python scripts/backfill_outcomes.py [--dry-run] [--limit N]
+
+NOT intended to be merged into main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import time
+
+from sqlalchemy import distinct, func, select
+
+from baloo.config.settings import get_settings
+from baloo.db.engine import get_session_factory
+from baloo.db.models import Finding, FindingOutcome, Review
+from baloo.outcomes.labeler import label_pr_outcomes
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+async def get_merged_prs_with_findings(limit: int | None = None) -> list[dict]:
+    """Get all merged PRs that have findings but no outcomes yet."""
+    settings = get_settings()
+    factory = get_session_factory(settings.database_url)
+
+    async with factory() as session:
+        # Find PRs with findings that don't have outcomes
+        subq = (
+            select(distinct(FindingOutcome.review_id))
+        ).scalar_subquery()
+
+        q = (
+            select(
+                Review.repo_full_name,
+                Review.pr_number,
+                Review.id.label("review_id"),
+                func.count(Finding.id).label("finding_count"),
+            )
+            .join(Finding, Review.id == Finding.review_id)
+            .where(
+                Review.review_status.in_(["approved", "commented", "changes_requested"]),
+                Review.id.notin_(subq),
+            )
+            .group_by(Review.repo_full_name, Review.pr_number, Review.id)
+            .order_by(Review.started_at.asc())
+        )
+        if limit:
+            q = q.limit(limit)
+
+        rows = (await session.execute(q)).all()
+
+    return [
+        {
+            "repo": r.repo_full_name,
+            "pr_number": r.pr_number,
+            "review_id": r.review_id,
+            "finding_count": r.finding_count,
+        }
+        for r in rows
+    ]
+
+
+async def main(dry_run: bool = False, limit: int | None = None):
+    prs = await get_merged_prs_with_findings(limit=limit)
+    total = len(prs)
+    logger.info(f"Found {total} PRs to backfill")
+
+    if dry_run:
+        for pr in prs:
+            logger.info(f"  [dry-run] {pr['repo']}#{pr['pr_number']} ({pr['finding_count']} findings)")
+        return
+
+    # Note: installation_id is needed for GitHub API access.
+    # For backfill, you'll need to provide this from your app's config.
+    from baloo.config.settings import get_settings
+    settings = get_settings()
+    installation_id = settings.github_app_installation_id
+
+    for i, pr in enumerate(prs, 1):
+        logger.info(f"[{i}/{total}] Labeling {pr['repo']}#{pr['pr_number']} ({pr['finding_count']} findings)")
+        try:
+            await label_pr_outcomes(pr["repo"], pr["pr_number"], installation_id)
+        except Exception as e:
+            logger.error(f"  Failed: {e}")
+            continue
+
+        # Rate limit: 1 second between PRs to avoid GitHub API limits
+        if i < total:
+            time.sleep(1)
+
+    logger.info(f"Backfill complete: {total} PRs processed")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Backfill finding outcomes")
+    parser.add_argument("--dry-run", action="store_true", help="List PRs without labeling")
+    parser.add_argument("--limit", type=int, default=None, help="Max PRs to process")
+    args = parser.parse_args()
+
+    asyncio.run(main(dry_run=args.dry_run, limit=args.limit))
+```
+
+- [ ] **Step 3: Commit on the backfill branch**
+
+```bash
+git add scripts/backfill_outcomes.py
+git commit -m "tool: add backfill script for finding outcomes (not for merge)"
+```
+
+- [ ] **Step 4: Switch back to feature branch**
+
+```bash
+git checkout -
+```

--- a/docs/superpowers/specs/2026-04-25-finding-outcomes-design.md
+++ b/docs/superpowers/specs/2026-04-25-finding-outcomes-design.md
@@ -1,0 +1,142 @@
+# Finding Outcomes: Learning from Past Reviews
+
+## Overview
+
+Add outcome tracking to Baloo findings so we can measure review quality over time. When a PR is merged, label each finding with an outcome based on what happened: was the code changed, did the developer reply, did they dispute it, or was it ignored?
+
+This is the measurement layer. No changes to the review pipeline — just data collection and reporting. Future work (prompt tuning, per-repo optimization) builds on this data.
+
+## Scope
+
+- **Forward capture** (production feature): On PR merge, label all findings for that PR. CLI reports for querying outcomes.
+- **Backfill script** (throwaway, not merged): One-time script to label findings on already-merged PRs.
+
+## Outcome Schema
+
+New table `finding_outcomes`:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | PK (UUID) | |
+| `finding_id` | FK -> findings | |
+| `review_id` | FK -> reviews | Denormalized for easy querying |
+| `repo_full_name` | text | |
+| `pr_number` | int | |
+| `outcome` | enum | `actioned`, `disputed`, `acknowledged`, `ignored` |
+| `signals` | jsonb | Raw signal data for future reinterpretation |
+| `labeled_at` | timestamp | When labeling ran |
+
+### Outcome Labels
+
+Single label per finding. When multiple signals are present, highest-priority label wins:
+
+1. **`actioned`** — Code near the flagged line changed in a subsequent commit
+2. **`disputed`** — Developer replied negatively ("false positive", "intentional", "disagree")
+3. **`acknowledged`** — Developer replied positively ("good catch", "thanks") without code change
+4. **`ignored`** — No reply, no code change
+
+### Signals (jsonb)
+
+Raw data preserved for future reinterpretation:
+
+```json
+{
+  "code_changed_near_line": true,
+  "thread_resolved": true,
+  "developer_replied": true,
+  "reply_sentiment": "positive",
+  "reply_text": "good catch, fixed"
+}
+```
+
+## Signal Collection
+
+On PR merge, for each finding:
+
+### Code Change Detection
+
+- Compare the diff between the commit Baloo reviewed and the final merge commit
+- If lines within +/-5 range of the flagged line were modified in a later commit, `code_changed_near_line: true`
+
+### Thread Interaction
+
+- Fetch PR review threads from GitHub API (reuse existing `get_pr_context` logic)
+- Match each finding to its posted comment via file path and line number
+- Check: was there a developer reply? Is the thread resolved?
+
+### Reply Sentiment
+
+Simple keyword matching (no LLM for v1):
+
+- **Positive**: "fixed", "good catch", "thanks", "done", "resolved"
+- **Negative**: "false positive", "intentional", "disagree", "not a bug", "by design"
+- **Neutral**: Any other reply
+
+## Merge Event Handler
+
+### Webhook Integration
+
+Add a `closed` action branch in `webhook_handler.py` (line 285). The app already receives `pull_request` events — no GitHub App configuration changes needed.
+
+When `action == "closed"` and `pull_request.merged == true`:
+- Trigger `label_pr_outcomes(repo_name, pr_number, installation_id)` as a background task
+
+### Labeling Function
+
+`label_pr_outcomes(repo_name, pr_number, installation_id)`:
+
+1. Query all findings for the PR from the DB
+2. If none, skip (PR was never reviewed by Baloo)
+3. Fetch PR threads and final diff via `GitHubAPIClient`
+4. For each finding, collect signals and apply priority logic to determine outcome
+5. Write `finding_outcomes` rows (upsert for idempotency)
+
+## Dashboard Page
+
+New page at `/dashboard/outcomes` in the existing Jinja2 + HTMX + Chart.js dashboard.
+
+### Queries
+
+Add outcome queries to `DashboardService` in `baloo/dashboard/queries.py`.
+
+### Views
+
+**Overview section** — Stat cards:
+- Total findings with outcomes, breakdown by outcome (actioned/disputed/acknowledged/ignored)
+- Hit rate: `actioned / total`
+- Noise rate: `(disputed + ignored) / total`
+
+**By severity & category** — Table or bar chart:
+- Hit rate per severity level (Critical, High, Medium)
+- Hit rate per category (e.g., Security: 85%, Style: 12%)
+
+**Trends** — Chart.js time-series (weekly/monthly buckets):
+- Hit rate trend
+- Noise rate trend
+- Volume trend (findings per review)
+
+**Repo filter** — Dropdown to scope all views to a specific repo (reuse existing repo filter pattern from `/dashboard/reviews`)
+
+### Template
+
+`baloo/dashboard/templates/outcomes.html` extending `base.html`, following the same patterns as `analytics.html`.
+
+## Backfill Script (separate branch, not merged)
+
+Standalone script:
+
+- Queries all merged PRs from `reviews` table that have findings
+- Runs the same labeling logic as forward capture
+- Rate-limited GitHub API calls
+- Progress output
+- Idempotent (safe to re-run)
+- Lives on its own branch, not merged into main
+
+## Future Work (out of scope)
+
+These build on the outcome data but are not part of this spec:
+
+- **Prompt injection**: Feed historical patterns into the agent prompt ("style nits rarely actioned in this repo")
+- **Post-review filter**: Suppress findings matching high-FP patterns
+- **Per-repo optimization**: Tune review behavior based on repo-specific outcome data
+- **Per-contributor optimization**: Adjust based on individual developer patterns

--- a/tests/dashboard/test_outcomes_page.py
+++ b/tests/dashboard/test_outcomes_page.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch  # noqa: F401 – used by Task 6 tests below
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient  # noqa: F401 – used by Task 6 tests below
+
+from baloo.dashboard.auth import verify_credentials
+from baloo.dashboard.queries import DashboardService
+from baloo.dashboard.router import router
+
+
+def test_get_outcomes_data_method_exists():
+    assert hasattr(DashboardService, "get_outcomes_data")
+    assert callable(DashboardService.get_outcomes_data)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[verify_credentials] = lambda: "tester"
+    return app

--- a/tests/dashboard/test_outcomes_page.py
+++ b/tests/dashboard/test_outcomes_page.py
@@ -20,3 +20,37 @@ def _build_app() -> FastAPI:
     app.include_router(router)
     app.dependency_overrides[verify_credentials] = lambda: "tester"
     return app
+
+
+def test_outcomes_page_renders():
+    app = _build_app()
+    mock_data = {
+        "total": 50,
+        "outcomes": {"actioned": 20, "disputed": 5, "acknowledged": 10, "ignored": 15},
+        "hit_rate": 40.0,
+        "noise_rate": 40.0,
+        "severity_data": {
+            "HIGH": {"total": 20, "actioned": 15, "hit_rate": 75.0},
+            "MEDIUM": {"total": 30, "actioned": 5, "hit_rate": 16.7},
+        },
+        "category_data": {
+            "Security": {"total": 15, "actioned": 12, "hit_rate": 80.0},
+            "Style": {"total": 20, "actioned": 2, "hit_rate": 10.0},
+        },
+        "trends": [
+            {"week": "2026-16", "total": 25, "hit_rate": 44.0, "noise_rate": 36.0},
+            {"week": "2026-17", "total": 25, "hit_rate": 36.0, "noise_rate": 44.0},
+        ],
+        "repos": ["owner/repo-a", "owner/repo-b"],
+    }
+
+    with patch(
+        "baloo.dashboard.router.DashboardService.get_outcomes_data",
+        new=AsyncMock(return_value=mock_data),
+    ):
+        client = TestClient(app)
+        response = client.get("/dashboard/outcomes")
+
+    assert response.status_code == 200
+    assert "Outcomes" in response.text
+    assert "40.0" in response.text  # hit_rate

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from baloo.db.models import Base, Finding, Review, ReviewLog
+from baloo.db.models import Base, Finding, FindingOutcome, Review, ReviewLog
 
 
 @pytest.fixture
@@ -157,6 +157,21 @@ def test_review_log_model_fields():
         "raw_text",
         "metadata_json",
     }
+
+
+def test_finding_outcome_model_exists():
+    """FindingOutcome has expected columns."""
+    outcome = FindingOutcome(
+        finding_id=1,
+        review_id=1,
+        repo_full_name="owner/repo",
+        pr_number=42,
+        outcome="actioned",
+        signals={"code_changed_near_line": True},
+    )
+    assert outcome.outcome == "actioned"
+    assert outcome.signals == {"code_changed_near_line": True}
+    assert outcome.repo_full_name == "owner/repo"
 
 
 async def test_review_optional_fields(async_session: AsyncSession):

--- a/tests/github/test_discussions.py
+++ b/tests/github/test_discussions.py
@@ -118,6 +118,66 @@ def test_build_discussion_digest_counts_awaiting_threads():
     assert "@reviewer" in digest
 
 
+def test_declined_thread_treated_as_resolved():
+    """A thread where the developer declines should be treated as resolved."""
+    raw_comments = [
+        {
+            "id": 20,
+            "body": "🐻 Baloo: SQL injection risk",
+            "user": {"login": "baloo-reviewer[bot]"},
+            "created_at": "2025-02-14T10:00:00Z",
+            "updated_at": "2025-02-14T10:00:00Z",
+            "path": "src/auth.py",
+            "line": 42,
+        },
+        {
+            "id": 21,
+            "in_reply_to_id": 20,
+            "body": "Declined — this is intentional, the input is already sanitized upstream.",
+            "user": {"login": "dev-user"},
+            "created_at": "2025-02-14T11:00:00Z",
+            "updated_at": "2025-02-14T11:00:00Z",
+            "path": "src/auth.py",
+            "line": 42,
+        },
+    ]
+
+    threads = build_review_threads(raw_comments)
+    assert len(threads) == 1
+    thread = threads[0]
+    assert thread.is_baloo_thread is True
+    assert thread.awaiting_response is False
+    assert thread.resolved is True  # decline keywords should resolve the thread
+
+
+def test_false_positive_reply_treated_as_resolved():
+    """A 'false positive' reply should resolve the thread."""
+    raw_comments = [
+        {
+            "id": 30,
+            "body": "Possible null pointer",
+            "user": {"login": "baloo-reviewer[bot]"},
+            "created_at": "2025-02-14T10:00:00Z",
+            "updated_at": "2025-02-14T10:00:00Z",
+            "path": "src/utils.py",
+            "line": 10,
+        },
+        {
+            "id": 31,
+            "in_reply_to_id": 30,
+            "body": "This is a false positive — the value is guaranteed non-null by the caller.",
+            "user": {"login": "dev-user"},
+            "created_at": "2025-02-14T11:00:00Z",
+            "updated_at": "2025-02-14T11:00:00Z",
+            "path": "src/utils.py",
+            "line": 10,
+        },
+    ]
+
+    threads = build_review_threads(raw_comments)
+    assert threads[0].resolved is True
+
+
 def test_build_general_discussion_includes_reviews():
     """Review bodies should be surfaced alongside issue comments."""
     issue_comments = [

--- a/tests/github/test_discussions.py
+++ b/tests/github/test_discussions.py
@@ -118,8 +118,8 @@ def test_build_discussion_digest_counts_awaiting_threads():
     assert "@reviewer" in digest
 
 
-def test_declined_thread_treated_as_resolved():
-    """A thread where the developer declines should be treated as resolved."""
+def test_developer_reply_not_resolved_not_awaiting():
+    """A thread where the developer replied (but didn't 'fix') is not resolved and not awaiting."""
     raw_comments = [
         {
             "id": 20,
@@ -147,35 +147,9 @@ def test_declined_thread_treated_as_resolved():
     thread = threads[0]
     assert thread.is_baloo_thread is True
     assert thread.awaiting_response is False
-    assert thread.resolved is True  # decline keywords should resolve the thread
-
-
-def test_false_positive_reply_treated_as_resolved():
-    """A 'false positive' reply should resolve the thread."""
-    raw_comments = [
-        {
-            "id": 30,
-            "body": "Possible null pointer",
-            "user": {"login": "baloo-reviewer[bot]"},
-            "created_at": "2025-02-14T10:00:00Z",
-            "updated_at": "2025-02-14T10:00:00Z",
-            "path": "src/utils.py",
-            "line": 10,
-        },
-        {
-            "id": 31,
-            "in_reply_to_id": 30,
-            "body": "This is a false positive — the value is guaranteed non-null by the caller.",
-            "user": {"login": "dev-user"},
-            "created_at": "2025-02-14T11:00:00Z",
-            "updated_at": "2025-02-14T11:00:00Z",
-            "path": "src/utils.py",
-            "line": 10,
-        },
-    ]
-
-    threads = build_review_threads(raw_comments)
-    assert threads[0].resolved is True
+    # Not resolved — developer responded but didn't use resolution keywords.
+    # The webhook handler skips these threads (not re-reviewed).
+    assert thread.resolved is False
 
 
 def test_build_general_discussion_includes_reviews():

--- a/tests/outcomes/test_labeler.py
+++ b/tests/outcomes/test_labeler.py
@@ -1,0 +1,236 @@
+"""Tests for outcome labeler."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from baloo.db.engine import reset_engine
+from baloo.db.models import Base, Finding, FindingOutcome, Review
+from baloo.outcomes.labeler import determine_outcome, label_pr_outcomes
+
+# ---------------------------------------------------------------------------
+# determine_outcome — pure priority logic
+# ---------------------------------------------------------------------------
+
+
+class TestDetermineOutcome:
+    def test_actioned_wins_over_everything(self):
+        signals = {
+            "code_changed_near_line": True,
+            "reply_sentiment": "negative",
+            "developer_replied": True,
+            "thread_resolved": True,
+        }
+        assert determine_outcome(signals) == "actioned"
+
+    def test_actioned_minimal_signals(self):
+        signals = {
+            "code_changed_near_line": True,
+            "reply_sentiment": None,
+            "developer_replied": False,
+            "thread_resolved": False,
+        }
+        assert determine_outcome(signals) == "actioned"
+
+    def test_disputed_when_negative_sentiment(self):
+        signals = {
+            "code_changed_near_line": False,
+            "reply_sentiment": "negative",
+            "developer_replied": True,
+            "thread_resolved": False,
+        }
+        assert determine_outcome(signals) == "disputed"
+
+    def test_acknowledged_positive_reply(self):
+        signals = {
+            "code_changed_near_line": False,
+            "reply_sentiment": "positive",
+            "developer_replied": True,
+            "thread_resolved": False,
+        }
+        assert determine_outcome(signals) == "acknowledged"
+
+    def test_acknowledged_thread_resolved(self):
+        signals = {
+            "code_changed_near_line": False,
+            "reply_sentiment": "neutral",
+            "developer_replied": True,
+            "thread_resolved": True,
+        }
+        assert determine_outcome(signals) == "acknowledged"
+
+    def test_ignored_no_signals(self):
+        signals = {
+            "code_changed_near_line": False,
+            "reply_sentiment": None,
+            "developer_replied": False,
+            "thread_resolved": False,
+        }
+        assert determine_outcome(signals) == "ignored"
+
+    def test_ignored_neutral_reply_not_resolved(self):
+        signals = {
+            "code_changed_near_line": False,
+            "reply_sentiment": "neutral",
+            "developer_replied": True,
+            "thread_resolved": False,
+        }
+        assert determine_outcome(signals) == "ignored"
+
+    def test_ignored_no_dev_reply_but_resolved(self):
+        """Thread resolved without dev reply doesn't count as acknowledged."""
+        signals = {
+            "code_changed_near_line": False,
+            "reply_sentiment": None,
+            "developer_replied": False,
+            "thread_resolved": True,
+        }
+        assert determine_outcome(signals) == "ignored"
+
+
+# ---------------------------------------------------------------------------
+# label_pr_outcomes — DB integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_factory():
+    reset_engine()
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    with patch("baloo.outcomes.labeler.get_session_factory", return_value=factory):
+        yield factory
+    await engine.dispose()
+    reset_engine()
+
+
+async def _seed_review_with_findings(factory, *, count=2) -> tuple[Review, list[Finding]]:
+    """Insert a review with findings and return them."""
+    async with factory() as session:
+        async with session.begin():
+            review = Review(
+                repo_full_name="owner/repo",
+                pr_number=42,
+                pr_title="Test PR",
+                pr_author="dev",
+                commit_sha="abc123",
+                review_status="commented",
+                trigger_reason="push",
+                started_at=datetime.now(timezone.utc),
+            )
+            session.add(review)
+            await session.flush()
+
+            findings = []
+            for i in range(count):
+                f = Finding(
+                    review_id=review.id,
+                    file_path=f"src/file{i}.py",
+                    line_number=10 + i,
+                    severity="medium",
+                    category="Quality",
+                    body=f"Finding {i}",
+                )
+                session.add(f)
+                findings.append(f)
+            await session.flush()
+
+    return review, findings
+
+
+def _mock_merge_signals(threads=None):
+    """Return an AsyncMock for fetch_merge_signals."""
+    diff = """\
+diff --git a/src/file0.py b/src/file0.py
+--- a/src/file0.py
++++ b/src/file0.py
+@@ -8,6 +8,7 @@
+ ctx
+ ctx
++changed line at 10
+ ctx
+"""
+    if threads is None:
+        threads = []
+    mock = AsyncMock(return_value=(diff, threads))
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_label_pr_outcomes_creates_rows(db_factory):
+    review, findings = await _seed_review_with_findings(db_factory)
+
+    # Thread matches file0.py line 10 with a positive dev reply
+    threads = [
+        {
+            "path": "src/file0.py",
+            "line": 10,
+            "is_resolved": False,
+            "comments": [
+                {"author": "baloo[bot]", "body": "issue here", "is_baloo": True},
+                {"author": "dev", "body": "good catch, fixed", "is_baloo": False},
+            ],
+        }
+    ]
+
+    diff = _mock_merge_signals().return_value[0]
+    mock_fetch = AsyncMock(return_value=(diff, threads))
+
+    with patch("baloo.outcomes.labeler.fetch_merge_signals", mock_fetch):
+        await label_pr_outcomes("owner/repo", 42, 12345)
+
+    # Verify outcomes were created
+    async with db_factory() as session:
+        from sqlalchemy import select
+
+        rows = (await session.execute(select(FindingOutcome))).scalars().all()
+        assert len(rows) == 2
+
+        outcomes_by_finding = {r.finding_id: r for r in rows}
+
+        # file0.py had code change near line 10 → actioned
+        f0 = outcomes_by_finding[findings[0].id]
+        assert f0.outcome == "actioned"
+        assert f0.repo_full_name == "owner/repo"
+        assert f0.pr_number == 42
+
+        # file1.py had no matching thread and no code change → ignored
+        f1 = outcomes_by_finding[findings[1].id]
+        assert f1.outcome == "ignored"
+
+
+@pytest.mark.asyncio
+async def test_label_pr_outcomes_skips_when_no_findings(db_factory):
+    """No findings → log and return without calling fetch_merge_signals."""
+    with patch("baloo.outcomes.labeler.fetch_merge_signals", new_callable=AsyncMock) as mock_fetch:
+        await label_pr_outcomes("owner/repo", 99, 12345)
+        mock_fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_label_pr_outcomes_idempotent(db_factory):
+    """Running twice doesn't duplicate FindingOutcome rows."""
+    review, findings = await _seed_review_with_findings(db_factory, count=1)
+
+    mock_fetch = AsyncMock(
+        return_value=(
+            _mock_merge_signals().return_value[0],
+            [],
+        )
+    )
+
+    with patch("baloo.outcomes.labeler.fetch_merge_signals", mock_fetch):
+        await label_pr_outcomes("owner/repo", 42, 12345)
+        await label_pr_outcomes("owner/repo", 42, 12345)
+
+    async with db_factory() as session:
+        from sqlalchemy import select
+
+        rows = (await session.execute(select(FindingOutcome))).scalars().all()
+        assert len(rows) == 1

--- a/tests/outcomes/test_signals.py
+++ b/tests/outcomes/test_signals.py
@@ -1,0 +1,260 @@
+"""Tests for signal collection functions."""
+
+from baloo.outcomes.signals import classify_sentiment, collect_thread_signals, detect_code_change
+
+# ---------------------------------------------------------------------------
+# classify_sentiment
+# ---------------------------------------------------------------------------
+
+
+class TestClassifySentiment:
+    def test_none_returns_none(self):
+        assert classify_sentiment(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert classify_sentiment("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert classify_sentiment("   ") is None
+
+    # Negative keywords
+    def test_false_positive_keyword(self):
+        assert classify_sentiment("this is a false positive") == "negative"
+
+    def test_intentional_keyword(self):
+        assert classify_sentiment("this was intentional") == "negative"
+
+    def test_disagree_keyword(self):
+        assert classify_sentiment("I disagree with this finding") == "negative"
+
+    def test_not_a_bug_keyword(self):
+        assert classify_sentiment("not a bug, works as designed") == "negative"
+
+    def test_by_design_keyword(self):
+        assert classify_sentiment("this behavior is by design") == "negative"
+
+    # Positive keywords
+    def test_fixed_keyword(self):
+        assert classify_sentiment("fixed in latest commit") == "positive"
+
+    def test_good_catch_keyword(self):
+        assert classify_sentiment("good catch, will address") == "positive"
+
+    def test_thanks_keyword(self):
+        assert classify_sentiment("thanks for the review") == "positive"
+
+    def test_done_keyword(self):
+        assert classify_sentiment("done") == "positive"
+
+    def test_resolved_keyword(self):
+        assert classify_sentiment("resolved this issue") == "positive"
+
+    # Neutral
+    def test_unmatched_text_returns_neutral(self):
+        assert classify_sentiment("I will look into this later") == "neutral"
+
+    def test_plain_text_neutral(self):
+        assert classify_sentiment("ok") == "neutral"
+
+    # Priority: negative beats positive
+    def test_negative_beats_positive(self):
+        # If both negative and positive keywords present, negative wins
+        assert classify_sentiment("fixed but actually false positive") == "negative"
+
+    # Case insensitivity
+    def test_case_insensitive_negative(self):
+        assert classify_sentiment("FALSE POSITIVE") == "negative"
+
+    def test_case_insensitive_positive(self):
+        assert classify_sentiment("FIXED in HEAD") == "positive"
+
+
+# ---------------------------------------------------------------------------
+# detect_code_change
+# ---------------------------------------------------------------------------
+
+SAMPLE_DIFF = """\
+diff --git a/foo/bar.py b/foo/bar.py
+--- a/foo/bar.py
++++ b/foo/bar.py
+@@ -10,6 +10,7 @@
+ context line
+ context line
++added line at 12
+ context line
+ context line
+ context line
+diff --git a/other.py b/other.py
+--- a/other.py
++++ b/other.py
+@@ -1,3 +1,4 @@
+ ctx
++added line in other at 2
+ ctx
+ ctx
+"""
+
+
+class TestDetectCodeChange:
+    def test_no_diff_returns_false(self):
+        assert detect_code_change("foo/bar.py", 12, None) is False
+
+    def test_empty_diff_returns_false(self):
+        assert detect_code_change("foo/bar.py", 12, "") is False
+
+    def test_none_line_number_returns_false(self):
+        assert detect_code_change("foo/bar.py", None, SAMPLE_DIFF) is False
+
+    def test_changed_line_exact_match(self):
+        # Added line lands at new-file line 12 in foo/bar.py
+        assert detect_code_change("foo/bar.py", 12, SAMPLE_DIFF) is True
+
+    def test_changed_line_within_5_above(self):
+        # line 12 changed; querying line 10 (2 away) should still return True
+        assert detect_code_change("foo/bar.py", 10, SAMPLE_DIFF) is True
+
+    def test_changed_line_within_5_below(self):
+        # line 12 changed; querying line 15 (3 away) should still return True
+        assert detect_code_change("foo/bar.py", 15, SAMPLE_DIFF) is True
+
+    def test_changed_line_just_outside_window(self):
+        # line 12 changed; querying line 18 (6 away) should return False
+        assert detect_code_change("foo/bar.py", 18, SAMPLE_DIFF) is False
+
+    def test_different_file_returns_false(self):
+        # The change is in foo/bar.py, not baz.py
+        assert detect_code_change("baz.py", 12, SAMPLE_DIFF) is False
+
+    def test_other_file_change_detected(self):
+        # other.py has an addition at new-file line 2
+        assert detect_code_change("other.py", 2, SAMPLE_DIFF) is True
+
+    def test_wrong_file_not_confused(self):
+        # other.py line 2 changed, but querying foo/bar.py line 2 should be False
+        assert detect_code_change("foo/bar.py", 2, SAMPLE_DIFF) is False
+
+    def test_boundary_exactly_5_away(self):
+        # line 12 changed; line 7 is exactly 5 away — should return True
+        assert detect_code_change("foo/bar.py", 7, SAMPLE_DIFF) is True
+
+    def test_boundary_6_away_returns_false(self):
+        # line 12 changed; line 6 is 6 away — should return False
+        assert detect_code_change("foo/bar.py", 6, SAMPLE_DIFF) is False
+
+
+# ---------------------------------------------------------------------------
+# collect_thread_signals
+# ---------------------------------------------------------------------------
+
+
+def _baloo_comment(body="Baloo says hi"):
+    return {"author": "baloo[bot]", "body": body, "is_baloo": True}
+
+
+def _dev_comment(body="looks intentional to me"):
+    return {"author": "dev_user", "body": body, "is_baloo": False}
+
+
+class TestCollectThreadSignals:
+    def test_none_thread_returns_empty_signals(self):
+        result = collect_thread_signals(None)
+        assert result == {
+            "thread_resolved": False,
+            "developer_replied": False,
+            "reply_sentiment": None,
+            "reply_text": None,
+        }
+
+    def test_resolved_thread_no_dev_reply(self):
+        thread = {
+            "is_resolved": True,
+            "comments": [_baloo_comment()],
+        }
+        result = collect_thread_signals(thread)
+        assert result["thread_resolved"] is True
+        assert result["developer_replied"] is False
+        assert result["reply_sentiment"] is None
+        assert result["reply_text"] is None
+
+    def test_unresolved_thread_no_dev_reply(self):
+        thread = {
+            "is_resolved": False,
+            "comments": [_baloo_comment()],
+        }
+        result = collect_thread_signals(thread)
+        assert result["thread_resolved"] is False
+        assert result["developer_replied"] is False
+
+    def test_dev_reply_detected(self):
+        thread = {
+            "is_resolved": False,
+            "comments": [_baloo_comment(), _dev_comment("fixed this")],
+        }
+        result = collect_thread_signals(thread)
+        assert result["developer_replied"] is True
+        assert result["reply_text"] == "fixed this"
+        assert result["reply_sentiment"] == "positive"
+
+    def test_dev_reply_negative_sentiment(self):
+        thread = {
+            "is_resolved": True,
+            "comments": [_baloo_comment(), _dev_comment("this is intentional")],
+        }
+        result = collect_thread_signals(thread)
+        assert result["thread_resolved"] is True
+        assert result["developer_replied"] is True
+        assert result["reply_sentiment"] == "negative"
+
+    def test_dev_reply_neutral_sentiment(self):
+        thread = {
+            "is_resolved": False,
+            "comments": [_baloo_comment(), _dev_comment("I will look into this")],
+        }
+        result = collect_thread_signals(thread)
+        assert result["reply_sentiment"] == "neutral"
+
+    def test_first_dev_reply_used(self):
+        """Only the first non-Baloo comment is used."""
+        thread = {
+            "is_resolved": False,
+            "comments": [
+                _baloo_comment(),
+                _dev_comment("fixed"),
+                _dev_comment("also resolved"),
+            ],
+        }
+        result = collect_thread_signals(thread)
+        assert result["reply_text"] == "fixed"
+
+    def test_reply_text_truncated_to_500_chars(self):
+        long_body = "x" * 600
+        thread = {
+            "is_resolved": False,
+            "comments": [_baloo_comment(), _dev_comment(long_body)],
+        }
+        result = collect_thread_signals(thread)
+        assert len(result["reply_text"]) == 500
+
+    def test_empty_comments_list(self):
+        thread = {"is_resolved": False, "comments": []}
+        result = collect_thread_signals(thread)
+        assert result["developer_replied"] is False
+        assert result["reply_text"] is None
+
+    def test_only_baloo_comments(self):
+        thread = {
+            "is_resolved": False,
+            "comments": [_baloo_comment(), _baloo_comment("follow-up")],
+        }
+        result = collect_thread_signals(thread)
+        assert result["developer_replied"] is False
+
+    def test_dev_comment_before_baloo(self):
+        """Dev comment appearing before Baloo comment should still be found."""
+        thread = {
+            "is_resolved": False,
+            "comments": [_dev_comment("done"), _baloo_comment()],
+        }
+        result = collect_thread_signals(thread)
+        assert result["developer_replied"] is True
+        assert result["reply_text"] == "done"

--- a/tests/outcomes/test_webhook_merge.py
+++ b/tests/outcomes/test_webhook_merge.py
@@ -1,0 +1,112 @@
+"""Tests for webhook handler PR merge -> outcome labeling integration."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from baloo.github.webhook_handler import app
+
+_USER = {
+    "login": "octocat",
+    "id": 1,
+    "avatar_url": "https://github.com/images/error/octocat.gif",
+    "html_url": "https://github.com/octocat",
+}
+
+_REPOSITORY = {
+    "id": 1296269,
+    "name": "repo",
+    "full_name": "owner/repo",
+    "owner": _USER,
+    "html_url": "https://github.com/owner/repo",
+    "default_branch": "main",
+}
+
+MERGED_PAYLOAD = {
+    "action": "closed",
+    "number": 42,
+    "repository": _REPOSITORY,
+    "installation": {"id": 999},
+    "pull_request": {
+        "number": 42,
+        "title": "My PR",
+        "html_url": "https://github.com/owner/repo/pull/42",
+        "draft": False,
+        "merged": True,
+        "head": {"sha": "abc123", "ref": "feat/my-feature"},
+        "base": {"sha": "def456", "ref": "main"},
+        "user": _USER,
+        "body": None,
+        "state": "closed",
+    },
+    "sender": _USER,
+}
+
+CLOSED_NOT_MERGED_PAYLOAD = {
+    **MERGED_PAYLOAD,
+    "pull_request": {
+        **MERGED_PAYLOAD["pull_request"],
+        "merged": False,
+    },
+}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def _webhook_headers(body: bytes) -> dict:
+    return {
+        "X-GitHub-Event": "pull_request",
+        "X-Hub-Signature-256": "sha256=dummy",
+        "Content-Type": "application/json",
+    }
+
+
+def test_merged_pr_triggers_label_pr_outcomes(client):
+    """A merged PR should fire label_pr_outcomes as a background task."""
+    body = json.dumps(MERGED_PAYLOAD).encode()
+
+    with (
+        patch(
+            "baloo.github.webhook_handler.verify_webhook_signature",
+            return_value=True,
+        ),
+        patch(
+            "baloo.github.webhook_handler.label_pr_outcomes",
+            new_callable=AsyncMock,
+        ) as mock_label,
+    ):
+        response = client.post("/webhook", content=body, headers=_webhook_headers(body))
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "labeling_outcomes"
+    assert data["pr"] == 42
+    mock_label.assert_called_once_with("owner/repo", 42, 999)
+
+
+def test_closed_not_merged_does_not_trigger_labeling(client):
+    """A closed-but-not-merged PR should NOT trigger outcome labeling."""
+    body = json.dumps(CLOSED_NOT_MERGED_PAYLOAD).encode()
+
+    with (
+        patch(
+            "baloo.github.webhook_handler.verify_webhook_signature",
+            return_value=True,
+        ),
+        patch(
+            "baloo.github.webhook_handler.label_pr_outcomes",
+            new_callable=AsyncMock,
+        ) as mock_label,
+    ):
+        response = client.post("/webhook", content=body, headers=_webhook_headers(body))
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ignored"
+    assert data["reason"] == "not merged"
+    mock_label.assert_not_called()


### PR DESCRIPTION
## Summary

- Track what happens to each Baloo finding after a PR is merged: was it actioned, disputed, acknowledged, or ignored?
- On PR merge webhook, label each finding with an outcome based on code changes near the flagged line, thread resolution, and developer reply sentiment
- New `/dashboard/outcomes` page with hit rate, noise rate, severity/category breakdowns, weekly trends, and outcome distribution charts
- New `finding_outcomes` DB table with Alembic migration

## Motivation

Build the measurement layer for review quality. Knowing which findings lead to code changes vs. get ignored lets us improve prompts and filtering over time. Global metrics first, per-repo and per-contributor optimization later.

## Changes

- **Model + Migration**: `FindingOutcome` model, Alembic migration 004
- **Signal Collection**: `baloo/outcomes/signals.py` — sentiment classification, code change detection, thread signal extraction
- **Labeler**: `baloo/outcomes/labeler.py` — orchestrates signal collection, applies priority logic (actioned > disputed > acknowledged > ignored), persists outcomes
- **Webhook**: Handles `pull_request:closed` + `merged=true` to trigger outcome labeling
- **Dashboard**: Queries in `DashboardService`, new `/dashboard/outcomes` route + template with Chart.js visualizations
- **Backfill**: Separate `tool/backfill-outcomes` branch with one-time script (not included in this PR)

## Test plan

- [ ] 376 tests passing (55 new tests across outcomes and dashboard)
- [ ] Lint and format clean (`ruff check`, `black --check`)
- [ ] Verify `/dashboard/outcomes` renders with mock data
- [ ] Verify merge webhook triggers `label_pr_outcomes`
- [ ] Verify idempotency (labeling same PR twice doesn't duplicate rows)