### PR TITLE
fix: run fidelity analysis and agent review concurrently

### DIFF
--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -828,18 +828,18 @@ async def process_pr_review(
                     review_mode_reason = f"Scope preparation failed: {exc}"
 
             # Run fidelity analysis and main review concurrently
-            fidelity_report_text = ""
-            fidelity_result = None
-            if settings.fidelity_enabled:
-                fidelity_report_text, fidelity_result = await _run_fidelity_analysis(
-                    github_client, repo_full_name, review_context
-                )
-
-            # Initialize agent and perform review
             from baloo.agent.client import BalooAgent
 
             agent = BalooAgent()
-            agent_result = await agent.review_pr(review_context, review_id=db_review_id)
+
+            if settings.fidelity_enabled:
+                (fidelity_report_text, fidelity_result), agent_result = await asyncio.gather(
+                    _run_fidelity_analysis(github_client, repo_full_name, review_context),
+                    agent.review_pr(review_context, review_id=db_review_id),
+                )
+            else:
+                fidelity_report_text, fidelity_result = "", None
+                agent_result = await agent.review_pr(review_context, review_id=db_review_id)
             agent_metadata = agent_result.metadata
             review_result = agent_result
 

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -1291,3 +1291,63 @@ async def test_does_not_approve_with_low_fidelity_score():
         for call in calls:
             review_result = call[0][2]
             assert review_result.approve is False
+
+
+@pytest.mark.asyncio
+async def test_fidelity_and_agent_review_run_concurrently_when_fidelity_enabled():
+    """When fidelity is enabled, both fidelity analysis and agent review are invoked."""
+    mock_github_client = MagicMock()
+    mock_github_client.post_comment = AsyncMock(return_value=12345)
+    mock_github_client.edit_comment = AsyncMock()
+    mock_github_client.post_review = AsyncMock(
+        return_value=PostedReviewResult(attempted=0, posted=0, dropped=[])
+    )
+    mock_github_client.reply_to_review_comment = AsyncMock()
+
+    mock_pr_context = MagicMock()
+    mock_pr_context.discussion_threads = []
+    mock_pr_context.issue_comments = []
+    mock_pr_context.awaiting_response_threads = 0
+    mock_pr_context.head_sha = "abc123"
+    mock_pr_context.head_branch = "feat/DEN-999/my-feature"
+    mock_pr_context.title = "My feature"
+    mock_pr_context.description = "Does something"
+    mock_pr_context.diff = "+ added code"
+    mock_github_client.get_pr_context = AsyncMock(return_value=mock_pr_context)
+
+    mock_agent = MagicMock()
+    mock_agent.review_pr = AsyncMock(
+        return_value=ReviewResult(
+            summary="Review complete",
+            comments=[],
+            approve=True,
+            request_changes=False,
+        )
+    )
+
+    fidelity_analysis_called = []
+
+    async def fake_run_fidelity_analysis(*args, **kwargs):
+        fidelity_analysis_called.append(True)
+        return "", None
+
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_github_client),
+        patch("baloo.agent.client.BalooAgent", return_value=mock_agent),
+        patch("baloo.config.settings.settings.fidelity_enabled", True),
+        patch("baloo.config.settings.settings.review_auto_approve", False),
+        patch(
+            "baloo.github.webhook_handler._run_fidelity_analysis",
+            side_effect=fake_run_fidelity_analysis,
+        ),
+    ):
+        await process_pr_review(
+            repo_full_name="test/repo",
+            pr_number=123,
+            installation_id=456,
+            trigger_reason="test",
+            notify_progress=False,
+        )
+
+    assert fidelity_analysis_called, "_run_fidelity_analysis was not called"
+    mock_agent.review_pr.assert_awaited_once()

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -1,5 +1,6 @@
 """Tests for webhook handler completion messages."""
 
+import asyncio
 from contextlib import ExitStack
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1340,6 +1341,7 @@ async def test_fidelity_and_agent_review_run_concurrently_when_fidelity_enabled(
             "baloo.github.webhook_handler._run_fidelity_analysis",
             side_effect=fake_run_fidelity_analysis,
         ),
+        patch("baloo.github.webhook_handler.asyncio.gather", wraps=asyncio.gather) as mock_gather,
     ):
         await process_pr_review(
             repo_full_name="test/repo",
@@ -1351,3 +1353,4 @@ async def test_fidelity_and_agent_review_run_concurrently_when_fidelity_enabled(
 
     assert fidelity_analysis_called, "_run_fidelity_analysis was not called"
     mock_agent.review_pr.assert_awaited_once()
+    mock_gather.assert_called_once()


### PR DESCRIPTION
## Summary

- Fidelity analysis and the main agent review were awaited sequentially despite a code comment saying "concurrently"
- Fixed with `asyncio.gather` so both run in parallel when fidelity is enabled, saving the full fidelity analysis time per review

## Root cause

The code had `await _run_fidelity_analysis(...)` followed by `await agent.review_pr(...)`. Neither depends on the other's result during execution (fidelity result is only used after both complete for the decision), so they are safely parallelisable.

## Changes

- `baloo/github/webhook_handler.py`: Use `asyncio.gather` when `fidelity_enabled=True`; moved `BalooAgent` instantiation before the branch to avoid duplication
- `tests/github/test_webhook_handler.py`: Added test verifying both are called when fidelity is enabled

## Test plan
- [x] 20 tests pass (`uv run pytest tests/github/test_webhook_handler.py -v`)
- [x] Lint clean (`uv run ruff check baloo/github/webhook_handler.py`)