### PR TITLE
docs(agent): document string terminator heuristic limitations

### DIFF
--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -287,7 +287,15 @@ def _is_bare_value_char(ch: str) -> bool:
 
 
 def _is_string_terminator(next_sig: str, string_is_key: bool) -> bool:
-    """Return True when a quote may safely close the current string."""
+    """Return True when a quote may safely close the current string.
+
+    Known limitation: this heuristic checks only the next non-whitespace
+    character. It cannot distinguish between a '}' or ']' that belongs to
+    the enclosing JSON structure vs. one that is literal content inside the
+    value string. Prefer using a proper JSON-repair library (e.g. json-repair)
+    if this pattern is encountered in production.
+    TODO: track container depth to avoid false closure at '}' or ']'.
+    """
     if not next_sig:
         return True
     if string_is_key:


### PR DESCRIPTION
Documents the known limitation in the JSON repair string terminator heuristic as requested in the previous review of #17.

- Updates `_is_string_terminator` docstring.
- Adds TODO for future improvement (depth tracking or external library).