### PR TITLE
fix(fidelity): avoid duplicate missing-plan reports

### DIFF
--- a/baloo/fidelity/fidelity_report.py
+++ b/baloo/fidelity/fidelity_report.py
@@ -2,6 +2,17 @@
 
 from baloo.fidelity.models import FidelityResult
 
+NO_TICKET_FIDELITY_SENTINEL = "<!-- baloo:no-ticket-fidelity-report -->"
+MISSING_PLAN_FIDELITY_SENTINEL = "<!-- baloo:missing-plan-fidelity-report -->"
+ERROR_FIDELITY_SENTINEL = "<!-- baloo:error-fidelity-report -->"
+STATIC_FIDELITY_SENTINELS = frozenset(
+    {
+        NO_TICKET_FIDELITY_SENTINEL,
+        MISSING_PLAN_FIDELITY_SENTINEL,
+        ERROR_FIDELITY_SENTINEL,
+    }
+)
+
 
 def format_fidelity_report(
     result: FidelityResult | None = None,
@@ -133,8 +144,10 @@ def _get_severity_icon(severity: str) -> str:
 
 def _format_no_ticket() -> str:
     """Format report when no ticket ID is found."""
-    return """<details>
+    return f"""<details>
 <summary>\U0001f4cb Fidelity Report - \u23ed\ufe0f Skipped</summary>
+
+{NO_TICKET_FIDELITY_SENTINEL}
 
 **No ticket ID found in PR.**
 
@@ -153,6 +166,8 @@ def _format_no_plan(ticket_id: str | None, plan_path: str | None) -> str:
     return f"""<details>
 <summary>\U0001f4cb Fidelity Report ({ticket_display}) - \u23ed\ufe0f Skipped</summary>
 
+{MISSING_PLAN_FIDELITY_SENTINEL}
+
 **No plan file found at `{path_display}`**
 
 To enable fidelity analysis, create a plan file before implementation.
@@ -166,6 +181,8 @@ def _format_error(ticket_id: str | None) -> str:
 
     return f"""<details>
 <summary>\U0001f4cb Fidelity Report ({ticket_display}) - \u26a0\ufe0f Error</summary>
+
+{ERROR_FIDELITY_SENTINEL}
 
 **Fidelity analysis encountered an error.**
 

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -18,7 +18,13 @@ from baloo.config.settings import settings
 from baloo.db.engine import close_db, init_db
 from baloo.db.service import ReviewCompleteDTO, ReviewService
 from baloo.fidelity.fidelity_analyzer import analyze_fidelity
-from baloo.fidelity.fidelity_report import format_fidelity_report
+from baloo.fidelity.fidelity_report import (
+    ERROR_FIDELITY_SENTINEL,
+    MISSING_PLAN_FIDELITY_SENTINEL,
+    NO_TICKET_FIDELITY_SENTINEL,
+    STATIC_FIDELITY_SENTINELS,
+    format_fidelity_report,
+)
 from baloo.fidelity.models import FidelityResult
 from baloo.fidelity.plan_fetcher import fetch_plan_content
 from baloo.fidelity.ticket_extractor import extract_ticket_id
@@ -151,17 +157,40 @@ _ISSUE_COMMENT_LOCATION_RE = re.compile(
 )
 
 
-def _is_missing_plan_fidelity_report(body: str) -> bool:
-    """Return True for Baloo fidelity comments that report a missing plan file."""
-    return "Fidelity Report" in body and "No plan file found" in body
+_LEGACY_STATIC_FIDELITY_MARKERS = {
+    NO_TICKET_FIDELITY_SENTINEL: ("No ticket ID found",),
+    MISSING_PLAN_FIDELITY_SENTINEL: ("No plan file found",),
+    ERROR_FIDELITY_SENTINEL: ("Fidelity analysis encountered an error",),
+}
 
 
-def _has_existing_missing_plan_fidelity_report(
-    issue_comments: list[DiscussionComment],
+def _static_fidelity_sentinel_for_body(body: str) -> str | None:
+    """Return the static fidelity report sentinel represented by a comment body."""
+    for sentinel in STATIC_FIDELITY_SENTINELS:
+        if sentinel in body:
+            return sentinel
+
+    if "Fidelity Report" not in body:
+        return None
+
+    # Keep one migration path for comments posted before sentinels existed.
+    for sentinel, legacy_markers in _LEGACY_STATIC_FIDELITY_MARKERS.items():
+        if all(marker in body for marker in legacy_markers):
+            return sentinel
+
+    return None
+
+
+def _has_existing_static_fidelity_report(
+    issue_comments: list[DiscussionComment], report_body: str
 ) -> bool:
-    """Check whether Baloo already posted a missing-plan fidelity report on the PR."""
+    """Check whether Baloo already posted this static fidelity report type."""
+    report_sentinel = _static_fidelity_sentinel_for_body(report_body)
+    if report_sentinel is None:
+        return False
+
     return any(
-        comment.is_baloo and _is_missing_plan_fidelity_report(comment.body)
+        comment.is_baloo and _static_fidelity_sentinel_for_body(comment.body) == report_sentinel
         for comment in issue_comments
     )
 
@@ -853,11 +882,11 @@ async def process_pr_review(
             # Post fidelity report as separate comment
             if fidelity_report_text:
                 try:
-                    if _is_missing_plan_fidelity_report(
-                        fidelity_report_text
-                    ) and _has_existing_missing_plan_fidelity_report(pr_context.issue_comments):
+                    if _has_existing_static_fidelity_report(
+                        pr_context.issue_comments, fidelity_report_text
+                    ):
                         logger.info(
-                            "Skipping duplicate missing-plan fidelity report for %s#%s",
+                            "Skipping duplicate static fidelity report for %s#%s",
                             repo_full_name,
                             pr_number,
                         )

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -151,6 +151,21 @@ _ISSUE_COMMENT_LOCATION_RE = re.compile(
 )
 
 
+def _is_missing_plan_fidelity_report(body: str) -> bool:
+    """Return True for Baloo fidelity comments that report a missing plan file."""
+    return "Fidelity Report" in body and "No plan file found" in body
+
+
+def _has_existing_missing_plan_fidelity_report(
+    issue_comments: list[DiscussionComment],
+) -> bool:
+    """Check whether Baloo already posted a missing-plan fidelity report on the PR."""
+    return any(
+        comment.is_baloo and _is_missing_plan_fidelity_report(comment.body)
+        for comment in issue_comments
+    )
+
+
 def _threads_from_issue_comments(
     issue_comments: list[DiscussionComment],
 ) -> list[DiscussionThread]:
@@ -838,10 +853,19 @@ async def process_pr_review(
             # Post fidelity report as separate comment
             if fidelity_report_text:
                 try:
-                    await github_client.post_comment(
-                        repo_full_name, pr_number, fidelity_report_text
-                    )
-                    logger.info(f"Posted fidelity report for {repo_full_name}#{pr_number}")
+                    if _is_missing_plan_fidelity_report(
+                        fidelity_report_text
+                    ) and _has_existing_missing_plan_fidelity_report(pr_context.issue_comments):
+                        logger.info(
+                            "Skipping duplicate missing-plan fidelity report for %s#%s",
+                            repo_full_name,
+                            pr_number,
+                        )
+                    else:
+                        await github_client.post_comment(
+                            repo_full_name, pr_number, fidelity_report_text
+                        )
+                        logger.info(f"Posted fidelity report for {repo_full_name}#{pr_number}")
                 except Exception as fidelity_err:
                     logger.warning(f"Failed to post fidelity report: {fidelity_err}")
 

--- a/tests/fidelity/test_fidelity_report.py
+++ b/tests/fidelity/test_fidelity_report.py
@@ -103,6 +103,12 @@ class TestFormatFidelityReportNoTicket:
         assert "feat/PROJ-XXX" in report
         assert "[PROJ-XXX]" in report
 
+    def test_no_ticket_report_includes_stable_sentinel(self):
+        """Static no-ticket reports include an opaque marker for dedup."""
+        report = format_fidelity_report(no_ticket=True)
+
+        assert "<!-- baloo:no-ticket-fidelity-report -->" in report
+
 
 class TestFormatFidelityReportNoPlan:
     """Tests for format_fidelity_report with no_plan=True."""
@@ -122,6 +128,16 @@ class TestFormatFidelityReportNoPlan:
         assert "Skipped" in report
         assert "No plan file found" in report
         assert "docs/plans/DEN-123.md" in report
+
+    def test_no_plan_report_includes_stable_sentinel(self):
+        """Static missing-plan reports include an opaque marker for dedup."""
+        report = format_fidelity_report(
+            no_plan=True,
+            ticket_id="DEN-123",
+            plan_path="docs/plans/DEN-123.md",
+        )
+
+        assert "<!-- baloo:missing-plan-fidelity-report -->" in report
 
 
 class TestFormatFidelityReportSuccess:
@@ -288,3 +304,9 @@ class TestFormatFidelityReportError:
         assert "DEN-123" in report
         assert "Error" in report
         assert "encountered an error" in report
+
+    def test_error_report_includes_stable_sentinel(self):
+        """Static error reports include an opaque marker for dedup."""
+        report = format_fidelity_report(result=None, ticket_id="DEN-123")
+
+        assert "<!-- baloo:error-fidelity-report -->" in report

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -1,12 +1,82 @@
 """Tests for webhook handler completion messages."""
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from baloo.fidelity.models import FidelityResult
-from baloo.github.models import ReviewComment, ReviewResult
+from baloo.github.models import DiscussionComment, ReviewComment, ReviewResult
 from baloo.github.webhook_handler import process_pr_review
+
+
+@pytest.mark.asyncio
+async def test_does_not_repost_missing_plan_fidelity_report():
+    """Do not post the missing-plan fidelity report more than once per PR."""
+
+    mock_github_client = MagicMock()
+    mock_github_client.post_comment = AsyncMock(return_value=12345)
+    mock_github_client.edit_comment = AsyncMock()
+    mock_github_client.post_review = AsyncMock()
+    mock_github_client.reply_to_review_comment = AsyncMock()
+
+    mock_pr_context = MagicMock()
+    mock_pr_context.discussion_threads = []
+    mock_pr_context.issue_comments = [
+        DiscussionComment(
+            id=111,
+            author="baloo[bot]",
+            body=(
+                "<details>\n"
+                "<summary>📋 Fidelity Report (DEN-123) - ⏭️ Skipped</summary>\n\n"
+                "**No plan file found at `docs/plans/DEN-123.md`**\n\n"
+                "</details>"
+            ),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            source="issue_comment",
+            is_baloo=True,
+        )
+    ]
+    mock_pr_context.awaiting_response_threads = 0
+    mock_pr_context.head_sha = "abc123"
+    mock_pr_context.head_branch = "feat/DEN-123/add-feature"
+    mock_pr_context.title = "Add new feature"
+    mock_pr_context.description = "This PR adds a new feature"
+    mock_pr_context.diff = "+ added code"
+    mock_github_client.get_pr_context = AsyncMock(return_value=mock_pr_context)
+
+    mock_agent = MagicMock()
+    mock_agent.review_pr = AsyncMock(
+        return_value=ReviewResult(
+            summary="Review complete",
+            comments=[],
+            approve=True,
+            request_changes=False,
+        )
+    )
+
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.fidelity_enabled", True),
+        patch("baloo.config.settings.settings.review_auto_approve", True),
+        patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"),
+        patch(
+            "baloo.github.webhook_handler.fetch_plan_content",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await process_pr_review(
+            repo_full_name="test/repo",
+            pr_number=123,
+            installation_id=456,
+            trigger_reason="test",
+            notify_progress=False,
+        )
+
+    posted_comments = [call.args[2] for call in mock_github_client.post_comment.call_args_list]
+    assert not any("No plan file found" in body for body in posted_comments)
 
 
 @pytest.mark.asyncio

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -1,10 +1,16 @@
 """Tests for webhook handler completion messages."""
 
+from contextlib import ExitStack
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from baloo.fidelity.fidelity_report import (
+    ERROR_FIDELITY_SENTINEL,
+    MISSING_PLAN_FIDELITY_SENTINEL,
+    NO_TICKET_FIDELITY_SENTINEL,
+)
 from baloo.fidelity.models import FidelityResult
 from baloo.github.models import DiscussionComment, ReviewComment, ReviewResult
 from baloo.github.webhook_handler import process_pr_review
@@ -215,6 +221,148 @@ async def test_does_not_repost_error_fidelity_report():
 
     posted_comments = [call.args[2] for call in mock_github_client.post_comment.call_args_list]
     assert not any("encountered an error" in body for body in posted_comments)
+
+
+async def _process_review_with_existing_fidelity_comment(
+    existing_comment_body: str,
+    *,
+    ticket_id: str | None,
+    plan_content: str | None = None,
+    fidelity_result: FidelityResult | None = None,
+) -> list[str]:
+    mock_github_client = MagicMock()
+    mock_github_client.post_comment = AsyncMock(return_value=12345)
+    mock_github_client.edit_comment = AsyncMock()
+    mock_github_client.post_review = AsyncMock()
+    mock_github_client.reply_to_review_comment = AsyncMock()
+
+    mock_pr_context = MagicMock()
+    mock_pr_context.discussion_threads = []
+    mock_pr_context.issue_comments = [
+        DiscussionComment(
+            id=111,
+            author="baloo[bot]",
+            body=existing_comment_body,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            source="issue_comment",
+            is_baloo=True,
+        )
+    ]
+    mock_pr_context.awaiting_response_threads = 0
+    mock_pr_context.head_sha = "abc123"
+    mock_pr_context.head_branch = "feat/DEN-123/add-feature"
+    mock_pr_context.title = "Add new feature"
+    mock_pr_context.description = "This PR adds a new feature"
+    mock_pr_context.diff = "+ added code"
+    mock_github_client.get_pr_context = AsyncMock(return_value=mock_pr_context)
+
+    mock_agent = MagicMock()
+    mock_agent.review_pr = AsyncMock(
+        return_value=ReviewResult(
+            summary="Review complete",
+            comments=[],
+            approve=True,
+            request_changes=False,
+        )
+    )
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "baloo.github.webhook_handler.GitHubAPIClient",
+                return_value=mock_github_client,
+            )
+        )
+        stack.enter_context(patch("baloo.agent.client.BalooAgent", return_value=mock_agent))
+        stack.enter_context(patch("baloo.config.settings.settings.fidelity_enabled", True))
+        stack.enter_context(patch("baloo.config.settings.settings.review_auto_approve", True))
+        stack.enter_context(
+            patch("baloo.github.webhook_handler.extract_ticket_id", return_value=ticket_id)
+        )
+        if ticket_id:
+            stack.enter_context(
+                patch(
+                    "baloo.github.webhook_handler.fetch_plan_content",
+                    AsyncMock(return_value=plan_content),
+                )
+            )
+        if ticket_id and plan_content:
+            stack.enter_context(
+                patch(
+                    "baloo.github.webhook_handler.analyze_fidelity",
+                    AsyncMock(return_value=fidelity_result),
+                )
+            )
+
+        await process_pr_review(
+            repo_full_name="test/repo",
+            pr_number=123,
+            installation_id=456,
+            trigger_reason="test",
+            notify_progress=False,
+        )
+
+    return [call.args[2] for call in mock_github_client.post_comment.call_args_list]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("existing_comment_body", "ticket_id", "plan_content", "forbidden_text"),
+    [
+        (
+            (
+                "<details>\n"
+                "<summary>📋 Fidelity Report - ⏭️ Skipped</summary>\n\n"
+                f"{NO_TICKET_FIDELITY_SENTINEL}\n\n"
+                "**No ticket ID found in PR.**\n\n"
+                "</details>"
+            ),
+            None,
+            None,
+            "No ticket ID found",
+        ),
+        (
+            (
+                "<details>\n"
+                "<summary>📋 Fidelity Report (DEN-123) - ⏭️ Skipped</summary>\n\n"
+                f"{MISSING_PLAN_FIDELITY_SENTINEL}\n\n"
+                "**No plan file found at `docs/plans/DEN-123.md`**\n\n"
+                "</details>"
+            ),
+            "DEN-123",
+            None,
+            "No plan file found",
+        ),
+        (
+            (
+                "<details>\n"
+                "<summary>📋 Fidelity Report (DEN-123) - ⚠️ Error</summary>\n\n"
+                f"{ERROR_FIDELITY_SENTINEL}\n\n"
+                "**Fidelity analysis encountered an error.**\n\n"
+                "</details>"
+            ),
+            "DEN-123",
+            "# Plan",
+            "encountered an error",
+        ),
+    ],
+)
+async def test_does_not_repost_sentinel_marked_static_fidelity_report(
+    existing_comment_body: str,
+    ticket_id: str | None,
+    plan_content: str | None,
+    forbidden_text: str,
+):
+    """Do not repost static fidelity reports when existing comments have sentinels."""
+    posted_comments = await _process_review_with_existing_fidelity_comment(
+        existing_comment_body,
+        ticket_id=ticket_id,
+        plan_content=plan_content,
+        fidelity_result=None,
+    )
+
+    assert not any(forbidden_text in body for body in posted_comments)
 
 
 @pytest.mark.asyncio

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -80,6 +80,144 @@ async def test_does_not_repost_missing_plan_fidelity_report():
 
 
 @pytest.mark.asyncio
+async def test_does_not_repost_no_ticket_fidelity_report():
+    """Do not post the no-ticket fidelity report more than once per PR."""
+
+    mock_github_client = MagicMock()
+    mock_github_client.post_comment = AsyncMock(return_value=12345)
+    mock_github_client.edit_comment = AsyncMock()
+    mock_github_client.post_review = AsyncMock()
+    mock_github_client.reply_to_review_comment = AsyncMock()
+
+    mock_pr_context = MagicMock()
+    mock_pr_context.discussion_threads = []
+    mock_pr_context.issue_comments = [
+        DiscussionComment(
+            id=111,
+            author="baloo[bot]",
+            body=(
+                "<details>\n"
+                "<summary>📋 Fidelity Report - ⏭️ Skipped</summary>\n\n"
+                "**No ticket ID found in PR.**\n\n"
+                "</details>"
+            ),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            source="issue_comment",
+            is_baloo=True,
+        )
+    ]
+    mock_pr_context.awaiting_response_threads = 0
+    mock_pr_context.head_sha = "abc123"
+    mock_pr_context.head_branch = "fix/fidelity-missing-report-dedupe"
+    mock_pr_context.title = "Fix duplicate fidelity reports"
+    mock_pr_context.description = ""
+    mock_pr_context.diff = "+ added code"
+    mock_github_client.get_pr_context = AsyncMock(return_value=mock_pr_context)
+
+    mock_agent = MagicMock()
+    mock_agent.review_pr = AsyncMock(
+        return_value=ReviewResult(
+            summary="Review complete",
+            comments=[],
+            approve=True,
+            request_changes=False,
+        )
+    )
+
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.fidelity_enabled", True),
+        patch("baloo.config.settings.settings.review_auto_approve", True),
+        patch("baloo.github.webhook_handler.extract_ticket_id", return_value=None),
+    ):
+        await process_pr_review(
+            repo_full_name="test/repo",
+            pr_number=123,
+            installation_id=456,
+            trigger_reason="test",
+            notify_progress=False,
+        )
+
+    posted_comments = [call.args[2] for call in mock_github_client.post_comment.call_args_list]
+    assert not any("No ticket ID found" in body for body in posted_comments)
+
+
+@pytest.mark.asyncio
+async def test_does_not_repost_error_fidelity_report():
+    """Do not post the fidelity error report more than once per PR."""
+
+    mock_github_client = MagicMock()
+    mock_github_client.post_comment = AsyncMock(return_value=12345)
+    mock_github_client.edit_comment = AsyncMock()
+    mock_github_client.post_review = AsyncMock()
+    mock_github_client.reply_to_review_comment = AsyncMock()
+
+    mock_pr_context = MagicMock()
+    mock_pr_context.discussion_threads = []
+    mock_pr_context.issue_comments = [
+        DiscussionComment(
+            id=111,
+            author="baloo[bot]",
+            body=(
+                "<details>\n"
+                "<summary>📋 Fidelity Report (DEN-123) - ⚠️ Error</summary>\n\n"
+                "**Fidelity analysis encountered an error.**\n\n"
+                "</details>"
+            ),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+            source="issue_comment",
+            is_baloo=True,
+        )
+    ]
+    mock_pr_context.awaiting_response_threads = 0
+    mock_pr_context.head_sha = "abc123"
+    mock_pr_context.head_branch = "feat/DEN-123/add-feature"
+    mock_pr_context.title = "Add new feature"
+    mock_pr_context.description = "This PR adds a new feature"
+    mock_pr_context.diff = "+ added code"
+    mock_github_client.get_pr_context = AsyncMock(return_value=mock_pr_context)
+
+    mock_agent = MagicMock()
+    mock_agent.review_pr = AsyncMock(
+        return_value=ReviewResult(
+            summary="Review complete",
+            comments=[],
+            approve=True,
+            request_changes=False,
+        )
+    )
+
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.fidelity_enabled", True),
+        patch("baloo.config.settings.settings.review_auto_approve", True),
+        patch("baloo.github.webhook_handler.extract_ticket_id", return_value="DEN-123"),
+        patch(
+            "baloo.github.webhook_handler.fetch_plan_content",
+            AsyncMock(return_value="# Plan"),
+        ),
+        patch(
+            "baloo.github.webhook_handler.analyze_fidelity",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await process_pr_review(
+            repo_full_name="test/repo",
+            pr_number=123,
+            installation_id=456,
+            trigger_reason="test",
+            notify_progress=False,
+        )
+
+    posted_comments = [call.args[2] for call in mock_github_client.post_comment.call_args_list]
+    assert not any("encountered an error" in body for body in posted_comments)
+
+
+@pytest.mark.asyncio
 async def test_updates_progress_comment_when_no_actionable_findings():
     """Test that progress comment is updated when no actionable findings."""
 


### PR DESCRIPTION
## Summary
- Detect Baloo's existing missing-plan fidelity report comments on a PR.
- Skip reposting the missing-plan fidelity notice on later review runs.
- Add a regression test for the duplicate missing-plan report case.

## Test plan
- [x] `uv run pytest tests/github/test_webhook_handler.py::test_does_not_repost_missing_plan_fidelity_report`
- [x] `uv run pytest tests/github/test_webhook_handler.py tests/fidelity/test_fidelity_report.py`
- [x] IDE lint check for touched files


Made with [Cursor](https://cursor.com)