### PR TITLE
fix: replace Weekly Trends with daily Accuracy Over Time chart

### DIFF
--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -480,43 +480,37 @@ class DashboardService:
                 for cat, v in cat_map.items()
             }
 
-            # --- Weekly trends (dialect-aware) ---
-            if "postgres" in settings.database_url:
-                week_label = func.to_char(
-                    func.date_trunc("week", FindingOutcome.labeled_at), "IYYY-IW"
-                )
-            else:
-                week_label = func.strftime("%Y-%W", FindingOutcome.labeled_at)
-
-            weekly_rows = (
+            # --- Daily accuracy trends ---
+            daily_rows = (
                 await session.execute(
                     select(
-                        week_label.label("week"),
+                        func.date(FindingOutcome.labeled_at).label("day"),
                         FindingOutcome.outcome,
                         func.count(FindingOutcome.id),
                     )
                     .where(*_base_filters())
-                    .group_by("week", FindingOutcome.outcome)
-                    .order_by("week")
+                    .group_by("day", FindingOutcome.outcome)
+                    .order_by("day")
                 )
             ).all()
 
-            week_map: dict[str, dict] = {}
-            for week, outcome, cnt in weekly_rows:
-                if week not in week_map:
-                    week_map[week] = {
+            day_map: dict[str, dict] = {}
+            for day, outcome, cnt in daily_rows:
+                day_key = str(day)
+                if day_key not in day_map:
+                    day_map[day_key] = {
                         "total": 0,
                         "actioned": 0,
                         "acknowledged": 0,
                         "disputed": 0,
                         "ignored": 0,
                     }
-                week_map[week]["total"] += cnt
-                if outcome in week_map[week]:
-                    week_map[week][outcome] += cnt
+                day_map[day_key]["total"] += cnt
+                if outcome in day_map[day_key]:
+                    day_map[day_key][outcome] += cnt
             trends = [
                 {
-                    "week": w,
+                    "day": d,
                     "total": v["total"],
                     "hit_rate": round(v["actioned"] / v["total"] * 100, 1) if v["total"] else 0.0,
                     "noise_rate": (
@@ -525,7 +519,7 @@ class DashboardService:
                         else 0.0
                     ),
                 }
-                for w, v in week_map.items()
+                for d, v in day_map.items()
             ]
 
             # --- Repos for filter dropdown ---

--- a/baloo/dashboard/templates/outcomes.html
+++ b/baloo/dashboard/templates/outcomes.html
@@ -152,7 +152,7 @@
     }
   });
 
-  // Weekly Trends - line chart with dual y-axis
+  // Accuracy Over Time - line chart with dual y-axis
   new Chart(document.getElementById('trendsChart'), {
     type: 'line',
     data: {

--- a/baloo/dashboard/templates/outcomes.html
+++ b/baloo/dashboard/templates/outcomes.html
@@ -70,7 +70,7 @@
     <canvas id="categoryChart" height="250"></canvas>
   </div>
   <div class="bg-white rounded-lg shadow p-5 lg:col-span-2">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Weekly Trends</h2>
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Accuracy Over Time</h2>
     <canvas id="trendsChart" height="250"></canvas>
   </div>
   <div class="bg-white rounded-lg shadow p-5">
@@ -156,7 +156,7 @@
   new Chart(document.getElementById('trendsChart'), {
     type: 'line',
     data: {
-      labels: trends.map(t => t.week),
+      labels: trends.map(t => t.day),
       datasets: [
         {
           label: 'Hit Rate %',

--- a/docs/superpowers/specs/2026-05-04-outcomes-daily-accuracy-design.md
+++ b/docs/superpowers/specs/2026-05-04-outcomes-daily-accuracy-design.md
@@ -1,0 +1,39 @@
+# Outcomes Page: Daily Accuracy Chart
+
+**Date:** 2026-05-04
+
+## Problem
+
+The Weekly Trends chart on the outcomes page is non-functional in practice. All existing outcome data falls within a single ISO week (2026-18), so the chart renders as a single dot with no trend visible. Weekly granularity won't become useful until many weeks of data accumulate.
+
+Daily data has 6 distinct days with meaningful variation in hit/noise rates, making daily granularity immediately actionable.
+
+## Decision
+
+Replace the Weekly Trends chart with an Accuracy Over Time chart at daily granularity. The weekly query in `get_outcomes_data` is swapped for a daily one. No new charts are added — it's a direct replacement.
+
+## Changes
+
+### Backend: `baloo/dashboard/queries.py`
+
+In `get_outcomes_data`, replace the weekly query block with a daily equivalent:
+
+- Group by `DATE(labeled_at)` (dialect-agnostic — SQLite and Postgres both support `DATE()`)
+- Aggregate outcomes per day into `daily_map` (same structure as `week_map`)
+- Each entry in `trends`: `{"day": "YYYY-MM-DD", "total": N, "hit_rate": X, "noise_rate": Y}`
+- Return key stays `trends` — no signature change
+
+### Frontend: `baloo/dashboard/templates/outcomes.html`
+
+- Chart title: "Weekly Trends" → "Accuracy Over Time"
+- X-axis labels: `t.week` → `t.day`
+- No other chart config changes
+
+### Tests: `tests/dashboard/test_outcomes_page.py`
+
+- Update mock `trends` entries to use `day` key instead of `week`
+
+## Out of Scope
+
+- Weekly trends chart is removed, not kept alongside. Can be re-added once months of data exist.
+- No changes to summary cards, severity/category charts, or outcome distribution.

--- a/tests/dashboard/test_outcomes_page.py
+++ b/tests/dashboard/test_outcomes_page.py
@@ -38,8 +38,8 @@ def test_outcomes_page_renders():
             "Style": {"total": 20, "actioned": 2, "hit_rate": 10.0},
         },
         "trends": [
-            {"week": "2026-16", "total": 25, "hit_rate": 44.0, "noise_rate": 36.0},
-            {"week": "2026-17", "total": 25, "hit_rate": 36.0, "noise_rate": 44.0},
+            {"day": "2026-04-27", "total": 168, "hit_rate": 83.3, "noise_rate": 16.7},
+            {"day": "2026-04-28", "total": 61, "hit_rate": 77.0, "noise_rate": 23.0},
         ],
         "repos": ["owner/repo-a", "owner/repo-b"],
     }
@@ -54,3 +54,4 @@ def test_outcomes_page_renders():
     assert response.status_code == 200
     assert "Outcomes" in response.text
     assert "40.0" in response.text  # hit_rate
+    assert "Accuracy Over Time" in response.text


### PR DESCRIPTION
## Summary

- Replaces the non-functional Weekly Trends chart (single dot — all data in one ISO week) with a daily Accuracy Over Time line chart
- Backend: `get_outcomes_data` now groups by `DATE(labeled_at)` instead of ISO week; trends entries use `day` key instead of `week`
- Template: chart title and x-axis label accessor updated to match

## Test Plan

- [ ] Outcomes page renders without errors
- [ ] Accuracy Over Time chart shows daily data points with correct hit rate / noise rate / volume
- [ ] All 451 tests pass (`uv run pytest`)