### PR TITLE
fix: reduce review noise and improve finding accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ deploy/
 site/
 
 .care-bear/
+temp/

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ uv run python scripts/local_review.py
 uv run python scripts/local_review.py --base origin/main --head HEAD
 uv run python scripts/local_review.py --json
 uv run python scripts/local_review.py --fail-on-blocking   # exit 1 if CRITICAL/HIGH findings
+# Review another clone while cwd is baloo-bear (e.g. uv --directory this repo):
+uv run python scripts/local_review.py --git-workdir /path/to/other-repo --base origin/main --head HEAD
 ```
 
 See [docs/development.md](docs/development.md) for the full contributor guide.

--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -83,7 +83,10 @@ class BalooAgent(PIAgentBase):
                     metadata.get("is_error"),
                 )
                 metadata["agent_error"] = True
-                metadata["error_category"] = metadata.get("error_category", "no_output")
+                if metadata.get("max_turns_reached"):
+                    metadata["error_category"] = "max_turns_reached"
+                else:
+                    metadata["error_category"] = metadata.get("error_category", "no_output")
 
             # Generate summary using shared formatter
             summary = CommentFormatter.format_summary(comments, metadata)

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -759,6 +759,7 @@ Serialized payload:
         last_assistant_text = ""
         all_assistant_texts: list[str] = []
         turn_count = 0
+        turn_tools: list[str] = []  # tool calls accumulated within the current turn
 
         while True:
             event = await asyncio.wait_for(
@@ -773,12 +774,19 @@ Serialized payload:
 
             if etype == "turn_end":
                 turn_count += 1
+                logger.info(
+                    "%s: turn %d — tools used: [%s]",
+                    self.agent_name,
+                    turn_count,
+                    ", ".join(turn_tools) if turn_tools else "none",
+                )
                 if review_logger:
                     await review_logger.turn_completed(
                         turn_number=turn_count,
                         tokens_in=result.input_tokens,
                         tokens_out=result.output_tokens,
                     )
+                turn_tools = []
                 # Enforce max turns
                 if turn_count >= self.options.max_turns:
                     logger.warning(
@@ -831,14 +839,15 @@ Serialized payload:
 
             elif etype == "tool_execution_start":
                 tool = event.get("toolName", "?")
-                logger.debug("%s: tool call → %s", self.agent_name, tool)
+                tool_input = event.get("input", {}) if isinstance(event.get("input"), dict) else {}
+                tool_file = (
+                    tool_input.get("path") or tool_input.get("pattern") or tool_input.get("glob")
+                )
+                tool_label = f"{tool}:{tool_file}" if tool_file else tool
+                turn_tools.append(tool_label)
+                logger.debug("%s: tool call → %s", self.agent_name, tool_label)
                 if review_logger:
-                    tool_file = (
-                        event.get("input", {}).get("path")
-                        if isinstance(event.get("input"), dict)
-                        else None
-                    )
-                    await review_logger.tool_use(tool_name=tool, file_path=tool_file)
+                    await review_logger.tool_use(tool_name=tool, file_path=tool_input.get("path"))
 
             elif etype == "agent_end":
                 break

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -58,6 +58,7 @@ class PIRunResult:
     duration_seconds: float = 0.0
     is_error: bool = False
     error_message: str = ""
+    max_turns_reached: bool = False
 
 
 def _extract_json_from_text(text: str) -> dict | None:
@@ -417,6 +418,7 @@ class PIAgentBase:
             "num_turns": result.num_turns,
             "duration_seconds": result.duration_seconds,
             "is_error": result.is_error,
+            "max_turns_reached": result.max_turns_reached,
         }
 
     # -----------------------------------------------------------------
@@ -784,6 +786,7 @@ Serialized payload:
                         self.agent_name,
                         self.options.max_turns,
                     )
+                    result.max_turns_reached = True
                     await send(self._make_command("abort"))
                     # Don't wait for abort response, just collect agent_end
                     break

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -15,8 +15,8 @@ Your response will be parsed as JSON automatically.  Return an object with:
 """
 
 REVIEW_SEVERITY_GUIDELINES = """## Severity Guidelines
-- **CRITICAL**: Security vulnerabilities, data loss, Silent Failures, or Guidelines violations
-- **HIGH**: Bugs or logic errors that can break functionality
+- **CRITICAL**: Reserve for confirmed exploitable vulnerabilities or certain catastrophic data loss only
+- **HIGH**: Security concerns, serious bugs, silent failure patterns, or clear guidelines violations
 - **MEDIUM**: Quality, maintainability, or performance issues
 - **LOW**: Style or minor polish improvements
 """
@@ -33,9 +33,9 @@ REVIEW_SYSTEM_PROMPT = f"""You are Baloo, expert code reviewer. Use read/grep/fi
 - **Verify your findings**: If unsure, use grep to search for the identifier
 
 ## Priority: Security > Bugs > Silent Failures > Performance > Quality
-- **Security (CRITICAL/HIGH)**: SQL injection (string concat), XSS, secrets exposure, command injection, auth/authz
+- **Security (HIGH)**: SQL injection (string concat), XSS, secrets exposure, command injection, auth/authz — use CRITICAL only when impact is clearly exploitable or catastrophic
 - **Bugs (HIGH/MEDIUM)**: Logic errors, null refs, leaks, race conditions, error handling
-- **Silent Failures (CRITICAL)**: Swallowed errors, missing input ignored, silent exception handling. Flag ANY of:
+- **Silent Failures (HIGH)**: Swallowed errors, missing input ignored, silent exception handling. Flag patterns such as:
   - Bare `except:` or `except Exception:` that don't re-raise or log the error
   - `try/except` blocks with `pass`, empty bodies, or only comments
   - Catching exceptions and returning default/fallback values without logging
@@ -43,13 +43,13 @@ REVIEW_SYSTEM_PROMPT = f"""You are Baloo, expert code reviewer. Use read/grep/fi
   - `if x is not None` / `if x` guards that skip critical logic without logging why
   - `continue` or `return` inside exception handlers without logging the error
   - Any pattern where an error condition is detected but execution continues silently
-  These are CRITICAL because they hide bugs, mask data issues, and make production debugging impossible.
+  Treat as HIGH unless tied to security, data corruption, or guaranteed wrong financial/identity outcomes.
 - **Performance (MEDIUM)**: Algorithm efficiency, N+1 queries, blocking ops
 - **Quality (MEDIUM/LOW)**: DRY, complexity, naming, tests
 
-## Project Guidelines Compliance (CRITICAL)
+## Project Guidelines Compliance (HIGH)
 You MUST read `AGENTS.md` and `CONTRIBUTING.md` at the repo root before checking for violations.
-Changes that contradict what those files say are CRITICAL findings. Common examples include:
+Changes that contradict what those files say are HIGH findings. Common examples include:
 - Branch names that don't follow the naming convention documented in the guidelines
 - Commit messages that don't follow the required format or are missing required ticket references
 - Code that violates architectural decisions or tooling choices stated in AGENTS.md

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -414,7 +414,7 @@ def build_pr_review_prompt(pr_context: PRContext | dict[str, Any]) -> str:
         guidelines_section = (
             f"The following guidelines were fetched directly from this repository:\n\n"
             f"```\n{repo_guidelines}\n```\n\n"
-            f'Flag any violations of the conventions documented above as **CRITICAL** with category "Guidelines".\n'
+            f'Flag any violations of the conventions documented above as **HIGH** with category "Guidelines".\n'
             f"Only flag a violation if the guidelines explicitly require a specific convention."
         )
     else:

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -31,6 +31,10 @@ REVIEW_SYSTEM_PROMPT = f"""You are Baloo, expert code reviewer. Use read/grep/fi
 - **NEVER flag code as missing** without verifying the entire file
 - **Check diff context carefully**: Code outside diff hunks still exists
 - **Verify your findings**: If unsure, use grep to search for the identifier
+- **Cross-file verification (MANDATORY)**: A PR spans multiple files. Before flagging:
+  - **AttributeError / missing field**: grep for the class definition (`grep -rn "class ClassName"`) and read the file that defines it. The attribute may be added in another file in the same PR.
+  - **Missing implementation**: read the file that should contain the implementation before claiming it doesn't exist. A test for `foo()` is not evidence that `foo()` is missing — read the source file.
+  - **Rule**: if the attribute/method/field could be defined in a file not yet read, read that file first.
 
 ## Priority: Security > Bugs > Silent Failures > Performance > Quality
 - **Security (HIGH)**: SQL injection (string concat), XSS, secrets exposure, command injection, auth/authz — use CRITICAL only when impact is clearly exploitable or catastrophic
@@ -473,6 +477,11 @@ Use the **read** tool to examine each changed file in full context:
 - Related code that may be referenced in changes
 
 **NEVER flag code as "missing" or "undefined" without first using the read tool to verify it doesn't exist elsewhere in the file.**
+
+**Cross-file verification**: When a changed file accesses an attribute or calls a method on a type defined in another file (e.g. `thread.outdated`, `result.max_turns_reached`), you MUST:
+1. Use grep to locate the class/type definition: e.g. `grep -rn "class DiscussionThread"`
+2. Read the defining file and verify whether that attribute exists
+Do this BEFORE flagging any AttributeError, missing field, or unimplemented method. The attribute may have been added in the same PR in a file you haven't read yet.
 
 ### Step 2: Search for Patterns (REQUIRED)
 Use the **grep** tool to search for:

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -486,7 +486,7 @@ Use the **grep** tool to search for:
   - `.get\\(` with default values for required inputs
   - `or ""` / `or []` / `or {{}}` / `or 0` - silent default substitution for missing data
   - `try/except` blocks that do NOT contain `log`, `logger`, `logging`, `raise`, `warn`, or `print`
-  For every match, verify if the error is truly being swallowed (no logging, no re-raise, no alerting). If so, flag as CRITICAL.
+  For every match, verify if the error is truly being swallowed (no logging, no re-raise, no alerting). If so, flag as HIGH (CRITICAL only if it causes certain data loss or an exploitable security vulnerability).
 - Code duplication: Search for function names and patterns similar to changed code
 - Test coverage: Search for test files related to changed modules
 

--- a/baloo/agent/schemas.py
+++ b/baloo/agent/schemas.py
@@ -39,7 +39,9 @@ _SEVERITY_ORDER = {"LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
 
 # Category → fixed severity. Quality is special (capped, not fixed).
 _CATEGORY_SEVERITY: dict[str, str] = {
-    "SECURITY": "CRITICAL",
+    # Security is always important but caps at HIGH so routine findings do not
+    # dominate as CRITICAL in the GitHub review signal.
+    "SECURITY": "HIGH",
     "BUGS": "HIGH",
     "SILENT FAILURES": "HIGH",
     "GUIDELINES": "HIGH",
@@ -122,7 +124,7 @@ class ReviewOutput(BaseModel):
 def enforce_severity(finding: ReviewFinding) -> str:
     """Derive severity from category using deterministic rules.
 
-    Security → CRITICAL, Bugs/Silent Failures/Guidelines → HIGH,
+    Security/Bugs/Silent Failures/Guidelines → HIGH,
     Performance → MEDIUM, Quality → capped at MEDIUM (keeps LOW if LOW).
     Unknown categories → MEDIUM.
     """

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -109,15 +109,17 @@ def _valid_diff_lines(diff: str) -> dict[str, set[int]]:
 
 
 def _apply_resolved_thread_state(
-    discussion_threads: list[DiscussionThread], resolved_ids: set[int]
+    discussion_threads: list[DiscussionThread],
+    resolved_ids: set[int],
+    outdated_ids: set[int] | None = None,
 ) -> None:
-    """Overlay GitHub's authoritative resolved state onto REST-built threads."""
-    if not resolved_ids:
-        return
-
+    """Overlay GitHub's authoritative resolved/outdated state onto REST-built threads."""
     for thread in discussion_threads:
         if thread.root_comment_id in resolved_ids:
             thread.resolved = True
+            thread.awaiting_response = False
+        elif outdated_ids and thread.root_comment_id in outdated_ids:
+            thread.outdated = True
             thread.awaiting_response = False
 
 
@@ -231,8 +233,10 @@ class GitHubAPIClient:
             # Overlay the authoritative isResolved state from GraphQL.
             # The REST API doesn't expose thread resolution, so without
             # this call we rely on a keyword heuristic which is unreliable.
-            resolved_ids = await self.fetch_resolved_thread_ids(repo_full_name, pr_number)
-            _apply_resolved_thread_state(discussion_threads, resolved_ids)
+            resolved_ids, outdated_ids = await self.fetch_resolved_thread_ids(
+                repo_full_name, pr_number
+            )
+            _apply_resolved_thread_state(discussion_threads, resolved_ids, outdated_ids)
 
             general_comments: list[DiscussionComment] = build_general_discussion(
                 issue_comments, reviews
@@ -710,16 +714,17 @@ class GitHubAPIClient:
             except httpx.HTTPStatusError:
                 return []
 
-    async def fetch_resolved_thread_ids(self, repo_full_name: str, pr_number: int) -> set[int]:
-        """Fetch the set of root comment database IDs for resolved review threads.
+    async def fetch_resolved_thread_ids(
+        self, repo_full_name: str, pr_number: int
+    ) -> tuple[set[int], set[int]]:
+        """Fetch resolved and outdated root comment database IDs for review threads.
 
         Uses the GraphQL API because the REST API does not expose the
-        ``isResolved`` state of review threads.
+        ``isResolved`` or ``isOutdated`` state of review threads.
 
         Returns:
-            Set of root-comment ``databaseId`` values for threads where
-            ``isResolved`` is True.  On error returns an empty set so
-            callers degrade gracefully (fail-open).
+            Tuple of (resolved_ids, outdated_ids).  On error returns empty sets
+            so callers degrade gracefully (fail-open).
         """
         owner, repo = repo_full_name.split("/", 1)
         query = """
@@ -742,6 +747,7 @@ class GitHubAPIClient:
         """
 
         resolved_ids: set[int] = set()
+        outdated_ids: set[int] = set()
         cursor: str | None = None
 
         try:
@@ -778,10 +784,14 @@ class GitHubAPIClient:
                     for node in threads_data.get("nodes", []):
                         if node is None:
                             continue
-                        if node.get("isResolved") or node.get("isOutdated"):
-                            comments = node.get("comments", {}).get("nodes", [])
-                            if comments and comments[0].get("databaseId"):
-                                resolved_ids.add(comments[0]["databaseId"])
+                        comments = node.get("comments", {}).get("nodes", [])
+                        if not comments or not comments[0].get("databaseId"):
+                            continue
+                        db_id = comments[0]["databaseId"]
+                        if node.get("isResolved"):
+                            resolved_ids.add(db_id)
+                        elif node.get("isOutdated"):
+                            outdated_ids.add(db_id)
 
                     page_info = threads_data.get("pageInfo", {})
                     if page_info.get("hasNextPage"):
@@ -797,7 +807,7 @@ class GitHubAPIClient:
                 exc_info=True,
             )
 
-        return resolved_ids
+        return resolved_ids, outdated_ids
 
     async def _fetch_paginated_json(
         self,

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -730,6 +730,7 @@ class GitHubAPIClient:
                 pageInfo { hasNextPage endCursor }
                 nodes {
                   isResolved
+                  isOutdated
                   comments(first: 1) {
                     nodes { databaseId }
                   }
@@ -777,7 +778,7 @@ class GitHubAPIClient:
                     for node in threads_data.get("nodes", []):
                         if node is None:
                             continue
-                        if node.get("isResolved"):
+                        if node.get("isResolved") or node.get("isOutdated"):
                             comments = node.get("comments", {}).get("nodes", [])
                             if comments and comments[0].get("databaseId"):
                                 resolved_ids.add(comments[0]["databaseId"])

--- a/baloo/github/discussions.py
+++ b/baloo/github/discussions.py
@@ -206,7 +206,11 @@ def build_discussion_digest(
 
     if review_threads:
         for thread in review_threads[:max_items]:
-            status = "⏳" if thread.awaiting_response else ("✅" if thread.resolved else "💬")
+            status = (
+                "⏳"
+                if thread.awaiting_response
+                else ("✅" if thread.resolved else ("⏭️" if thread.outdated else "💬"))
+            )
             location = f"{thread.path}:{thread.line}" if thread.path else f"thread #{thread.id}"
             last = thread.comments[-1]
             summary = _summarize_body(last.body)

--- a/baloo/github/models.py
+++ b/baloo/github/models.py
@@ -117,6 +117,7 @@ class DiscussionThread(BaseModel):
     is_baloo_thread: bool = False
     awaiting_response: bool = False
     resolved: bool = False
+    outdated: bool = False
     last_activity: datetime
     root_comment_id: int | None = None
 

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -441,6 +441,29 @@ def _calculate_similarity(s1: str, s2: str) -> float:
     return sim
 
 
+def _build_db_findings(
+    comments: list[ReviewComment],
+    posted_review_result: PostedReviewResult | None,
+) -> list[dict]:
+    """Build the findings list for DB storage, excluding dropped comments."""
+    dropped_ids: set[int] = (
+        {id(d.comment) for d in posted_review_result.dropped}
+        if posted_review_result and posted_review_result.dropped
+        else set()
+    )
+    return [
+        {
+            "file_path": c.path,
+            "line_number": c.line,
+            "severity": c.severity,
+            "category": c.category,
+            "body": c.body,
+        }
+        for c in comments
+        if id(c) not in dropped_ids
+    ]
+
+
 def _match_thread(
     lookup: dict[str, list[DiscussionThread]], comment: ReviewComment
 ) -> DiscussionThread | None:
@@ -874,6 +897,7 @@ async def process_pr_review(
             )  # reserved for future conversational thread agent
             skipped_duplicates = 0
             skipped_resolved = 0
+            skipped_outdated = 0
             skipped_responded = 0
             skipped_unchanged_scope = 0
             skipped_outside_line_scope = 0
@@ -909,6 +933,19 @@ async def process_pr_review(
                     )
                     continue
 
+                # Thread is outdated (code was rebased/amended under the comment).
+                # The finding may still be valid but we can't place it on the
+                # current diff, so skip re-posting but don't count as responded.
+                if thread.outdated:
+                    skipped_outdated += 1
+                    logger.info(
+                        "Skipping outdated thread: %s:%s (thread %s)",
+                        comment.path,
+                        comment.line,
+                        thread.id,
+                    )
+                    continue
+
                 if thread.awaiting_response:
                     skipped_duplicates += 1
                     continue
@@ -938,6 +975,8 @@ async def process_pr_review(
                 summary_text += f"\n\n💬 Skipped {skipped_responded} thread(s) with developer responses (not re-reviewed)."
             if skipped_duplicates:
                 summary_text += f"\n\n↪️ Skipped {skipped_duplicates} existing Baloo thread(s) already awaiting a response."
+            if skipped_outdated:
+                summary_text += f"\n\n⏭️ Skipped {skipped_outdated} outdated thread(s) (code changed under comment)."
             if skipped_resolved:
                 summary_text += f"\n\n✅ Skipped {skipped_resolved} resolved thread(s)."
             if skipped_similar_repeats:
@@ -978,6 +1017,7 @@ async def process_pr_review(
                 f"Low: {severity_counts.get(ReviewSeverity.LOW.value, 0)}), "
                 f"follow_ups={len(follow_up_comments)}, skipped_responded={skipped_responded}, "
                 f"skipped_duplicates={skipped_duplicates}, skipped_resolved={skipped_resolved}, "
+                f"skipped_outdated={skipped_outdated}, "
                 f"skipped_similar_repeats={skipped_similar_repeats}, "
                 f"skipped_unchanged_scope={skipped_unchanged_scope}, "
                 f"skipped_outside_line_scope={skipped_outside_line_scope}, "
@@ -1215,20 +1255,7 @@ async def process_pr_review(
                     error_message=error_detail,
                     error_category=error_category,
                     fallback_model=fallback_model,
-                    findings=[
-                        {
-                            "file_path": c.path,
-                            "line_number": c.line,
-                            "severity": c.severity,
-                            "category": c.category,
-                            "body": c.body,
-                        }
-                        for c in decision_comments
-                        if not (
-                            posted_review_result
-                            and any(d.comment is c for d in posted_review_result.dropped)
-                        )
-                    ],
+                    findings=_build_db_findings(decision_comments, posted_review_result),
                 )
 
                 await ReviewService.complete_review(

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -148,6 +148,11 @@ async def health() -> dict[str, str]:
 
 # Max lines difference to consider a finding as part of an existing thread
 LINE_MATCH_TOLERANCE = 5
+# When the anchor line moved (edits above the hunk), still match the same issue
+# if signatures are clearly the same (stricter similarity threshold).
+LINE_MATCH_TOLERANCE_LOOSE = 18
+# Minimum similarity for loose (wider line window) dedupe against prior threads.
+_LINE_MATCH_LOOSE_MIN_SIMILARITY = 0.55
 
 
 def _build_thread_lookup(threads: list[DiscussionThread]) -> dict[str, list[DiscussionThread]]:
@@ -452,8 +457,9 @@ def _match_thread(
 
     comment_sig = _extract_issue_signature(comment.body)
 
-    best_match = None
-    best_similarity = 0.0
+    # Prefer higher similarity, then closer line (tuple sorts ascending).
+    best_key: tuple[float, int] | None = None
+    best_match: DiscussionThread | None = None
 
     for thread in threads_in_file:
         # 1. Skip non-Baloo threads (but keep resolved ones — the caller
@@ -461,36 +467,36 @@ def _match_thread(
         if not thread.is_baloo_thread:
             continue
 
-        # 2. Check if line is within tolerance
-        line_diff = abs(thread.line - comment.line)
-        if line_diff > LINE_MATCH_TOLERANCE:
+        if not thread.comments:
             continue
 
-        # 3. Check content similarity
-        if not thread.comments:
+        line_diff = abs(thread.line - comment.line)
+        if line_diff > LINE_MATCH_TOLERANCE_LOOSE:
             continue
 
         thread_sig = _extract_issue_signature(thread.comments[0].body)
         similarity = _calculate_similarity(comment_sig, thread_sig)
 
-        # DEBUG
-        # print(f"Comparing line {comment.line} with thread at {thread.line}")
-        # print(f"Similarity: {similarity}")
-        # print(f"S1: {comment_sig}")
-        # print(f"S2: {thread_sig}")
-
-        # 4. If exact line match and very high similarity, it's a definite match
+        # Definite match: same anchor line and very high similarity
         if line_diff == 0 and similarity > 0.8:
             return thread
 
-        # 5. Otherwise, track the best fuzzy match
-        if similarity > best_similarity:
-            best_similarity = similarity
+        strict_band = line_diff <= LINE_MATCH_TOLERANCE and similarity >= 0.2
+        loose_band = (
+            line_diff > LINE_MATCH_TOLERANCE
+            and line_diff <= LINE_MATCH_TOLERANCE_LOOSE
+            and similarity >= _LINE_MATCH_LOOSE_MIN_SIMILARITY
+        )
+        if not (strict_band or loose_band):
+            continue
+
+        # Minimize (-similarity, line_diff) == prefer higher sim, closer line
+        key = (-similarity, line_diff)
+        if best_key is None or key < best_key:
+            best_key = key
             best_match = thread
 
-    # Return best match if it's "similar enough"
-    # Threshold 0.2 catches semantically related but differently phrased issues
-    return best_match if best_similarity >= 0.2 else None
+    return best_match
 
 
 @app.post("/webhook")
@@ -1112,11 +1118,6 @@ async def process_pr_review(
                         completion_msg += (
                             f"\n\nPosted {posted_review_result.posted} inline comment(s)."
                         )
-                        if posted_review_result.dropped:
-                            completion_msg += (
-                                f" Dropped {len(posted_review_result.dropped)} inline finding(s) "
-                                "that could not be placed on the diff; details were logged."
-                            )
                 elif not request_changes and approve:
                     completion_msg = (
                         f"✅ Baloo review completed in {review_duration}s. No issues found!"
@@ -1223,6 +1224,10 @@ async def process_pr_review(
                             "body": c.body,
                         }
                         for c in decision_comments
+                        if not (
+                            posted_review_result
+                            and any(d.comment is c for d in posted_review_result.dropped)
+                        )
                     ],
                 )
 

--- a/scripts/local_review.py
+++ b/scripts/local_review.py
@@ -36,6 +36,17 @@ def run_git(args: Sequence[str], cwd: str | None = None, check: bool = True) -> 
     return proc.stdout.rstrip("\n")
 
 
+def _git_start_path(git_workdir: str | Path | None) -> Path:
+    """Directory used to resolve the git repo root (repo or any path inside it)."""
+    if git_workdir is not None:
+        start = Path(git_workdir).expanduser().resolve()
+    else:
+        start = Path.cwd()
+    if not start.exists():
+        raise RuntimeError(f"Git workdir does not exist: {start}")
+    return start
+
+
 def build_local_pr_context(
     *,
     base: str,
@@ -44,10 +55,24 @@ def build_local_pr_context(
     description: str,
     author: str,
     repo_full_name: str | None = None,
+    git_workdir: str | Path | None = None,
     git: GitRunner = run_git,
 ) -> PRContext:
-    """Build a synthetic PRContext from local git diff data."""
-    repo_root = git(["rev-parse", "--show-toplevel"], None, True)
+    """Build a synthetic PRContext from local git diff data.
+
+    Args:
+        git_workdir: Filesystem path to the repository (or a path inside it) whose
+            ``git diff base...head`` should be reviewed. When omitted, ``Path.cwd()``
+            is used — set this when running via ``uv run --directory …`` so the
+            process cwd is not the repo under review.
+    """
+    start = _git_start_path(git_workdir)
+    try:
+        repo_root = git(["rev-parse", "--show-toplevel"], str(start), True)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            f"Not a git repository (failed rev-parse --show-toplevel from {start})"
+        ) from exc
     head_branch = git(["rev-parse", "--abbrev-ref", head], repo_root, True)
     head_sha = git(["rev-parse", head], repo_root, True)
     diff_range = f"{base}...{head}"
@@ -111,9 +136,24 @@ async def run_local_review(
 
 
 async def async_main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=(
+            "When using `uv run --directory /path/to/baloo-bear`, the process cwd is "
+            "that project — pass `--git-workdir /path/to/repo-under-review` so diffs "
+            "and guidelines load from the correct repository."
+        ),
+    )
     parser.add_argument("--base", default="origin/main", help="Base ref for the comparison")
     parser.add_argument("--head", default="HEAD", help="Head ref for the comparison")
+    parser.add_argument(
+        "--git-workdir",
+        metavar="PATH",
+        help=(
+            "Git repository root (or any path inside it) for diff/refs; "
+            "defaults to current working directory"
+        ),
+    )
     parser.add_argument("--title", default="Local Baloo review", help="Synthetic PR title")
     parser.add_argument("--description", default="", help="Synthetic PR description")
     parser.add_argument("--author", default="local", help="Synthetic PR author")
@@ -135,6 +175,7 @@ async def async_main(argv: Sequence[str] | None = None) -> int:
             description=args.description,
             author=args.author,
             repo_full_name=args.repo_full_name,
+            git_workdir=args.git_workdir,
         )
         return await run_local_review(
             context=context,

--- a/tests/agent/test_client_integration.py
+++ b/tests/agent/test_client_integration.py
@@ -157,6 +157,20 @@ class TestBalooAgentErrorHandling:
             assert result.approve is True  # No issues = approve
 
     @pytest.mark.asyncio
+    async def test_max_turns_reached_sets_error_category(self, sample_pr_context):
+        """When PI hits its turn limit, error_category must be max_turns_reached not no_output."""
+        with patch.object(
+            BalooAgent,
+            "_run_with_fallback",
+            new=AsyncMock(return_value=(None, {"max_turns_reached": True, "num_turns": 20})),
+        ):
+            agent = BalooAgent()
+            result = await agent.review_pr(sample_pr_context)
+
+        assert result.metadata["agent_error"] is True
+        assert result.metadata["error_category"] == "max_turns_reached"
+
+    @pytest.mark.asyncio
     async def test_review_pr_handles_error_stop_reason(self, sample_pr_context):
         """Test handling of error stop reason from PI."""
         events = _make_pi_events(None, is_error=True)

--- a/tests/agent/test_client_integration.py
+++ b/tests/agent/test_client_integration.py
@@ -197,8 +197,8 @@ class TestBalooAgentSuccessPath:
 
             assert len(result.comments) == 1
             assert result.comments[0].path == "test.py"
-            assert result.comments[0].severity == "CRITICAL"  # Security enforced to CRITICAL
-            assert result.approve is False  # CRITICAL severity = request changes
+            assert result.comments[0].severity == "HIGH"  # Security enforced to HIGH
+            assert result.approve is False  # HIGH severity still requests changes
             assert result.request_changes is True
 
     @pytest.mark.asyncio
@@ -354,8 +354,8 @@ class TestBalooAgentSeveritySummary:
             mock_exec.return_value = _mock_pi_process(events)
             result = await agent.review_pr(sample_pr_context)
 
-            assert "CRITICAL" in result.summary
-            assert "🔴" in result.summary
+            assert "HIGH" in result.summary
+            assert "🟠" in result.summary
 
     @pytest.mark.asyncio
     async def test_summary_includes_low_severity(self, sample_pr_context):

--- a/tests/agent/test_schemas.py
+++ b/tests/agent/test_schemas.py
@@ -191,7 +191,7 @@ class TestFindingsToComments:
         assert len(comments) == 1
         assert comments[0].path == "test.py"
         assert comments[0].line == 10
-        assert comments[0].severity == "CRITICAL"  # Security enforced to CRITICAL
+        assert comments[0].severity == "HIGH"  # Security enforced to HIGH
         assert comments[0].category == "Security"
         assert "SQL Injection Risk" in comments[0].body
         assert "Data breach possible" in comments[0].body
@@ -227,7 +227,7 @@ class TestFindingsToComments:
             ]
         }
         comments = findings_to_comments(data)
-        assert comments[0].severity == "CRITICAL"  # Security → CRITICAL
+        assert comments[0].severity == "HIGH"  # Security → HIGH
         assert comments[1].severity == "MEDIUM"  # Quality MEDIUM stays MEDIUM
 
     def test_optional_fields_missing(self):
@@ -391,14 +391,14 @@ class TestNormalizeCategory:
 class TestEnforceSeverity:
     """Tests for rule-based severity enforcement by category."""
 
-    def test_security_always_critical(self):
-        """Security findings should always be CRITICAL regardless of LLM severity."""
+    def test_security_always_high(self):
+        """Security findings map to HIGH regardless of LLM severity."""
         finding = ReviewFinding(file="a.py", line=1, severity="MEDIUM", category="Security")
-        assert enforce_severity(finding) == "CRITICAL"
+        assert enforce_severity(finding) == "HIGH"
 
     def test_security_low_escalated(self):
         finding = ReviewFinding(file="a.py", line=1, severity="LOW", category="Security")
-        assert enforce_severity(finding) == "CRITICAL"
+        assert enforce_severity(finding) == "HIGH"
 
     def test_bugs_enforced_to_high(self):
         """Bugs category should be enforced to HIGH."""
@@ -458,8 +458,8 @@ class TestEnforceSeverity:
             ]
         }
         comments = findings_to_comments(data)
-        # Security MEDIUM should be escalated to CRITICAL
-        assert comments[0].severity == "CRITICAL"
+        # Security MEDIUM should be escalated to HIGH
+        assert comments[0].severity == "HIGH"
         # Quality CRITICAL should be capped to MEDIUM
         assert comments[1].severity == "MEDIUM"
 

--- a/tests/github/test_resolved_threads.py
+++ b/tests/github/test_resolved_threads.py
@@ -32,9 +32,10 @@ def _graphql_response(nodes: list[dict], has_next: bool = False, cursor: str = "
     }
 
 
-def _thread_node(comment_db_id: int, is_resolved: bool) -> dict:
+def _thread_node(comment_db_id: int, is_resolved: bool, is_outdated: bool = False) -> dict:
     return {
         "isResolved": is_resolved,
+        "isOutdated": is_outdated,
         "comments": {"nodes": [{"databaseId": comment_db_id}]},
     }
 
@@ -76,7 +77,9 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 42)
 
-        assert ids == {100, 300}
+        resolved_ids, outdated_ids = ids
+        assert resolved_ids == {100, 300}
+        assert outdated_ids == set()
 
     @pytest.mark.asyncio
     async def test_paginates(self):
@@ -100,7 +103,9 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == {10, 20}
+        resolved_ids, outdated_ids = ids
+        assert resolved_ids == {10, 20}
+        assert outdated_ids == set()
         assert call_count == 2
 
     @pytest.mark.asyncio
@@ -117,7 +122,7 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == set()
+        assert ids == (set(), set())
 
     @pytest.mark.asyncio
     async def test_returns_empty_on_http_error(self):
@@ -135,7 +140,7 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == set()
+        assert ids == (set(), set())
 
     @pytest.mark.asyncio
     async def test_logs_exception_type_when_resolved_thread_fetch_fails(self, caplog):
@@ -150,7 +155,7 @@ class TestFetchResolvedThreadIds:
             with caplog.at_level("WARNING", logger="baloo.github.api_client"):
                 ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == set()
+        assert ids == (set(), set())
         assert "TimeoutException" in caplog.text
 
     @pytest.mark.asyncio
@@ -172,7 +177,30 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == set()
+        assert ids == (set(), set())
+
+    @pytest.mark.asyncio
+    async def test_separates_outdated_from_resolved(self):
+        body = _graphql_response(
+            [
+                _thread_node(100, is_resolved=True),
+                _thread_node(200, is_resolved=False, is_outdated=True),
+                _thread_node(300, is_resolved=False),
+            ]
+        )
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.post = AsyncMock(return_value=_mock_response(body))
+            mock_client_cls.return_value = mock_client
+
+            client = GitHubAPIClient(installation_id=1)
+            resolved_ids, outdated_ids = await client.fetch_resolved_thread_ids("owner/repo", 42)
+
+        assert resolved_ids == {100}
+        assert outdated_ids == {200}
 
 
 class TestApplyResolvedThreadState:

--- a/tests/github/test_thread_matching.py
+++ b/tests/github/test_thread_matching.py
@@ -197,14 +197,14 @@ class TestMatchThread:
         assert matched.id == 1
 
     def test_no_match_outside_tolerance(self):
-        """Should not match thread outside LINE_MATCH_TOLERANCE."""
+        """Should not match when line is beyond the loose window."""
         thread = _make_thread(1, "file.py", 50, "**[HIGH] Bugs** - Issue description")
         lookup = _build_thread_lookup([thread])
 
-        # Comment is 10 lines away (outside tolerance of 5)
+        # 35 lines away — outside LINE_MATCH_TOLERANCE_LOOSE
         comment = ReviewComment(
             path="file.py",
-            line=60,
+            line=85,
             body="**[HIGH] Bugs** - Issue description",
             severity="HIGH",
             category="Bugs",
@@ -212,6 +212,23 @@ class TestMatchThread:
 
         matched = _match_thread(lookup, comment)
         assert matched is None
+
+    def test_loose_line_match_when_anchor_shifted(self):
+        """Same issue after edits can sit many lines away; still dedupe to the thread."""
+        thread = _make_thread(1, "file.py", 50, "**[HIGH] Bugs** - Issue description")
+        lookup = _build_thread_lookup([thread])
+
+        comment = ReviewComment(
+            path="file.py",
+            line=62,
+            body="**[HIGH] Bugs** - Issue description",
+            severity="HIGH",
+            category="Bugs",
+        )
+
+        matched = _match_thread(lookup, comment)
+        assert matched is not None
+        assert matched.id == 1
 
     def test_no_match_different_file(self):
         """Should not match thread in different file."""

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -235,7 +235,7 @@ async def test_progress_comment_reports_dropped_inline_findings_internally():
     completion_msg = mock_github_client.edit_comment.call_args.args[2]
     assert "Found 2 issue(s)" in completion_msg
     assert "Posted 1 inline comment(s)." in completion_msg
-    assert "Dropped 1 inline finding(s)" in completion_msg
+    assert "Dropped" not in completion_msg
 
 
 @pytest.mark.asyncio

--- a/tests/test_local_review.py
+++ b/tests/test_local_review.py
@@ -1,11 +1,17 @@
 """Tests for the local Baloo review CLI."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from baloo.github.models import ReviewComment, ReviewResult
-from scripts.local_review import _parse_numstat, build_local_pr_context, run_local_review
+from scripts.local_review import (
+    _git_start_path,
+    _parse_numstat,
+    build_local_pr_context,
+    run_local_review,
+)
 
 
 def test_parse_numstat_skips_malformed_lines():
@@ -58,6 +64,71 @@ def test_build_local_pr_context_from_git_diff():
     assert context.files_changed[0].status == "modified"
     assert context.files_changed[0].additions == 3
     assert context.files_changed[1].additions == 0
+
+
+def test_build_local_pr_context_git_workdir_sets_initial_git_cwd(tmp_path):
+    """rev-parse --show-toplevel must run with cwd=git_workdir (uv --directory safe)."""
+    workdir = tmp_path / "nested" / "here"
+    workdir.mkdir(parents=True)
+    workdir = str(workdir.resolve())
+    git_calls: list[tuple[tuple[str, ...], str | None]] = []
+
+    outputs = {
+        ("rev-parse", "--show-toplevel"): "/resolved/repo/root",
+        ("rev-parse", "--abbrev-ref", "HEAD"): "feature/x",
+        ("rev-parse", "HEAD"): "abc123",
+        (
+            "config",
+            "--get",
+            "remote.origin.url",
+        ): "git@github.com:Blue-Bear-Security/blueden.git",
+        ("diff", "--numstat", "origin/main...HEAD"): "1\t0\tREADME.md\n",
+        ("diff", "--name-status", "origin/main...HEAD"): "M\tREADME.md\n",
+        ("diff", "origin/main...HEAD"): "diff --git a/README.md b/README.md\n",
+        ("show", "HEAD:AGENTS.md"): "",
+        ("show", "HEAD:CONTRIBUTING.md"): "",
+    }
+
+    def fake_git(args, cwd=None, check=True):
+        git_calls.append((tuple(args), cwd))
+        return outputs[tuple(args)]
+
+    ctx = build_local_pr_context(
+        base="origin/main",
+        head="HEAD",
+        title="t",
+        description="",
+        author="a",
+        git_workdir=workdir,
+        git=fake_git,
+    )
+
+    assert git_calls[0] == (("rev-parse", "--show-toplevel"), workdir)
+    assert ctx.repo_full_name == "Blue-Bear-Security/blueden"
+    assert all(cwd == "/resolved/repo/root" for _, cwd in git_calls[1:])
+
+
+def test_build_local_pr_context_rejects_missing_git_workdir():
+    missing = "/this/path/does/not/exist/for/baloo/local_review_test_zzzz"
+
+    def fake_git(args, cwd=None, check=True):
+        raise AssertionError("git should not run when workdir is missing")
+
+    with pytest.raises(RuntimeError, match="does not exist"):
+        build_local_pr_context(
+            base="origin/main",
+            head="HEAD",
+            title="t",
+            description="",
+            author="a",
+            git_workdir=missing,
+            git=fake_git,
+        )
+
+
+def test_git_start_path_accepts_path_object():
+    here = Path(__file__).resolve().parent
+    assert _git_start_path(here) == here
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Outdated threads treated as resolved** — Baloo was counting GitHub's outdated threads (comments on code that no longer exists) as open, blocking approval and repeatedly reporting "Still waiting on N threads." Now outdated threads are treated the same as explicitly-resolved ones.
- **Remove dropped-findings message** — The "Dropped N inline finding(s)" progress comment told developers about problems they couldn't act on. Removed.
- **Only store posted findings in DB** — Findings dropped at GitHub posting time were being saved and getting outcome labels at merge, inflating actioned rates with findings the developer never saw. Now only findings that reached GitHub are stored.
- **Security/Silent Failures/Guidelines CRITICAL → HIGH** — CRITICAL was triggering on nearly every PR, dominating the signal. CRITICAL is now reserved for confirmed exploitable vulnerabilities or certain catastrophic data loss.
- **Wider thread dedup window (5 → 18 lines)** — Findings whose anchor line shifted after nearby edits were being re-posted as new comments. Extended tolerance to 18 lines with a stricter similarity threshold for the wider band.
- **`--git-workdir` flag for local review CLI** — Allows reviewing a repo other than cwd when running via `uv run --directory`.

## Test plan

- [x] 415 tests passing
- [ ] Deploy and verify outdated thread fix unblocks approval on PRs with many commits
- [ ] Verify CRITICAL count drops in dashboard after severity reclassification deploys