### PR TITLE
fix: ensure all timestamps use UTC consistently

### DIFF
--- a/baloo/dashboard/templates/base.html
+++ b/baloo/dashboard/templates/base.html
@@ -42,5 +42,31 @@
   <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
     {% block content %}{% endblock %}
   </main>
+  <script>
+    function convertTimestamps(root) {
+      root.querySelectorAll("time.local-time").forEach(function(el) {
+        var d = new Date(el.getAttribute("datetime"));
+        if (!isNaN(d)) {
+          el.textContent = d.getFullYear() + "-" +
+            String(d.getMonth() + 1).padStart(2, "0") + "-" +
+            String(d.getDate()).padStart(2, "0") + " " +
+            String(d.getHours()).padStart(2, "0") + ":" +
+            String(d.getMinutes()).padStart(2, "0");
+        }
+      });
+      root.querySelectorAll("time.local-time-short").forEach(function(el) {
+        var d = new Date(el.getAttribute("datetime"));
+        if (!isNaN(d)) {
+          el.textContent = String(d.getHours()).padStart(2, "0") + ":" +
+            String(d.getMinutes()).padStart(2, "0") + ":" +
+            String(d.getSeconds()).padStart(2, "0");
+        }
+      });
+    }
+    convertTimestamps(document);
+    document.body.addEventListener("htmx:afterSwap", function(e) {
+      convertTimestamps(e.detail.target);
+    });
+  </script>
 </body>
 </html>

--- a/baloo/dashboard/templates/overview.html
+++ b/baloo/dashboard/templates/overview.html
@@ -169,7 +169,7 @@
           {% endif %}
         </td>
         <td class="px-4 py-3 text-sm text-red-700 max-w-xs truncate" title="{{ r.error_message }}">{{ r.error_message[:80] if r.error_message else "-" }}{{ "..." if r.error_message and r.error_message|length > 80 else "" }}</td>
-        <td class="px-4 py-3 text-sm text-gray-500">{{ r.started_at.strftime("%Y-%m-%d %H:%M") }}</td>
+        <td class="px-4 py-3 text-sm text-gray-500"><time datetime="{{ r.started_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}" class="local-time">{{ r.started_at.strftime("%Y-%m-%d %H:%M") }} UTC</time></td>
       </tr>
       {% endfor %}
     </tbody>
@@ -217,7 +217,7 @@
           {% endif %}
         </td>
         <td class="px-4 py-3 text-sm text-gray-500">{{ "%.1fs"|format(r.duration_seconds) if r.duration_seconds else "-" }}</td>
-        <td class="px-4 py-3 text-sm text-gray-500">{{ r.started_at.strftime("%Y-%m-%d %H:%M") }}</td>
+        <td class="px-4 py-3 text-sm text-gray-500"><time datetime="{{ r.started_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}" class="local-time">{{ r.started_at.strftime("%Y-%m-%d %H:%M") }} UTC</time></td>
       </tr>
       {% endfor %}
       {% if not recent_reviews %}

--- a/baloo/dashboard/templates/partials/review_logs.html
+++ b/baloo/dashboard/templates/partials/review_logs.html
@@ -4,7 +4,7 @@
   <div class="flex items-start gap-3">
     <!-- Timestamp -->
     <span class="text-xs text-gray-400 font-mono whitespace-nowrap mt-0.5">
-      {{ log.created_at.strftime("%H:%M:%S") }}
+      <time datetime="{{ log.created_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}" class="local-time-short">{{ log.created_at.strftime("%H:%M:%S") }} UTC</time>
     </span>
 
     <!-- Event badge -->

--- a/baloo/dashboard/templates/partials/reviews_table.html
+++ b/baloo/dashboard/templates/partials/reviews_table.html
@@ -37,7 +37,7 @@
       </td>
       <td class="px-4 py-3 text-sm text-gray-500">{{ "%.1fs"|format(r.duration_seconds) if r.duration_seconds else "-" }}</td>
       <td class="px-4 py-3 text-sm text-gray-500">{{ "$%.4f"|format(r.cost_usd) if r.cost_usd else "-" }}</td>
-      <td class="px-4 py-3 text-sm text-gray-500">{{ r.started_at.strftime("%Y-%m-%d %H:%M") }}</td>
+      <td class="px-4 py-3 text-sm text-gray-500"><time datetime="{{ r.started_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}" class="local-time">{{ r.started_at.strftime("%Y-%m-%d %H:%M") }} UTC</time></td>
     </tr>
     {% endfor %}
     {% if not reviews %}

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """Main entry point for Baloo application."""
 
 import logging
+import time
 
 import uvicorn
 
@@ -10,9 +11,11 @@ from baloo.version import BUILD_DATE, COMMIT_SHA, VERSION, get_version_info
 
 # Logging format shared by the app and uvicorn
 LOG_FORMAT = "%(asctime)s %(levelname)-5s [%(name)s] %(message)s"
+LOG_DATEFMT = "%Y-%m-%d %H:%M:%S UTC"
 
 # Configure root logger (covers all non-uvicorn loggers)
-logging.basicConfig(level=settings.log_level, format=LOG_FORMAT)
+logging.basicConfig(level=settings.log_level, format=LOG_FORMAT, datefmt=LOG_DATEFMT)
+logging.Formatter.converter = time.gmtime
 
 # Uvicorn log config — override its default formatters so every line
 # gets a timestamp, matching the rest of the application output.
@@ -20,8 +23,8 @@ UVICORN_LOG_CONFIG: dict = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "default": {"format": LOG_FORMAT},
-        "access": {"format": LOG_FORMAT},
+        "default": {"format": LOG_FORMAT, "datefmt": LOG_DATEFMT},
+        "access": {"format": LOG_FORMAT, "datefmt": LOG_DATEFMT},
     },
     "handlers": {
         "default": {


### PR DESCRIPTION
## Summary
- Force application and uvicorn log timestamps to UTC via `time.gmtime` converter and explicit `datefmt` with "UTC" suffix
- Dashboard timestamps rendered as `<time>` elements with ISO 8601 UTC `datetime` attributes, converted to browser-local timezone via JS on page load and after HTMX swaps
- Server-rendered fallback shows "UTC" suffix for no-JS clients

## Test plan
- [x] All 382 existing tests pass
- [ ] Verify log output shows "UTC" suffix in timestamps
- [ ] Verify dashboard times display in browser-local timezone
- [ ] Verify HTMX-loaded partials (pagination, logs) also convert correctly
- [ ] Verify no-JS fallback shows "UTC" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)