### PR TITLE
Fix Baloo review counts and local review tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Inline comments appear on the exact lines:
 | **FP reduction** | Optional second LLM pass to verify findings and drop false positives |
 | **Dashboard** | Optional PostgreSQL-backed review history UI with cost tracking |
 | **Dependabot-aware** | Specialized review logic for dependency update PRs |
+| **Local dry-run** | Run [`scripts/local_review.py`](scripts/local_review.py) against a local git diff — no GitHub webhook or posted comments |
 
 ## Quick Start
 
@@ -165,6 +166,19 @@ uv run python main.py      # run locally
 uv run pytest              # test
 uv run ruff check baloo    # lint
 uv run black --check baloo # format check
+```
+
+### Local review (dry run)
+
+You can run the same review pipeline against your working tree before opening a PR. The script builds a synthetic pull request from a git diff (`base...head`), loads `AGENTS.md` / `CONTRIBUTING.md` from the head ref when present, and prints findings to stdout — nothing is posted to GitHub.
+
+Requires the same LLM credentials as production (for example `ANTHROPIC_API_KEY` or `GEMINI_API_KEY` in your environment).
+
+```bash
+uv run python scripts/local_review.py
+uv run python scripts/local_review.py --base origin/main --head HEAD
+uv run python scripts/local_review.py --json
+uv run python scripts/local_review.py --fail-on-blocking   # exit 1 if CRITICAL/HIGH findings
 ```
 
 See [docs/development.md](docs/development.md) for the full contributor guide.

--- a/baloo/agent/costs.py
+++ b/baloo/agent/costs.py
@@ -1,0 +1,122 @@
+"""Normalize model usage and estimate token costs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NormalizedUsage:
+    """Provider-neutral usage counters for one model response."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    thinking_tokens: int = 0
+    cost_usd: float = 0.0
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """Per-million-token prices for a model family."""
+
+    input_per_mtok: float
+    output_per_mtok: float
+    cache_write_per_mtok: float
+    cache_read_per_mtok: float
+
+
+# Anthropic public API prices per million tokens. Cache write uses the standard
+# 5-minute cache creation price; 1-hour cache writes require request-level TTL
+# details that PI does not currently expose.
+ANTHROPIC_PRICING: dict[str, ModelPricing] = {
+    "claude-sonnet-4-6": ModelPricing(3.0, 15.0, 3.75, 0.30),
+    "claude-haiku-4-5-20251001": ModelPricing(1.0, 5.0, 1.25, 0.10),
+    "claude-opus-4-6": ModelPricing(5.0, 25.0, 6.25, 0.50),
+    "claude-opus-4-7": ModelPricing(5.0, 25.0, 6.25, 0.50),
+}
+
+
+def normalize_usage(usage: dict[str, Any], *, provider: str, model: str) -> NormalizedUsage:
+    """Normalize PI/provider usage payloads and estimate billable cost."""
+    input_tokens = _usage_int(usage, "input", "input_tokens", "inputTokens")
+    output_tokens = _usage_int(usage, "output", "output_tokens", "outputTokens")
+    cache_read_tokens = _usage_int(
+        usage,
+        "cacheRead",
+        "cache_read_input_tokens",
+        "cacheReadInputTokens",
+    )
+    cache_write_tokens = _usage_int(
+        usage,
+        "cacheWrite",
+        "cache_creation_input_tokens",
+        "cacheCreationInputTokens",
+    )
+    thinking_tokens = _usage_int(usage, "thinking", "thinking_tokens", "thinkingTokens")
+
+    estimated_cost = _estimate_cost(
+        provider=provider,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+    )
+    cost_usd = estimated_cost if estimated_cost is not None else _provider_reported_cost(usage)
+
+    return NormalizedUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        thinking_tokens=thinking_tokens,
+        cost_usd=cost_usd,
+    )
+
+
+def _estimate_cost(
+    *,
+    provider: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+) -> float | None:
+    if provider != "anthropic":
+        return None
+
+    pricing = ANTHROPIC_PRICING.get(model)
+    if pricing is None:
+        return None
+
+    return (
+        (input_tokens / 1_000_000) * pricing.input_per_mtok
+        + (output_tokens / 1_000_000) * pricing.output_per_mtok
+        + (cache_write_tokens / 1_000_000) * pricing.cache_write_per_mtok
+        + (cache_read_tokens / 1_000_000) * pricing.cache_read_per_mtok
+    )
+
+
+def _provider_reported_cost(usage: dict[str, Any]) -> float:
+    cost = usage.get("cost", {})
+    if isinstance(cost, dict):
+        total = cost.get("total")
+        if isinstance(total, int | float):
+            return float(total)
+    if isinstance(cost, int | float):
+        return float(cost)
+    return 0.0
+
+
+def _usage_int(usage: dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+    return 0

--- a/baloo/agent/costs.py
+++ b/baloo/agent/costs.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -121,4 +124,10 @@ def _usage_int(usage: dict[str, Any], *keys: str) -> int:
             return value
         if isinstance(value, float):
             return int(value)
+    if usage:
+        logger.debug(
+            "_usage_int: none of %s present in usage keys %s",
+            keys,
+            list(usage.keys()),
+        )
     return 0

--- a/baloo/agent/costs.py
+++ b/baloo/agent/costs.py
@@ -62,6 +62,7 @@ def normalize_usage(usage: dict[str, Any], *, provider: str, model: str) -> Norm
         model=model,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        thinking_tokens=thinking_tokens,
         cache_read_tokens=cache_read_tokens,
         cache_write_tokens=cache_write_tokens,
     )
@@ -83,6 +84,7 @@ def _estimate_cost(
     model: str,
     input_tokens: int,
     output_tokens: int,
+    thinking_tokens: int,
     cache_read_tokens: int,
     cache_write_tokens: int,
 ) -> float | None:
@@ -95,7 +97,7 @@ def _estimate_cost(
 
     return (
         (input_tokens / 1_000_000) * pricing.input_per_mtok
-        + (output_tokens / 1_000_000) * pricing.output_per_mtok
+        + ((output_tokens + thinking_tokens) / 1_000_000) * pricing.output_per_mtok
         + (cache_write_tokens / 1_000_000) * pricing.cache_write_per_mtok
         + (cache_read_tokens / 1_000_000) * pricing.cache_read_per_mtok
     )

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -18,6 +18,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from baloo.agent.costs import normalize_usage
 from baloo.config.settings import get_settings
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,7 @@ class PIRunResult:
     output_tokens: int = 0
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
+    thinking_tokens: int = 0
     cost_usd: float = 0.0
     num_turns: int = 0
     model: str = ""
@@ -407,7 +409,9 @@ class PIAgentBase:
             "model": result.model or self.options.model,
             "input_tokens": result.input_tokens,
             "output_tokens": result.output_tokens,
-            "thinking_tokens": 0,
+            "cache_read_tokens": result.cache_read_tokens,
+            "cache_write_tokens": result.cache_write_tokens,
+            "thinking_tokens": result.thinking_tokens,
             "thinking_budget": None,
             "cost_usd": result.cost_usd,
             "num_turns": result.num_turns,
@@ -565,6 +569,9 @@ class PIAgentBase:
                 # Accumulate retry costs into the main metadata
                 metadata["input_tokens"] += retry_metadata.get("input_tokens", 0)
                 metadata["output_tokens"] += retry_metadata.get("output_tokens", 0)
+                metadata["cache_read_tokens"] += retry_metadata.get("cache_read_tokens", 0)
+                metadata["cache_write_tokens"] += retry_metadata.get("cache_write_tokens", 0)
+                metadata["thinking_tokens"] += retry_metadata.get("thinking_tokens", 0)
                 metadata["cost_usd"] += retry_metadata.get("cost_usd", 0)
                 metadata["num_turns"] += retry_metadata.get("num_turns", 0)
                 metadata["json_retry"] = True
@@ -798,16 +805,20 @@ Serialized payload:
 
                     # Accumulate usage
                     usage = msg.get("usage", {})
-                    result.input_tokens += usage.get("input", 0)
-                    result.output_tokens += usage.get("output", 0)
-                    result.cache_read_tokens += usage.get("cacheRead", 0)
-                    result.cache_write_tokens += usage.get("cacheWrite", 0)
+                    message_model = msg.get("model", result.model)
+                    normalized_usage = normalize_usage(
+                        usage,
+                        provider=self.options.provider,
+                        model=message_model,
+                    )
+                    result.input_tokens += normalized_usage.input_tokens
+                    result.output_tokens += normalized_usage.output_tokens
+                    result.cache_read_tokens += normalized_usage.cache_read_tokens
+                    result.cache_write_tokens += normalized_usage.cache_write_tokens
+                    result.thinking_tokens += normalized_usage.thinking_tokens
+                    result.cost_usd += normalized_usage.cost_usd
 
-                    cost = usage.get("cost", {})
-                    if isinstance(cost, dict):
-                        result.cost_usd += cost.get("total", 0) or 0
-
-                    result.model = msg.get("model", result.model)
+                    result.model = message_model
 
                     # Check for errors
                     stop_reason = msg.get("stopReason", "")

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import logging
 import re
+from dataclasses import dataclass
 
 import httpx
 
@@ -22,10 +23,30 @@ from baloo.github.models import (
     PRContext,
     PRDiscussionContext,
     PRMetadata,
+    ReviewComment,
     ReviewResult,
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DroppedReviewComment:
+    """Review comment that could not be placed on the GitHub diff."""
+
+    comment: ReviewComment
+    reason: str
+    nearest_valid_line: int | None = None
+
+
+@dataclass(frozen=True)
+class PostedReviewResult:
+    """Outcome of posting a pull request review."""
+
+    attempted: int
+    posted: int
+    dropped: list[DroppedReviewComment]
+    github_rejected: bool = False
 
 
 # Matches unified-diff hunk headers: @@ -old_start[,old_count] +new_start[,new_count] @@
@@ -85,6 +106,24 @@ def _valid_diff_lines(diff: str) -> dict[str, set[int]]:
         result[current_file] = current_lines
 
     return result
+
+
+def _apply_resolved_thread_state(
+    discussion_threads: list[DiscussionThread], resolved_ids: set[int]
+) -> None:
+    """Overlay GitHub's authoritative resolved state onto REST-built threads."""
+    if not resolved_ids:
+        return
+
+    for thread in discussion_threads:
+        if thread.root_comment_id in resolved_ids:
+            thread.resolved = True
+            thread.awaiting_response = False
+
+
+def _enum_value(value) -> str:
+    """Return enum value or string form for logging."""
+    return value.value if hasattr(value, "value") else str(value)
 
 
 class GitHubAPIClient:
@@ -193,10 +232,7 @@ class GitHubAPIClient:
             # The REST API doesn't expose thread resolution, so without
             # this call we rely on a keyword heuristic which is unreliable.
             resolved_ids = await self.fetch_resolved_thread_ids(repo_full_name, pr_number)
-            if resolved_ids:
-                for thread in discussion_threads:
-                    if thread.root_comment_id in resolved_ids:
-                        thread.resolved = True
+            _apply_resolved_thread_state(discussion_threads, resolved_ids)
 
             general_comments: list[DiscussionComment] = build_general_discussion(
                 issue_comments, reviews
@@ -246,7 +282,7 @@ class GitHubAPIClient:
         pr_number: int,
         review_result: ReviewResult,
         diff: str = "",
-    ) -> None:
+    ) -> PostedReviewResult:
         """
         Post a review to a pull request.
 
@@ -267,13 +303,27 @@ class GitHubAPIClient:
 
         # ---- validate comment line numbers against the diff ----
         valid_comments = list(review_result.comments)
+        dropped_comments: list[DroppedReviewComment] = []
         if diff and review_result.comments:
             valid_lines = _valid_diff_lines(diff)
             valid_comments = []
             for comment in review_result.comments:
                 file_lines = valid_lines.get(comment.path)
                 if file_lines is None:
-                    logger.warning("Dropping comment: file %s not in diff", comment.path)
+                    dropped_comments.append(
+                        DroppedReviewComment(comment=comment, reason="file_not_in_diff")
+                    )
+                    logger.warning(
+                        "Dropped review finding: reason=file_not_in_diff repo=%s pr=%s "
+                        "path=%s line=%s severity=%s category=%s body_preview=%r",
+                        repo_full_name,
+                        pr_number,
+                        comment.path,
+                        comment.line,
+                        _enum_value(comment.severity),
+                        _enum_value(comment.category),
+                        comment.body[:160],
+                    )
                     continue
                 if comment.line not in file_lines:
                     # Try to snap to the nearest valid line in the same file
@@ -289,11 +339,25 @@ class GitHubAPIClient:
                         comment = comment.model_copy(update={"line": nearest})
                         valid_comments.append(comment)
                     else:
+                        dropped_comments.append(
+                            DroppedReviewComment(
+                                comment=comment,
+                                reason="line_not_in_diff",
+                                nearest_valid_line=nearest,
+                            )
+                        )
                         logger.warning(
-                            "Dropping comment: %s:%d not in diff (nearest valid: %s)",
+                            "Dropped review finding: reason=line_not_in_diff repo=%s pr=%s "
+                            "path=%s line=%s nearest_valid_line=%s severity=%s category=%s "
+                            "body_preview=%r",
+                            repo_full_name,
+                            pr_number,
                             comment.path,
                             comment.line,
                             nearest,
+                            _enum_value(comment.severity),
+                            _enum_value(comment.category),
+                            comment.body[:160],
                         )
                     continue
                 valid_comments.append(comment)
@@ -301,9 +365,11 @@ class GitHubAPIClient:
             dropped = len(review_result.comments) - len(valid_comments)
             if dropped:
                 logger.warning(
-                    "Dropped %d/%d comments with invalid diff lines",
+                    "Dropped %d/%d review finding(s) with invalid diff lines for %s#%s",
                     dropped,
                     len(review_result.comments),
+                    repo_full_name,
+                    pr_number,
                 )
 
         async with httpx.AsyncClient() as client:
@@ -340,6 +406,12 @@ class GitHubAPIClient:
                 logger.info(
                     f"Successfully posted review with {len(valid_comments)} inline comments"
                 )
+                return PostedReviewResult(
+                    attempted=len(review_result.comments),
+                    posted=len(valid_comments),
+                    dropped=dropped_comments,
+                    github_rejected=False,
+                )
 
             except httpx.HTTPStatusError as e:
                 if e.response.status_code == 422:
@@ -351,9 +423,22 @@ class GitHubAPIClient:
                         "GitHub rejected review despite line validation (422). " "Error: %s",
                         e.response.text,
                     )
+                    return PostedReviewResult(
+                        attempted=len(review_result.comments),
+                        posted=0,
+                        dropped=dropped_comments,
+                        github_rejected=True,
+                    )
                 else:
                     # Other HTTP error - re-raise
                     raise
+
+        return PostedReviewResult(
+            attempted=len(review_result.comments),
+            posted=len(valid_comments),
+            dropped=dropped_comments,
+            github_rejected=False,
+        )
 
     async def post_comment(self, repo_full_name: str, pr_number: int, comment: str) -> int:
         """
@@ -664,7 +749,12 @@ class GitHubAPIClient:
                         break
 
         except Exception as exc:
-            logger.warning("Failed to fetch resolved thread state: %s", exc)
+            logger.warning(
+                "Failed to fetch resolved thread state: %s: %r",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
 
         return resolved_ids
 

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -196,6 +196,19 @@ def _has_existing_static_fidelity_report(
     )
 
 
+def _total_review_cost_usd(review_metadata: dict, fidelity_metadata: dict) -> float:
+    """Aggregate all model-call cost components associated with a review."""
+    fp_metadata = review_metadata.get("fp_verification") or {}
+    if not isinstance(fp_metadata, dict):
+        fp_metadata = {}
+
+    return (
+        (review_metadata.get("cost_usd") or 0.0)
+        + (fidelity_metadata.get("cost_usd") or 0.0)
+        + (fp_metadata.get("cost_usd") or 0.0)
+    )
+
+
 def _threads_from_issue_comments(
     issue_comments: list[DiscussionComment],
 ) -> list[DiscussionThread]:
@@ -936,9 +949,7 @@ async def process_pr_review(
                 total_output_tokens = (review_metadata.get("output_tokens") or 0) + (
                     fidelity_metadata.get("output_tokens") or 0
                 )
-                total_cost_usd = (review_metadata.get("cost_usd") or 0.0) + (
-                    fidelity_metadata.get("cost_usd") or 0.0
-                )
+                total_cost_usd = _total_review_cost_usd(review_metadata, fidelity_metadata)
 
                 # Detect agent soft-failures: agent caught an error
                 # internally and returned 0 findings

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -28,7 +28,7 @@ from baloo.fidelity.fidelity_report import (
 from baloo.fidelity.models import FidelityResult
 from baloo.fidelity.plan_fetcher import fetch_plan_content
 from baloo.fidelity.ticket_extractor import extract_ticket_id
-from baloo.github.api_client import GitHubAPIClient
+from baloo.github.api_client import GitHubAPIClient, PostedReviewResult
 from baloo.github.auth import verify_webhook_signature
 from baloo.github.models import (
     DiscussionComment,
@@ -40,6 +40,7 @@ from baloo.github.models import (
 from baloo.outcomes.labeler import label_pr_outcomes
 from baloo.processor.decision_engine import DecisionEngine
 from baloo.processor.findings_filter import FindingsFilter
+from baloo.processor.formatter import CommentFormatter
 from baloo.processor.severity_router import (
     ReviewSeverity,
     count_by_severity,
@@ -705,7 +706,7 @@ async def process_pr_review(
 
             decision_summary = DecisionEngine.get_decision_summary(approve, request_changes)
 
-            summary_text = agent_result.summary
+            summary_text = CommentFormatter.format_summary(decision_comments, agent_metadata)
             summary_text = f"{summary_text}\n\n{decision_summary}"
 
             if skipped_responded:
@@ -764,6 +765,7 @@ async def process_pr_review(
 
             # Route new findings by severity for posting/logging
             routed = route_findings(review_result.comments)
+            posted_review_result: PostedReviewResult | None = None
             logger.info(
                 f"New findings routed: {len(routed['review'])} blocking (CRITICAL/HIGH), "
                 f"{len(routed['checks'])} non-blocking (MEDIUM)"
@@ -810,7 +812,7 @@ async def process_pr_review(
 
             if request_changes and (routed["review"] or follow_up_comments):
                 logger.info("Posting request-changes review with new or follow-up findings")
-                await github_client.post_review(
+                posted_result = await github_client.post_review(
                     repo_full_name,
                     pr_number,
                     ReviewResult(
@@ -821,6 +823,16 @@ async def process_pr_review(
                     ),
                     diff=pr_context.diff,
                 )
+                if isinstance(posted_result, PostedReviewResult):
+                    posted_review_result = posted_result
+                    if posted_result.dropped:
+                        logger.warning(
+                            "Dropped %d/%d blocking review finding(s) while posting %s#%s",
+                            len(posted_result.dropped),
+                            posted_result.attempted,
+                            repo_full_name,
+                            pr_number,
+                        )
             elif request_changes and not has_new_feedback:
                 logger.info(
                     "Baloo is still waiting on existing threads; no new review posted to avoid noise."
@@ -858,6 +870,15 @@ async def process_pr_review(
                         f"{counts.get(ReviewSeverity.MEDIUM.value, 0)} medium, "
                         f"{counts.get(ReviewSeverity.LOW.value, 0)} low."
                     )
+                    if posted_review_result is not None:
+                        completion_msg += (
+                            f"\n\nPosted {posted_review_result.posted} inline comment(s)."
+                        )
+                        if posted_review_result.dropped:
+                            completion_msg += (
+                                f" Dropped {len(posted_review_result.dropped)} inline finding(s) "
+                                "that could not be placed on the diff; details were logged."
+                            )
                 elif not request_changes and approve:
                     completion_msg = (
                         f"✅ Baloo review completed in {review_duration}s. No issues found!"

--- a/baloo/processor/formatter.py
+++ b/baloo/processor/formatter.py
@@ -85,6 +85,8 @@ class CommentFormatter:
         model = metadata.get("model", "unknown")
         in_tok = metadata.get("input_tokens", 0)
         out_tok = metadata.get("output_tokens", 0)
+        cache_read_tok = metadata.get("cache_read_tokens", 0)
+        cache_write_tok = metadata.get("cache_write_tokens", 0)
         think_tok = metadata.get("thinking_tokens", 0)
         cost = metadata.get("cost_usd", 0)
         turns = metadata.get("num_turns", 0)
@@ -94,6 +96,10 @@ class CommentFormatter:
         if think_tok > 0:
             thinking_info = f"<li>**Thinking Tokens:** {think_tok:,}</li>"
 
+        cache_info = ""
+        if cache_read_tok > 0 or cache_write_tok > 0:
+            cache_info = f"<li>**Cache:** {cache_write_tok:,} write / {cache_read_tok:,} read</li>"
+
         return f"""
 <details>
 <summary>📊 Review Metadata</summary>
@@ -101,6 +107,7 @@ class CommentFormatter:
 <ul>
   <li>**Model:** `{model}`</li>
   <li>**Tokens:** {in_tok:,} (in) / {out_tok:,} (out)</li>
+  {cache_info}
   {thinking_info}
   <li>**Cost:** ${cost:.4f}</li>
   <li>**Turns:** {turns}</li>

--- a/scripts/local_review.py
+++ b/scripts/local_review.py
@@ -1,0 +1,277 @@
+"""Run a Baloo review locally without posting to GitHub."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from urllib.parse import urlparse
+
+from baloo.agent.client import BalooAgent
+from baloo.github.models import FileChange, PRContext, PRDiscussionContext, PRMetadata, ReviewResult
+
+GitRunner = Callable[[Sequence[str], str | None, bool], str]
+
+
+def run_git(args: Sequence[str], cwd: str | None = None, check: bool = True) -> str:
+    """Run a git command and return stdout."""
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if check and proc.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed with exit {proc.returncode}: {proc.stderr.strip()}"
+        )
+    return proc.stdout.rstrip("\n")
+
+
+def build_local_pr_context(
+    *,
+    base: str,
+    head: str,
+    title: str,
+    description: str,
+    author: str,
+    repo_full_name: str | None = None,
+    git: GitRunner = run_git,
+) -> PRContext:
+    """Build a synthetic PRContext from local git diff data."""
+    repo_root = git(["rev-parse", "--show-toplevel"], None, True)
+    head_branch = git(["rev-parse", "--abbrev-ref", head], repo_root, True)
+    head_sha = git(["rev-parse", head], repo_root, True)
+    diff_range = f"{base}...{head}"
+    diff = git(["diff", diff_range], repo_root, True)
+
+    if not diff.strip():
+        raise RuntimeError(f"No diff found for {diff_range}")
+
+    repo = repo_full_name or _infer_repo_full_name(repo_root, git)
+    files_changed = _build_file_changes(
+        numstat=git(["diff", "--numstat", diff_range], repo_root, True),
+        name_status=git(["diff", "--name-status", diff_range], repo_root, True),
+    )
+    repo_guidelines = _load_repo_guidelines(head, repo_root, git)
+
+    return PRContext(
+        metadata=PRMetadata(
+            repo_full_name=repo,
+            pr_number=0,
+            title=title,
+            description=description,
+            author=author,
+            base_branch=base,
+            head_branch=head_branch,
+            head_sha=head_sha,
+            files_changed=files_changed,
+            repo_guidelines=repo_guidelines,
+        ),
+        discussion=PRDiscussionContext(
+            digest="**Open Baloo threads awaiting response:** 0\n"
+            "**Recent inline discussions:**\n"
+            "- No inline review threads yet.",
+            awaiting_response_count=0,
+        ),
+        diff=diff,
+    )
+
+
+async def run_local_review(
+    *,
+    context: PRContext,
+    agent: BalooAgent,
+    model: str | None,
+    output_json: bool,
+    fail_on_blocking: bool,
+) -> int:
+    """Run BalooAgent against a synthetic context and print the dry-run result."""
+    if model:
+        result = await agent.review_pr(context, model_override=model)
+    else:
+        result = await agent.review_pr(context)
+
+    if output_json:
+        print(json.dumps(_result_to_json(result), indent=2))
+    else:
+        _print_markdown_result(result)
+
+    if fail_on_blocking and _has_blocking_findings(result):
+        return 1
+    return 0
+
+
+async def async_main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main", help="Base ref for the comparison")
+    parser.add_argument("--head", default="HEAD", help="Head ref for the comparison")
+    parser.add_argument("--title", default="Local Baloo review", help="Synthetic PR title")
+    parser.add_argument("--description", default="", help="Synthetic PR description")
+    parser.add_argument("--author", default="local", help="Synthetic PR author")
+    parser.add_argument("--repo-full-name", help="Override inferred owner/repo name")
+    parser.add_argument("--model", help="Optional Baloo model override")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    parser.add_argument(
+        "--fail-on-blocking",
+        action="store_true",
+        help="Exit 1 when CRITICAL/HIGH findings are present",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        context = build_local_pr_context(
+            base=args.base,
+            head=args.head,
+            title=args.title,
+            description=args.description,
+            author=args.author,
+            repo_full_name=args.repo_full_name,
+        )
+        return await run_local_review(
+            context=context,
+            agent=BalooAgent(),
+            model=args.model,
+            output_json=args.json,
+            fail_on_blocking=args.fail_on_blocking,
+        )
+    except Exception as exc:
+        print(f"local review failed: {exc}", file=sys.stderr)
+        return 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return asyncio.run(async_main(argv))
+
+
+def _build_file_changes(*, numstat: str, name_status: str) -> list[FileChange]:
+    stats = _parse_numstat(numstat)
+    changes: list[FileChange] = []
+
+    for raw_line in name_status.splitlines():
+        if not raw_line.strip():
+            continue
+        parts = raw_line.split("\t")
+        status_code = parts[0]
+        filename = parts[-1]
+        additions, deletions = stats.get(filename, (0, 0))
+        changes.append(
+            FileChange(
+                filename=filename,
+                status=_status_name(status_code),
+                additions=additions,
+                deletions=deletions,
+                changes=additions + deletions,
+            )
+        )
+
+    return changes
+
+
+def _parse_numstat(output: str) -> dict[str, tuple[int, int]]:
+    stats: dict[str, tuple[int, int]] = {}
+    for raw_line in output.splitlines():
+        if not raw_line.strip():
+            continue
+        additions_raw, deletions_raw, filename = raw_line.split("\t", 2)
+        additions = 0 if additions_raw == "-" else int(additions_raw)
+        deletions = 0 if deletions_raw == "-" else int(deletions_raw)
+        stats[filename] = (additions, deletions)
+    return stats
+
+
+def _status_name(status_code: str) -> str:
+    status = status_code[0]
+    return {
+        "A": "added",
+        "C": "copied",
+        "D": "removed",
+        "M": "modified",
+        "R": "renamed",
+        "T": "modified",
+        "U": "modified",
+    }.get(status, "modified")
+
+
+def _load_repo_guidelines(head: str, repo_root: str, git: GitRunner) -> str | None:
+    guideline_parts: list[str] = []
+    for path in ("AGENTS.md", "CONTRIBUTING.md"):
+        content = git(["show", f"{head}:{path}"], repo_root, False).strip()
+        if content:
+            guideline_parts.append(content)
+    return "\n\n---\n\n".join(guideline_parts) if guideline_parts else None
+
+
+def _infer_repo_full_name(repo_root: str, git: GitRunner) -> str:
+    remote = git(["config", "--get", "remote.origin.url"], repo_root, False).strip()
+    parsed = _parse_github_remote(remote)
+    if parsed:
+        return parsed
+    return f"local/{Path(repo_root).name}"
+
+
+def _parse_github_remote(remote: str) -> str | None:
+    if not remote:
+        return None
+
+    if remote.startswith("git@"):
+        path = remote.split(":", 1)[-1]
+    else:
+        parsed = urlparse(remote)
+        path = parsed.path.lstrip("/")
+
+    if path.endswith(".git"):
+        path = path[:-4]
+
+    parts = [part for part in path.split("/") if part]
+    if len(parts) >= 2:
+        return "/".join(parts[-2:])
+    return None
+
+
+def _print_markdown_result(result: ReviewResult) -> None:
+    print(result.summary)
+    if not result.comments:
+        return
+
+    print("\n## Findings")
+    for comment in result.comments:
+        severity = _value(comment.severity)
+        category = _value(comment.category)
+        print(f"\n### [{severity}] {category} - {comment.path}:{comment.line}")
+        print(comment.body)
+
+
+def _result_to_json(result: ReviewResult) -> dict:
+    return {
+        "summary": result.summary,
+        "approve": result.approve,
+        "request_changes": result.request_changes,
+        "findings": [
+            {
+                "path": comment.path,
+                "line": comment.line,
+                "severity": _value(comment.severity),
+                "category": _value(comment.category),
+                "body": comment.body,
+            }
+            for comment in result.comments
+        ],
+    }
+
+
+def _has_blocking_findings(result: ReviewResult) -> bool:
+    return any(_value(comment.severity) in {"CRITICAL", "HIGH"} for comment in result.comments)
+
+
+def _value(value) -> str:
+    return value.value if hasattr(value, "value") else str(value)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_review.py
+++ b/scripts/local_review.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import subprocess
 import sys
 from collections.abc import Callable, Sequence
@@ -13,6 +14,8 @@ from urllib.parse import urlparse
 
 from baloo.agent.client import BalooAgent
 from baloo.github.models import FileChange, PRContext, PRDiscussionContext, PRMetadata, ReviewResult
+
+logger = logging.getLogger(__name__)
 
 GitRunner = Callable[[Sequence[str], str | None, bool], str]
 
@@ -178,7 +181,11 @@ def _parse_numstat(output: str) -> dict[str, tuple[int, int]]:
     for raw_line in output.splitlines():
         if not raw_line.strip():
             continue
-        additions_raw, deletions_raw, filename = raw_line.split("\t", 2)
+        parts = raw_line.split("\t", 2)
+        if len(parts) < 3:
+            logger.warning("Unexpected numstat line (skipping): %r", raw_line)
+            continue
+        additions_raw, deletions_raw, filename = parts
         additions = 0 if additions_raw == "-" else int(additions_raw)
         deletions = 0 if deletions_raw == "-" else int(deletions_raw)
         stats[filename] = (additions, deletions)

--- a/tests/agent/test_client_integration.py
+++ b/tests/agent/test_client_integration.py
@@ -471,7 +471,9 @@ class TestBalooAgentMetadata:
 
             assert result.metadata["input_tokens"] == 2000
             assert result.metadata["output_tokens"] == 500
-            assert result.metadata["cost_usd"] == 0.10
+            assert result.metadata["cache_read_tokens"] == 1000
+            assert result.metadata["cache_write_tokens"] == 200
+            assert result.metadata["cost_usd"] == pytest.approx(0.01455)
 
     def test_format_metadata_section(self):
         """Test summary formatting with metadata."""
@@ -479,6 +481,8 @@ class TestBalooAgentMetadata:
             "model": "claude-sonnet-4-6",
             "input_tokens": 2000,
             "output_tokens": 500,
+            "cache_read_tokens": 1000,
+            "cache_write_tokens": 200,
             "thinking_tokens": 0,
             "thinking_budget": None,
             "cost_usd": 0.10,
@@ -489,4 +493,5 @@ class TestBalooAgentMetadata:
         result = CommentFormatter.format_summary([], metadata)
 
         assert "**Model:** `claude-sonnet-4-6`" in result
+        assert "**Cache:** 200 write / 1,000 read" in result
         assert "**Cost:** $0.1000" in result

--- a/tests/agent/test_costs.py
+++ b/tests/agent/test_costs.py
@@ -50,6 +50,23 @@ def test_uses_pi_camel_case_usage_fields():
     assert normalized.cost_usd == pytest.approx(0.01455)
 
 
+def test_bills_separately_reported_thinking_tokens_as_output():
+    usage = {
+        "input_tokens": 1_000_000,
+        "output_tokens": 100_000,
+        "thinking_tokens": 50_000,
+    }
+
+    normalized = normalize_usage(
+        usage,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+
+    assert normalized.thinking_tokens == 50_000
+    assert normalized.cost_usd == pytest.approx(5.25)
+
+
 def test_falls_back_to_provider_reported_cost_for_unknown_pricing():
     normalized = normalize_usage(
         {"input": 2_000, "output": 500, "cost": {"total": 0.10}},

--- a/tests/agent/test_costs.py
+++ b/tests/agent/test_costs.py
@@ -1,8 +1,10 @@
 """Tests for model usage normalization and cost estimation."""
 
+import logging
+
 import pytest
 
-from baloo.agent.costs import normalize_usage
+from baloo.agent.costs import _usage_int, normalize_usage
 
 
 def test_estimates_anthropic_cost_from_billing_usage_fields():
@@ -65,6 +67,13 @@ def test_bills_separately_reported_thinking_tokens_as_output():
 
     assert normalized.thinking_tokens == 50_000
     assert normalized.cost_usd == pytest.approx(5.25)
+
+
+def test_usage_int_logs_debug_when_aliases_missing(caplog):
+    """Missing usage aliases should emit debug signal instead of failing silently."""
+    caplog.set_level(logging.DEBUG)
+    assert _usage_int({"unknown_metric": 5}, "input", "input_tokens") == 0
+    assert "_usage_int" in caplog.text
 
 
 def test_falls_back_to_provider_reported_cost_for_unknown_pricing():

--- a/tests/agent/test_costs.py
+++ b/tests/agent/test_costs.py
@@ -1,0 +1,60 @@
+"""Tests for model usage normalization and cost estimation."""
+
+import pytest
+
+from baloo.agent.costs import normalize_usage
+
+
+def test_estimates_anthropic_cost_from_billing_usage_fields():
+    """Anthropic cache tokens should be priced separately from regular input."""
+    usage = {
+        "input_tokens": 1_000_000,
+        "output_tokens": 100_000,
+        "cache_creation_input_tokens": 10_000,
+        "cache_read_input_tokens": 20_000,
+        "cost": {"total": 999.0},
+    }
+
+    normalized = normalize_usage(
+        usage,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+
+    assert normalized.input_tokens == 1_000_000
+    assert normalized.output_tokens == 100_000
+    assert normalized.cache_write_tokens == 10_000
+    assert normalized.cache_read_tokens == 20_000
+    assert normalized.cost_usd == pytest.approx(4.5435)
+
+
+def test_uses_pi_camel_case_usage_fields():
+    usage = {
+        "input": 2_000,
+        "output": 500,
+        "cacheWrite": 200,
+        "cacheRead": 1_000,
+        "cost": {"total": 0.10},
+    }
+
+    normalized = normalize_usage(
+        usage,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+
+    assert normalized.input_tokens == 2_000
+    assert normalized.output_tokens == 500
+    assert normalized.cache_write_tokens == 200
+    assert normalized.cache_read_tokens == 1_000
+    assert normalized.cost_usd == pytest.approx(0.01455)
+
+
+def test_falls_back_to_provider_reported_cost_for_unknown_pricing():
+    normalized = normalize_usage(
+        {"input": 2_000, "output": 500, "cost": {"total": 0.10}},
+        provider="google",
+        model="gemini-2.5-flash",
+    )
+
+    assert normalized.cost_usd == 0.10

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -210,9 +210,56 @@ class TestPIAgentBaseRunQuery:
             assert output["findings"][0]["file"] == "a.py"
             assert metadata["input_tokens"] == 500
             assert metadata["output_tokens"] == 100
-            assert metadata["cost_usd"] == 0.01
+            assert metadata["cache_read_tokens"] == 0
+            assert metadata["cache_write_tokens"] == 0
+            assert metadata["cost_usd"] == pytest.approx(0.003)
             assert metadata["num_turns"] == 1
             assert metadata["model"] == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_anthropic_usage_metadata_includes_cache_tokens_and_estimated_cost(self):
+        """Runtime metadata should expose all Anthropic billing token classes."""
+        structured = {"findings": [], "summary": {}}
+        usage = {
+            "input_tokens": 1_000_000,
+            "output_tokens": 100_000,
+            "cache_creation_input_tokens": 10_000,
+            "cache_read_input_tokens": 20_000,
+            "cost": {"total": 999.0},
+        }
+        events = self._make_events(structured, usage)
+
+        agent = PIAgentBase(PIAgentOptions(model="claude-sonnet-4-6", provider="anthropic"))
+
+        with patch("baloo.agent.pi_runtime.asyncio.create_subprocess_exec") as mock_exec:
+            proc = AsyncMock()
+            proc.returncode = None
+            proc.stdin = AsyncMock()
+            proc.stdin.write = MagicMock()
+            proc.stdin.drain = AsyncMock()
+            proc.stdout = AsyncMock(spec=asyncio.StreamReader)
+
+            event_iter = iter(events)
+
+            async def fake_readline():
+                try:
+                    return next(event_iter)
+                except StopIteration:
+                    return b""
+
+            proc.stdout.readline = fake_readline
+            proc.stderr = AsyncMock()
+            proc.kill = MagicMock()
+            proc.wait = AsyncMock()
+            mock_exec.return_value = proc
+
+            _, metadata = await agent.run_query("Review")
+
+        assert metadata["input_tokens"] == 1_000_000
+        assert metadata["output_tokens"] == 100_000
+        assert metadata["cache_write_tokens"] == 10_000
+        assert metadata["cache_read_tokens"] == 20_000
+        assert metadata["cost_usd"] == pytest.approx(4.5435)
 
     @pytest.mark.asyncio
     async def test_empty_response(self):

--- a/tests/github/test_api_client_post_review.py
+++ b/tests/github/test_api_client_post_review.py
@@ -1,0 +1,75 @@
+"""Tests for posting pull request reviews."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from baloo.github.api_client import GitHubAPIClient
+from baloo.github.models import ReviewComment, ReviewResult
+
+
+def _mock_response(body: dict | None = None):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = body or {}
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_post_review_reports_and_logs_dropped_invalid_diff_comments(caplog):
+    """Invalid diff-line findings should be observable internally."""
+    diff = "\n".join(
+        [
+            "diff --git a/file.py b/file.py",
+            "@@ -8,3 +8,3 @@",
+            " context",
+            "+added",
+            " context",
+        ]
+    )
+    valid = ReviewComment(
+        path="file.py",
+        line=9,
+        body="Valid high finding",
+        severity="HIGH",
+        category="Bugs",
+    )
+    invalid = ReviewComment(
+        path="file.py",
+        line=99,
+        body="Invalid high finding",
+        severity="HIGH",
+        category="Silent Failures",
+    )
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_cls,
+        patch(
+            "baloo.github.auth.GitHubAuth.get_installation_token",
+            return_value="fake-token",
+        ),
+    ):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=_mock_response({"id": 123}))
+        mock_client_cls.return_value = mock_client
+
+        client = GitHubAPIClient(installation_id=1)
+        with caplog.at_level("WARNING", logger="baloo.github.api_client"):
+            result = await client.post_review(
+                "owner/repo",
+                42,
+                ReviewResult(summary="Review summary", comments=[valid, invalid]),
+                diff=diff,
+            )
+
+    assert result.attempted == 2
+    assert result.posted == 1
+    assert len(result.dropped) == 1
+    assert result.dropped[0].comment == invalid
+    assert result.dropped[0].reason == "line_not_in_diff"
+    assert result.dropped[0].nearest_valid_line == 10
+    assert "reason=line_not_in_diff" in caplog.text
+    assert "severity=HIGH" in caplog.text
+    assert "category=Silent Failures" in caplog.text

--- a/tests/github/test_resolved_threads.py
+++ b/tests/github/test_resolved_threads.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from baloo.github.api_client import GitHubAPIClient
+from baloo.github.api_client import GitHubAPIClient, _apply_resolved_thread_state
+from baloo.github.discussions import build_discussion_digest
+from baloo.github.models import DiscussionComment, DiscussionThread
 
 
 def _graphql_response(nodes: list[dict], has_next: bool = False, cursor: str = "c1") -> dict:
@@ -135,6 +138,22 @@ class TestFetchResolvedThreadIds:
         assert ids == set()
 
     @pytest.mark.asyncio
+    async def test_logs_exception_type_when_resolved_thread_fetch_fails(self, caplog):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(side_effect=httpx.TimeoutException(""))
+            mock_client_cls.return_value = mock_client
+
+            client = GitHubAPIClient(installation_id=1)
+            with caplog.at_level("WARNING", logger="baloo.github.api_client"):
+                ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
+
+        assert ids == set()
+        assert "TimeoutException" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_no_resolved_threads(self):
         body = _graphql_response(
             [
@@ -154,3 +173,39 @@ class TestFetchResolvedThreadIds:
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
         assert ids == set()
+
+
+class TestApplyResolvedThreadState:
+    def test_resolved_baloo_thread_is_not_counted_as_awaiting_response(self):
+        """GraphQL-resolved threads should not remain open just because Baloo commented last."""
+        now = datetime.now(timezone.utc)
+        thread = DiscussionThread(
+            id=100,
+            path="file.py",
+            line=10,
+            comments=[
+                DiscussionComment(
+                    id=100,
+                    author="baloo-code-reviewer[bot]",
+                    body="**[HIGH] Bugs** - Existing issue",
+                    created_at=now,
+                    updated_at=now,
+                    source="review_comment",
+                    is_baloo=True,
+                    path="file.py",
+                    line=10,
+                )
+            ],
+            is_baloo_thread=True,
+            awaiting_response=True,
+            resolved=False,
+            last_activity=now,
+            root_comment_id=100,
+        )
+
+        _apply_resolved_thread_state([thread], {100})
+        _, awaiting_count = build_discussion_digest([thread], [])
+
+        assert thread.resolved is True
+        assert thread.awaiting_response is False
+        assert awaiting_count == 0

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -12,8 +12,202 @@ from baloo.fidelity.fidelity_report import (
     NO_TICKET_FIDELITY_SENTINEL,
 )
 from baloo.fidelity.models import FidelityResult
-from baloo.github.models import DiscussionComment, ReviewComment, ReviewResult
+from baloo.github.api_client import DroppedReviewComment, PostedReviewResult
+from baloo.github.models import DiscussionComment, DiscussionThread, ReviewComment, ReviewResult
 from baloo.github.webhook_handler import process_pr_review
+
+
+def _baloo_thread(
+    *,
+    thread_id: int,
+    path: str,
+    line: int,
+    body: str,
+    awaiting_response: bool = False,
+    resolved: bool = False,
+) -> DiscussionThread:
+    now = datetime.now(timezone.utc)
+    return DiscussionThread(
+        id=thread_id,
+        path=path,
+        line=line,
+        comments=[
+            DiscussionComment(
+                id=thread_id,
+                author="baloo-code-reviewer[bot]",
+                body=body,
+                created_at=now,
+                updated_at=now,
+                source="review_comment",
+                is_baloo=True,
+                path=path,
+                line=line,
+            )
+        ],
+        is_baloo_thread=True,
+        awaiting_response=awaiting_response,
+        resolved=resolved,
+        last_activity=now,
+        root_comment_id=thread_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_review_summary_uses_actionable_findings_after_resolved_thread_skip():
+    """Review body counts should reflect deduped actionable findings, not raw agent output."""
+    mock_github_client = MagicMock()
+    mock_github_client.post_comment = AsyncMock()
+    mock_github_client.edit_comment = AsyncMock()
+    mock_github_client.reply_to_review_comment = AsyncMock()
+    mock_github_client.post_review = AsyncMock(
+        return_value=PostedReviewResult(attempted=1, posted=1, dropped=[])
+    )
+
+    resolved_body = "**[HIGH] Bugs** - Existing resolved issue"
+    mock_pr_context = MagicMock()
+    mock_pr_context.discussion_threads = [
+        _baloo_thread(
+            thread_id=111,
+            path="file.py",
+            line=10,
+            body=resolved_body,
+            awaiting_response=False,
+            resolved=True,
+        )
+    ]
+    mock_pr_context.issue_comments = []
+    mock_pr_context.awaiting_response_threads = 0
+    mock_pr_context.head_sha = "abc123"
+    mock_pr_context.head_branch = "fix/counts"
+    mock_pr_context.title = "Fix counts"
+    mock_pr_context.description = ""
+    mock_pr_context.diff = "+ added code"
+    mock_github_client.get_pr_context = AsyncMock(return_value=mock_pr_context)
+
+    mock_agent = MagicMock()
+    mock_agent.review_pr = AsyncMock(
+        return_value=ReviewResult(
+            summary="## 🐻 Baloo Review Summary\n\n🟠 **2** High\n**Total**: 2 issue(s) found",
+            comments=[
+                ReviewComment(
+                    path="file.py",
+                    line=10,
+                    body="**Existing resolved issue**\n\nStill present",
+                    severity="HIGH",
+                    category="Bugs",
+                ),
+                ReviewComment(
+                    path="new.py",
+                    line=20,
+                    body="**Fresh issue**\n\nNew actionable finding",
+                    severity="HIGH",
+                    category="Bugs",
+                ),
+            ],
+            approve=False,
+            request_changes=True,
+        )
+    )
+
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.fidelity_enabled", False),
+        patch("baloo.config.settings.settings.fp_verification_enabled", False),
+        patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"),
+    ):
+        await process_pr_review(
+            repo_full_name="test/repo",
+            pr_number=123,
+            installation_id=456,
+            trigger_reason="test",
+            notify_progress=False,
+        )
+
+    posted_review = mock_github_client.post_review.call_args.args[2]
+    assert "**Total**: 1 issue(s) found" in posted_review.summary
+    assert "**Total**: 2 issue(s) found" not in posted_review.summary
+    assert "✅ Skipped 1 resolved thread(s)." in posted_review.summary
+
+
+@pytest.mark.asyncio
+async def test_progress_comment_reports_dropped_inline_findings_internally():
+    """Progress comments should not imply every actionable finding was posted inline."""
+    mock_github_client = MagicMock()
+    mock_github_client.post_comment = AsyncMock(return_value=12345)
+    mock_github_client.edit_comment = AsyncMock()
+    mock_github_client.reply_to_review_comment = AsyncMock()
+
+    dropped_comment = ReviewComment(
+        path="file.py",
+        line=99,
+        body="Dropped high finding with enough detail",
+        severity="HIGH",
+        category="Bugs",
+    )
+    mock_github_client.post_review = AsyncMock(
+        return_value=PostedReviewResult(
+            attempted=2,
+            posted=1,
+            dropped=[
+                DroppedReviewComment(
+                    comment=dropped_comment,
+                    reason="line_not_in_diff",
+                    nearest_valid_line=10,
+                )
+            ],
+        )
+    )
+
+    mock_pr_context = MagicMock()
+    mock_pr_context.discussion_threads = []
+    mock_pr_context.issue_comments = []
+    mock_pr_context.awaiting_response_threads = 0
+    mock_pr_context.head_sha = "abc123"
+    mock_pr_context.head_branch = "fix/counts"
+    mock_pr_context.title = "Fix counts"
+    mock_pr_context.description = ""
+    mock_pr_context.diff = "+ added code"
+    mock_github_client.get_pr_context = AsyncMock(return_value=mock_pr_context)
+
+    mock_agent = MagicMock()
+    mock_agent.review_pr = AsyncMock(
+        return_value=ReviewResult(
+            summary="Raw summary",
+            comments=[
+                ReviewComment(
+                    path="file.py",
+                    line=10,
+                    body="Posted high finding with enough detail",
+                    severity="HIGH",
+                    category="Bugs",
+                ),
+                dropped_comment,
+            ],
+            approve=False,
+            request_changes=True,
+        )
+    )
+
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.fidelity_enabled", False),
+        patch("baloo.config.settings.settings.fp_verification_enabled", False),
+        patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"),
+    ):
+        await process_pr_review(
+            repo_full_name="test/repo",
+            pr_number=123,
+            installation_id=456,
+            trigger_reason="test",
+            notify_progress=True,
+        )
+
+    completion_msg = mock_github_client.edit_comment.call_args.args[2]
+    assert "Found 2 issue(s)" in completion_msg
+    assert "Posted 1 inline comment(s)." in completion_msg
+    assert "Dropped 1 inline finding(s)" in completion_msg
 
 
 @pytest.mark.asyncio

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -14,7 +14,7 @@ from baloo.fidelity.fidelity_report import (
 from baloo.fidelity.models import FidelityResult
 from baloo.github.api_client import DroppedReviewComment, PostedReviewResult
 from baloo.github.models import DiscussionComment, DiscussionThread, ReviewComment, ReviewResult
-from baloo.github.webhook_handler import process_pr_review
+from baloo.github.webhook_handler import _total_review_cost_usd, process_pr_review
 
 
 def _baloo_thread(
@@ -50,6 +50,19 @@ def _baloo_thread(
         last_activity=now,
         root_comment_id=thread_id,
     )
+
+
+def test_total_review_cost_includes_fp_verification_cost():
+    """Persisted review cost should include main, fidelity, and FP verifier calls."""
+    total = _total_review_cost_usd(
+        {
+            "cost_usd": 0.10,
+            "fp_verification": {"cost_usd": 0.03},
+        },
+        {"cost_usd": 0.02},
+    )
+
+    assert total == pytest.approx(0.15)
 
 
 @pytest.mark.asyncio
@@ -114,6 +127,7 @@ async def test_review_summary_uses_actionable_findings_after_resolved_thread_ski
         patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
         patch("baloo.config.settings.settings.fidelity_enabled", False),
         patch("baloo.config.settings.settings.fp_verification_enabled", False),
+        patch("baloo.github.webhook_handler.settings.fp_verification_enabled", False),
         patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"),
     ):
         await process_pr_review(
@@ -194,6 +208,7 @@ async def test_progress_comment_reports_dropped_inline_findings_internally():
         patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
         patch("baloo.config.settings.settings.fidelity_enabled", False),
         patch("baloo.config.settings.settings.fp_verification_enabled", False),
+        patch("baloo.github.webhook_handler.settings.fp_verification_enabled", False),
         patch("baloo.config.settings.settings.review_min_severity", "MEDIUM"),
     ):
         await process_pr_review(

--- a/tests/test_local_review.py
+++ b/tests/test_local_review.py
@@ -5,7 +5,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from baloo.github.models import ReviewComment, ReviewResult
-from scripts.local_review import build_local_pr_context, run_local_review
+from scripts.local_review import _parse_numstat, build_local_pr_context, run_local_review
+
+
+def test_parse_numstat_skips_malformed_lines():
+    """Malformed git numstat lines should not crash parsing."""
+    stats = _parse_numstat("1\t2\n7\t8\tgood.py\n")
+    assert stats == {"good.py": (7, 8)}
 
 
 def test_build_local_pr_context_from_git_diff():

--- a/tests/test_local_review.py
+++ b/tests/test_local_review.py
@@ -1,0 +1,90 @@
+"""Tests for the local Baloo review CLI."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from baloo.github.models import ReviewComment, ReviewResult
+from scripts.local_review import build_local_pr_context, run_local_review
+
+
+def test_build_local_pr_context_from_git_diff():
+    """Synthetic PR context should be built from local git state."""
+    outputs = {
+        ("rev-parse", "--show-toplevel"): "/repo",
+        ("rev-parse", "--abbrev-ref", "HEAD"): "fix/local-review",
+        ("rev-parse", "HEAD"): "abc123",
+        (
+            "config",
+            "--get",
+            "remote.origin.url",
+        ): "git@github.com:Blue-Bear-Security/baloo-bear.git",
+        ("diff", "--numstat", "origin/main...HEAD"): "3\t1\tbaloo/foo.py\n-\t-\tbinary.bin\n",
+        ("diff", "--name-status", "origin/main...HEAD"): "M\tbaloo/foo.py\nA\tbinary.bin\n",
+        (
+            "diff",
+            "origin/main...HEAD",
+        ): "diff --git a/baloo/foo.py b/baloo/foo.py\n@@ -1 +1 @@\n-old\n+new\n",
+        ("show", "HEAD:AGENTS.md"): "Repo guidelines",
+        ("show", "HEAD:CONTRIBUTING.md"): "",
+    }
+
+    def fake_git(args, cwd=None, check=True):
+        return outputs[tuple(args)]
+
+    context = build_local_pr_context(
+        base="origin/main",
+        head="HEAD",
+        title="Local review",
+        description="Dry run",
+        author="dev",
+        git=fake_git,
+    )
+
+    assert context.pr_number == 0
+    assert context.repo_full_name == "Blue-Bear-Security/baloo-bear"
+    assert context.base_branch == "origin/main"
+    assert context.head_branch == "fix/local-review"
+    assert context.head_sha == "abc123"
+    assert context.repo_guidelines == "Repo guidelines"
+    assert context.diff.startswith("diff --git")
+    assert [f.filename for f in context.files_changed] == ["baloo/foo.py", "binary.bin"]
+    assert context.files_changed[0].status == "modified"
+    assert context.files_changed[0].additions == 3
+    assert context.files_changed[1].additions == 0
+
+
+@pytest.mark.asyncio
+async def test_run_local_review_prints_summary_and_returns_blocking_status(capsys):
+    """CLI runner should call BalooAgent without posting to GitHub."""
+    context = MagicMock()
+    result = ReviewResult(
+        summary="## Summary",
+        comments=[
+            ReviewComment(
+                path="file.py",
+                line=10,
+                body="High issue",
+                severity="HIGH",
+                category="Bugs",
+            )
+        ],
+        approve=False,
+        request_changes=True,
+    )
+    agent = MagicMock()
+    agent.review_pr = AsyncMock(return_value=result)
+
+    exit_code = await run_local_review(
+        context=context,
+        agent=agent,
+        model=None,
+        output_json=False,
+        fail_on_blocking=True,
+    )
+
+    captured = capsys.readouterr()
+    assert "## Summary" in captured.out
+    assert "[HIGH] Bugs - file.py:10" in captured.out
+    assert exit_code == 1
+    agent.review_pr.assert_awaited_once_with(context)


### PR DESCRIPTION
## Summary
- Fix Baloo review summaries and progress updates so counts reflect actionable findings, resolved threads, and dropped inline comments.
- Add `scripts/local_review.py` for local dry-run reviews against git diffs before opening a PR.
- Normalize Anthropic usage/cost accounting, including cache tokens, thinking tokens, and FP verification costs.

## Test plan
- `DATABASE_ENABLED=false REVIEW_AUTO_APPROVE=true uv run pytest`
- `uv run ruff check baloo scripts tests`
- Code review completed with no blocking issues; follow-up thinking-token cost gap fixed and covered by tests.

Made with [Cursor](https://cursor.com)