### PR TITLE
feat: auto-resolve Baloo threads when issue is fixed in follow-up commit

### DIFF
--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -567,6 +567,43 @@ class GitHubAPIClient:
             response.raise_for_status()
             return True
 
+    async def resolve_review_thread(self, thread_node_id: str) -> bool:
+        """Resolve a pull request review thread via GraphQL mutation.
+
+        Args:
+            thread_node_id: The GraphQL node ID of the thread (PullRequestReviewThread.id).
+
+        Returns:
+            True on success, False on any error (fail-open — a failed resolve is not fatal).
+        """
+        mutation = """
+        mutation($threadId: ID!) {
+          resolveReviewThread(input: {threadId: $threadId}) {
+            thread { id isResolved }
+          }
+        }
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "https://api.github.com/graphql",
+                    headers=self._get_headers(),
+                    json={"query": mutation, "variables": {"threadId": thread_node_id}},
+                )
+                response.raise_for_status()
+                body = response.json()
+                if "errors" in body:
+                    logger.warning(
+                        "GraphQL error resolving thread %s: %s",
+                        thread_node_id,
+                        body["errors"],
+                    )
+                    return False
+                return True
+        except Exception as exc:
+            logger.warning("Failed to resolve thread %s: %s", thread_node_id, exc)
+            return False
+
     async def get_commit_info(self, repo_full_name: str, commit_sha: str) -> dict:
         """
         Fetch information about a specific commit.

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -112,9 +112,12 @@ def _apply_resolved_thread_state(
     discussion_threads: list[DiscussionThread],
     resolved_ids: set[int],
     outdated_ids: set[int] | None = None,
+    thread_node_ids: dict[int, str] | None = None,
 ) -> None:
     """Overlay GitHub's authoritative resolved/outdated state onto REST-built threads."""
     for thread in discussion_threads:
+        if thread_node_ids and thread.root_comment_id is not None:
+            thread.node_id = thread_node_ids.get(thread.root_comment_id)
         if thread.root_comment_id in resolved_ids:
             thread.resolved = True
             thread.awaiting_response = False
@@ -233,10 +236,12 @@ class GitHubAPIClient:
             # Overlay the authoritative isResolved state from GraphQL.
             # The REST API doesn't expose thread resolution, so without
             # this call we rely on a keyword heuristic which is unreliable.
-            resolved_ids, outdated_ids = await self.fetch_resolved_thread_ids(
+            resolved_ids, outdated_ids, thread_node_ids = await self.fetch_resolved_thread_ids(
                 repo_full_name, pr_number
             )
-            _apply_resolved_thread_state(discussion_threads, resolved_ids, outdated_ids)
+            _apply_resolved_thread_state(
+                discussion_threads, resolved_ids, outdated_ids, thread_node_ids
+            )
 
             general_comments: list[DiscussionComment] = build_general_discussion(
                 issue_comments, reviews
@@ -716,15 +721,15 @@ class GitHubAPIClient:
 
     async def fetch_resolved_thread_ids(
         self, repo_full_name: str, pr_number: int
-    ) -> tuple[set[int], set[int]]:
+    ) -> tuple[set[int], set[int], dict[int, str]]:
         """Fetch resolved and outdated root comment database IDs for review threads.
 
         Uses the GraphQL API because the REST API does not expose the
         ``isResolved`` or ``isOutdated`` state of review threads.
 
         Returns:
-            Tuple of (resolved_ids, outdated_ids).  On error returns empty sets
-            so callers degrade gracefully (fail-open).
+            Tuple of (resolved_ids, outdated_ids, node_id_map).  On error returns
+            empty sets/dict so callers degrade gracefully (fail-open).
         """
         owner, repo = repo_full_name.split("/", 1)
         query = """
@@ -734,6 +739,7 @@ class GitHubAPIClient:
               reviewThreads(first: 100, after: $cursor) {
                 pageInfo { hasNextPage endCursor }
                 nodes {
+                  id
                   isResolved
                   isOutdated
                   comments(first: 1) {
@@ -748,6 +754,7 @@ class GitHubAPIClient:
 
         resolved_ids: set[int] = set()
         outdated_ids: set[int] = set()
+        node_id_map: dict[int, str] = {}
         cursor: str | None = None
 
         try:
@@ -788,6 +795,9 @@ class GitHubAPIClient:
                         if not comments or not comments[0].get("databaseId"):
                             continue
                         db_id = comments[0]["databaseId"]
+                        thread_node_id = node.get("id")
+                        if thread_node_id:
+                            node_id_map[db_id] = thread_node_id
                         if node.get("isResolved"):
                             resolved_ids.add(db_id)
                         elif node.get("isOutdated"):
@@ -807,7 +817,7 @@ class GitHubAPIClient:
                 exc_info=True,
             )
 
-        return resolved_ids, outdated_ids
+        return resolved_ids, outdated_ids, node_id_map
 
     async def _fetch_paginated_json(
         self,

--- a/baloo/github/models.py
+++ b/baloo/github/models.py
@@ -120,6 +120,7 @@ class DiscussionThread(BaseModel):
     outdated: bool = False
     last_activity: datetime
     root_comment_id: int | None = None
+    node_id: str | None = None
 
 
 class PRMetadata(BaseModel):

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -45,6 +45,7 @@ from baloo.outcomes.labeler import label_pr_outcomes
 from baloo.processor.decision_engine import DecisionEngine
 from baloo.processor.findings_filter import FindingsFilter
 from baloo.processor.formatter import CommentFormatter
+from baloo.processor.fp_verifier import FPVerifier
 from baloo.processor.severity_router import (
     ReviewSeverity,
     count_by_severity,
@@ -407,6 +408,61 @@ def _comment_from_thread(thread: DiscussionThread) -> ReviewComment:
         severity=severity,
         category=category,
     )
+
+
+async def _reverify_awaiting_threads(
+    awaiting_threads: list[DiscussionThread],
+    pr_context: PRContext,
+    api_client,
+) -> int:
+    """Re-verify awaiting Baloo threads against the new diff.
+
+    For each thread where the LLM says the issue is no longer present (fp verdict),
+    post a resolution reply and resolve the GitHub thread.
+
+    Returns:
+        Number of threads auto-resolved.
+    """
+    if not awaiting_threads:
+        return 0
+
+    eligible = [t for t in awaiting_threads if t.node_id]
+    if not eligible:
+        logger.info("No awaiting threads with node_id — skipping re-verification")
+
+    comments = [_comment_from_thread(t) for t in eligible]
+
+    verifier = FPVerifier()
+    fp_result = await verifier.verify(comments, pr_context)
+
+    # fp_result.rejected = findings the verifier says are no longer present
+    rejected_paths_lines = {(r.comment.path, r.comment.line) for r in fp_result.rejected}
+
+    resolved_count = 0
+    for thread in eligible:
+        if (thread.path, thread.line) not in rejected_paths_lines:
+            continue
+
+        logger.info(
+            "Thread re-verified as fixed: %s:%s (thread node %s)",
+            thread.path,
+            thread.line,
+            thread.node_id,
+        )
+
+        repo = pr_context.repo_full_name
+
+        if thread.root_comment_id is not None:
+            await api_client.reply_to_review_comment(
+                repo,
+                thread.root_comment_id,
+                "Looks like this was addressed in the latest commit. Resolving.",
+            )
+
+        await api_client.resolve_review_thread(thread.node_id)
+        resolved_count += 1
+
+    return resolved_count
 
 
 def _dedupe_similar_findings(comments: list[ReviewComment]) -> tuple[list[ReviewComment], int]:
@@ -889,8 +945,6 @@ async def process_pr_review(
 
             # FP verification pass (LLM-powered, before heuristic filter)
             if settings.fp_verification_enabled and review_result.comments:
-                from baloo.processor.fp_verifier import FPVerifier
-
                 verifier = FPVerifier()
                 fp_result = await verifier.verify(review_result.comments, pr_context)
                 # Build a fresh metadata dict rather than mutating the agent
@@ -943,6 +997,7 @@ async def process_pr_review(
             skipped_resolved = 0
             skipped_outdated = 0
             skipped_responded = 0
+            awaiting_not_refiled: list[DiscussionThread] = []
             skipped_unchanged_scope = 0
             skipped_outside_line_scope = 0
 
@@ -992,6 +1047,7 @@ async def process_pr_review(
 
                 if thread.awaiting_response:
                     skipped_duplicates += 1
+                    awaiting_not_refiled.append(thread)
                     continue
 
                 # Developer responded (not resolved, not awaiting) — they've
@@ -1002,10 +1058,14 @@ async def process_pr_review(
 
             decision_comments = fresh_comments + [comment for _, comment in follow_up_comments]
 
+            auto_resolved_count = await _reverify_awaiting_threads(
+                awaiting_not_refiled, pr_context, github_client
+            )
+
             approve, request_changes = DecisionEngine.make_decision(
                 decision_comments, fidelity_result=fidelity_result
             )
-            awaiting_threads = pr_context.awaiting_response_threads
+            awaiting_threads = pr_context.awaiting_response_threads - auto_resolved_count
 
             if awaiting_threads and not request_changes and not decision_comments:
                 request_changes = True
@@ -1023,6 +1083,11 @@ async def process_pr_review(
                 summary_text += f"\n\n⏭️ Skipped {skipped_outdated} outdated thread(s) (code changed under comment)."
             if skipped_resolved:
                 summary_text += f"\n\n✅ Skipped {skipped_resolved} resolved thread(s)."
+            if auto_resolved_count:
+                summary_text += (
+                    f"\n\n✅ Auto-resolved {auto_resolved_count} previously flagged thread(s) "
+                    "that look fixed in this commit."
+                )
             if skipped_similar_repeats:
                 summary_text += (
                     f"\n\n🧹 Collapsed {skipped_similar_repeats} near-duplicate finding(s) "

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -35,6 +35,7 @@ from baloo.github.auth import verify_webhook_signature
 from baloo.github.models import (
     DiscussionComment,
     DiscussionThread,
+    FindingCategory,
     PRContext,
     PullRequestWebhookPayload,
     ReviewComment,
@@ -362,6 +363,50 @@ def _extract_issue_signature(body: str) -> str:
 
     # Fallback: normalize the whole body
     return " ".join(body.strip().lower().split())
+
+
+_SEVERITY_RE = re.compile(r"\*\*\[(\w+)\]\s+\w[\w ]*\*\*")
+_CATEGORY_RE = re.compile(r"\*\*\[(?:\w+)\]\s+([\w][\w ]*?)\*\*")
+
+_CATEGORY_MAP: dict[str, FindingCategory] = {
+    "security": FindingCategory.SECURITY,
+    "bugs": FindingCategory.BUGS,
+    "silent failures": FindingCategory.SILENT_FAILURES,
+    "guidelines": FindingCategory.GUIDELINES,
+    "performance": FindingCategory.PERFORMANCE,
+    "quality": FindingCategory.QUALITY,
+}
+
+
+def _comment_from_thread(thread: DiscussionThread) -> ReviewComment:
+    """Reconstruct a ReviewComment from a Baloo DiscussionThread for re-verification.
+
+    Parses severity and category from the root comment body using the Baloo
+    comment format: **[SEVERITY] Category** - **Title**
+    Falls back to MEDIUM/QUALITY if the body doesn't match.
+    """
+    body = thread.comments[0].body if thread.comments else ""
+
+    severity = ReviewSeverity.MEDIUM
+    m = _SEVERITY_RE.search(body)
+    if m:
+        try:
+            severity = ReviewSeverity(m.group(1).upper())
+        except ValueError:
+            pass
+
+    category = FindingCategory.QUALITY
+    m2 = _CATEGORY_RE.search(body)
+    if m2:
+        category = _CATEGORY_MAP.get(m2.group(1).lower().strip(), FindingCategory.QUALITY)
+
+    return ReviewComment(
+        path=thread.path or "",
+        line=thread.line or 0,
+        body=body,
+        severity=severity,
+        category=category,
+    )
 
 
 def _dedupe_similar_findings(comments: list[ReviewComment]) -> tuple[list[ReviewComment], int]:

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -414,6 +414,7 @@ async def _reverify_awaiting_threads(
     awaiting_threads: list[DiscussionThread],
     pr_context: PRContext,
     api_client,
+    db_review_id: int | None = None,
 ) -> int:
     """Re-verify awaiting Baloo threads against the new diff.
 
@@ -461,6 +462,50 @@ async def _reverify_awaiting_threads(
 
         await api_client.resolve_review_thread(thread.node_id)
         resolved_count += 1
+
+        # Update finding_outcomes row for this finding if DB is enabled
+        if settings.database_enabled and db_review_id is not None:
+            try:
+                from sqlalchemy import select
+
+                from baloo.db.engine import get_session_factory
+                from baloo.db.models import Finding, FindingOutcome
+
+                session_factory = get_session_factory(settings.database_url)
+                async with session_factory() as session:
+                    async with session.begin():
+                        # Look up the Finding by review_id, file_path, line_number
+                        finding_stmt = select(Finding).where(
+                            Finding.review_id == db_review_id,
+                            Finding.file_path == (thread.path or ""),
+                            Finding.line_number == thread.line,
+                        )
+                        finding_result = await session.execute(finding_stmt)
+                        finding = finding_result.scalars().first()
+
+                        if finding is not None:
+                            # Update existing FindingOutcome row if present
+                            outcome_stmt = select(FindingOutcome).where(
+                                FindingOutcome.finding_id == finding.id
+                            )
+                            outcome_result = await session.execute(outcome_stmt)
+                            outcome_row = outcome_result.scalars().first()
+
+                            if outcome_row is not None:
+                                signals = dict(outcome_row.signals or {})
+                                signals["thread_resolved"] = True
+                                outcome_row.signals = signals
+                                logger.info(
+                                    "Updated finding_outcomes thread_resolved=True for finding %d",
+                                    finding.id,
+                                )
+            except Exception as db_err:
+                logger.warning(
+                    "Failed to update finding_outcomes for thread %s:%s: %s",
+                    thread.path,
+                    thread.line,
+                    db_err,
+                )
 
     return resolved_count
 
@@ -943,42 +988,6 @@ async def process_pr_review(
             agent_metadata = agent_result.metadata
             review_result = agent_result
 
-            # FP verification pass (LLM-powered, before heuristic filter)
-            if settings.fp_verification_enabled and review_result.comments:
-                verifier = FPVerifier()
-                fp_result = await verifier.verify(review_result.comments, pr_context)
-                # Build a fresh metadata dict rather than mutating the agent
-                # result's dict via aliasing — keeps provenance explicit and
-                # avoids breakage if ReviewResult ever copies its metadata.
-                merged_metadata = {
-                    **review_result.metadata,
-                    "fp_verification": {
-                        "total": fp_result.stats.total_verified,
-                        "kept": fp_result.stats.kept,
-                        "rejected": fp_result.stats.rejected,
-                        "errors": fp_result.stats.errors,
-                        "cost_usd": fp_result.stats.total_cost_usd,
-                        "duration_seconds": fp_result.stats.duration_seconds,
-                    },
-                }
-                review_result = ReviewResult(
-                    summary=review_result.summary,
-                    comments=fp_result.verified,
-                    approve=review_result.approve,
-                    request_changes=review_result.request_changes,
-                    metadata=merged_metadata,
-                )
-                # Keep `agent_metadata` in sync so the final ReviewResult
-                # built below (which re-uses agent_metadata) still carries
-                # the fp_verification stats forward to the DB row.
-                agent_metadata = merged_metadata
-                logger.info(
-                    "FP verification: %d/%d findings kept (rejected %d)",
-                    fp_result.stats.kept,
-                    fp_result.stats.total_verified,
-                    fp_result.stats.rejected,
-                )
-
             findings_filter = FindingsFilter()
             filtered_comments = findings_filter.filter_findings(review_result.comments)
             filtered_comments, skipped_similar_repeats = _dedupe_similar_findings(filtered_comments)
@@ -989,7 +998,7 @@ async def process_pr_review(
             all_threads = list(pr_context.discussion_threads)
             all_threads.extend(_threads_from_issue_comments(pr_context.issue_comments))
             thread_lookup = _build_thread_lookup(all_threads)
-            fresh_comments: list[ReviewComment] = []
+            new_findings_comments: list[ReviewComment] = []
             follow_up_comments: list[tuple[DiscussionThread, ReviewComment]] = (
                 []
             )  # reserved for future conversational thread agent
@@ -1016,7 +1025,7 @@ async def process_pr_review(
                         ):
                             skipped_outside_line_scope += 1
                             continue
-                    fresh_comments.append(comment)
+                    new_findings_comments.append(comment)
                     continue
 
                 # Thread was resolved (GitHub "Resolve conversation").
@@ -1056,11 +1065,47 @@ async def process_pr_review(
                 skipped_responded += 1
                 continue
 
-            decision_comments = fresh_comments + [comment for _, comment in follow_up_comments]
+            # Run both FP passes concurrently after the thread-matching loop:
+            # Pass A: FP verification on new findings
+            # Pass B: Re-verification of awaiting threads
+            async def _fp_verify_new_findings(
+                comments: list[ReviewComment],
+            ) -> list[ReviewComment]:
+                """Run FP verifier on new findings; returns verified list."""
+                if not (settings.fp_verification_enabled and comments):
+                    return comments
+                verifier = FPVerifier()
+                fp_result = await verifier.verify(comments, pr_context)
+                nonlocal agent_metadata
+                merged_metadata = {
+                    **review_result.metadata,
+                    "fp_verification": {
+                        "total": fp_result.stats.total_verified,
+                        "kept": fp_result.stats.kept,
+                        "rejected": fp_result.stats.rejected,
+                        "errors": fp_result.stats.errors,
+                        "cost_usd": fp_result.stats.total_cost_usd,
+                        "duration_seconds": fp_result.stats.duration_seconds,
+                    },
+                }
+                agent_metadata = merged_metadata
+                logger.info(
+                    "FP verification: %d/%d findings kept (rejected %d)",
+                    fp_result.stats.kept,
+                    fp_result.stats.total_verified,
+                    fp_result.stats.rejected,
+                )
+                return fp_result.verified
 
-            auto_resolved_count = await _reverify_awaiting_threads(
-                awaiting_not_refiled, pr_context, github_client
+            verified_new_findings, auto_resolved_count = await asyncio.gather(
+                _fp_verify_new_findings(new_findings_comments),
+                _reverify_awaiting_threads(
+                    awaiting_not_refiled, pr_context, github_client, db_review_id=db_review_id
+                ),
             )
+
+            fresh_comments = verified_new_findings
+            decision_comments = fresh_comments + [comment for _, comment in follow_up_comments]
 
             approve, request_changes = DecisionEngine.make_decision(
                 decision_comments, fidelity_result=fidelity_result

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -430,6 +430,7 @@ async def _reverify_awaiting_threads(
     eligible = [t for t in awaiting_threads if t.node_id]
     if not eligible:
         logger.info("No awaiting threads with node_id — skipping re-verification")
+        return 0
 
     comments = [_comment_from_thread(t) for t in eligible]
 
@@ -454,11 +455,23 @@ async def _reverify_awaiting_threads(
         repo = pr_context.repo_full_name
 
         if thread.root_comment_id is not None:
-            await api_client.reply_to_review_comment(
-                repo,
-                thread.root_comment_id,
-                "Looks like this was addressed in the latest commit. Resolving.",
-            )
+            try:
+                replied = await api_client.reply_to_review_comment(
+                    repo,
+                    thread.root_comment_id,
+                    "Looks like this was addressed in the latest commit. Resolving.",
+                )
+                if not replied:
+                    logger.warning(
+                        "Failed to post resolution reply on thread %s — resolving anyway",
+                        thread.node_id,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "Error posting resolution reply on thread %s: %s — resolving anyway",
+                    thread.node_id,
+                    exc,
+                )
 
         await api_client.resolve_review_thread(thread.node_id)
         resolved_count += 1

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -427,6 +427,10 @@ async def _reverify_awaiting_threads(
     if not awaiting_threads:
         return 0
 
+    if not settings.fp_verification_enabled:
+        logger.debug("FP verification disabled — skipping awaiting thread re-verification")
+        return 0
+
     eligible = [t for t in awaiting_threads if t.node_id]
     if not eligible:
         logger.info("No awaiting threads with node_id — skipping re-verification")
@@ -1019,7 +1023,7 @@ async def process_pr_review(
             skipped_resolved = 0
             skipped_outdated = 0
             skipped_responded = 0
-            awaiting_not_refiled: list[DiscussionThread] = []
+            matched_awaiting_ids: set = set()
             skipped_unchanged_scope = 0
             skipped_outside_line_scope = 0
 
@@ -1069,7 +1073,7 @@ async def process_pr_review(
 
                 if thread.awaiting_response:
                     skipped_duplicates += 1
-                    awaiting_not_refiled.append(thread)
+                    matched_awaiting_ids.add(thread.id)
                     continue
 
                 # Developer responded (not resolved, not awaiting) — they've
@@ -1077,6 +1081,20 @@ async def process_pr_review(
                 # Don't re-litigate; just note these threads exist.
                 skipped_responded += 1
                 continue
+
+            # Collect threads from previous reviews that are still awaiting a
+            # response but were NOT re-flagged by any new finding.  These are
+            # candidates for auto-resolution: the agent no longer flags the
+            # issue, so the fix may have landed.
+            awaiting_not_refiled: list[DiscussionThread] = [
+                t
+                for t in all_threads
+                if t.is_baloo_thread
+                and t.awaiting_response
+                and not t.resolved
+                and not t.outdated
+                and t.id not in matched_awaiting_ids
+            ]
 
             # Run both FP passes concurrently after the thread-matching loop:
             # Pass A: FP verification on new findings

--- a/baloo/outcomes/labeler.py
+++ b/baloo/outcomes/labeler.py
@@ -74,8 +74,10 @@ async def fetch_merge_signals(
         raw_comments = await client._fetch_paginated_json(http, comments_url, headers=headers)
 
     # Fetch resolved thread IDs via GraphQL
-    resolved_ids, _outdated_ids, _thread_node_ids = await client.fetch_resolved_thread_ids(
-        repo_full_name, pr_number
+    resolved_ids, _outdated_ids, _thread_node_ids = (
+        await client.fetch_resolved_thread_ids(  # node_ids not needed here
+            repo_full_name, pr_number
+        )
     )
 
     # Group comments into threads by in_reply_to_id

--- a/baloo/outcomes/labeler.py
+++ b/baloo/outcomes/labeler.py
@@ -74,7 +74,9 @@ async def fetch_merge_signals(
         raw_comments = await client._fetch_paginated_json(http, comments_url, headers=headers)
 
     # Fetch resolved thread IDs via GraphQL
-    resolved_ids = await client.fetch_resolved_thread_ids(repo_full_name, pr_number)
+    resolved_ids, _outdated_ids, _thread_node_ids = await client.fetch_resolved_thread_ids(
+        repo_full_name, pr_number
+    )
 
     # Group comments into threads by in_reply_to_id
     # Root comments have in_reply_to_id == None

--- a/docs/superpowers/plans/2026-05-04-outcomes-daily-accuracy.md
+++ b/docs/superpowers/plans/2026-05-04-outcomes-daily-accuracy.md
@@ -1,0 +1,173 @@
+# Outcomes Daily Accuracy Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the non-functional Weekly Trends line chart on the outcomes page with a daily Accuracy Over Time chart.
+
+**Architecture:** The weekly grouping query in `get_outcomes_data` is replaced with a daily one using `DATE(labeled_at)`, which is dialect-agnostic. The return key `trends` is unchanged; each entry's `week` field becomes `day`. The template swaps the chart title and x-axis label accessor.
+
+**Tech Stack:** Python/SQLAlchemy (backend), Jinja2 + Chart.js 4 (frontend), pytest (tests)
+
+**Worktree:** `.worktrees/fix/outcomes-daily-accuracy`
+
+---
+
+### Task 1: Update tests to reflect daily data shape
+
+**Files:**
+- Modify: `tests/dashboard/test_outcomes_page.py`
+
+- [ ] **Step 1: Update mock trends data and add title assertion**
+
+In `test_outcomes_page_renders`, change the `trends` entries from `week` keys to `day` keys, and add an assertion that the new chart title appears:
+
+```python
+"trends": [
+    {"day": "2026-04-27", "total": 168, "hit_rate": 83.3, "noise_rate": 16.7},
+    {"day": "2026-04-28", "total": 61,  "hit_rate": 77.0, "noise_rate": 23.0},
+],
+```
+
+And at the end of the test, add:
+
+```python
+assert "Accuracy Over Time" in response.text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd .worktrees/fix/outcomes-daily-accuracy
+uv run pytest tests/dashboard/test_outcomes_page.py -v
+```
+
+Expected: `test_outcomes_page_renders` FAILS — `"Accuracy Over Time"` not in response (template still says "Weekly Trends").
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/dashboard/test_outcomes_page.py
+git commit -m "test: update outcomes mock data to use daily trends shape"
+```
+
+---
+
+### Task 2: Replace weekly query with daily query in backend
+
+**Files:**
+- Modify: `baloo/dashboard/queries.py` (lines 483–529)
+
+- [ ] **Step 1: Replace the weekly trends block**
+
+Find the comment `# --- Weekly trends (dialect-aware) ---` and replace everything from that comment through the `trends = [...]` list comprehension with:
+
+```python
+# --- Daily accuracy trends ---
+daily_rows = (
+    await session.execute(
+        select(
+            func.date(FindingOutcome.labeled_at).label("day"),
+            FindingOutcome.outcome,
+            func.count(FindingOutcome.id),
+        )
+        .where(*_base_filters())
+        .group_by("day", FindingOutcome.outcome)
+        .order_by("day")
+    )
+).all()
+
+day_map: dict[str, dict] = {}
+for day, outcome, cnt in daily_rows:
+    day_key = str(day)
+    if day_key not in day_map:
+        day_map[day_key] = {
+            "total": 0,
+            "actioned": 0,
+            "acknowledged": 0,
+            "disputed": 0,
+            "ignored": 0,
+        }
+    day_map[day_key]["total"] += cnt
+    if outcome in day_map[day_key]:
+        day_map[day_key][outcome] += cnt
+trends = [
+    {
+        "day": d,
+        "total": v["total"],
+        "hit_rate": round(v["actioned"] / v["total"] * 100, 1) if v["total"] else 0.0,
+        "noise_rate": (
+            round((v["disputed"] + v["ignored"]) / v["total"] * 100, 1)
+            if v["total"]
+            else 0.0
+        ),
+    }
+    for d, v in day_map.items()
+]
+```
+
+- [ ] **Step 2: Run tests — still failing (template not updated yet)**
+
+```bash
+uv run pytest tests/dashboard/test_outcomes_page.py -v
+```
+
+Expected: still FAIL on `"Accuracy Over Time"` assertion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add baloo/dashboard/queries.py
+git commit -m "feat: switch outcomes trends query from weekly to daily granularity"
+```
+
+---
+
+### Task 3: Update template
+
+**Files:**
+- Modify: `baloo/dashboard/templates/outcomes.html` (lines 73, 159)
+
+- [ ] **Step 1: Update chart title**
+
+Change line 73:
+```html
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Weekly Trends</h2>
+```
+to:
+```html
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Accuracy Over Time</h2>
+```
+
+- [ ] **Step 2: Update x-axis label accessor**
+
+Change line 159:
+```javascript
+      labels: trends.map(t => t.week),
+```
+to:
+```javascript
+      labels: trends.map(t => t.day),
+```
+
+- [ ] **Step 3: Run tests — should now pass**
+
+```bash
+uv run pytest tests/dashboard/test_outcomes_page.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+uv run pytest --tb=short -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add baloo/dashboard/templates/outcomes.html
+git commit -m "feat: replace Weekly Trends chart with daily Accuracy Over Time"
+```

--- a/docs/superpowers/plans/2026-05-04-thread-auto-resolution.md
+++ b/docs/superpowers/plans/2026-05-04-thread-auto-resolution.md
@@ -1,0 +1,1062 @@
+# Thread Auto-Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When Baloo re-reviews a PR and a previously flagged issue is no longer present, automatically reply "Looks like this was addressed in the latest commit. Resolving." and resolve the GitHub thread via GraphQL mutation.
+
+**Architecture:** Extend the FP verifier to run a second concurrent pass over unresolved awaiting threads (reconstructed as ReviewComment objects), using the new diff as context. On an `fp` verdict the thread is replied to and resolved via a new `resolveReviewThread` GraphQL mutation. Thread node IDs are fetched alongside the existing resolved-state query and stored on `DiscussionThread`.
+
+**Tech Stack:** Python 3.10+, pydantic v2, httpx, pytest/pytest-asyncio, GitHub GraphQL API
+
+---
+
+## Task 1: Add `node_id` to `DiscussionThread` and propagate from GraphQL
+
+**Files:**
+- Modify: `baloo/github/models.py`
+- Modify: `baloo/github/api_client.py` (lines ~111–124 `_apply_resolved_thread_state`, lines ~736–753 GraphQL query)
+- Test: `tests/github/test_discussions.py`
+
+### Background
+
+`DiscussionThread` currently tracks `resolved`, `outdated`, `awaiting_response`, `is_baloo_thread`, and `root_comment_id` (the REST comment integer ID). To resolve a thread via GraphQL mutation we need the thread's **GraphQL node ID** (a base64 string like `"PRT_kwDO..."`) — a different identifier from `databaseId`.
+
+The existing `fetch_resolved_thread_ids` query already fetches threads; we just need to add `id` to it and return the mapping.
+
+- [ ] **Step 1: Write the failing test for `node_id` field**
+
+In `tests/github/test_discussions.py`, add:
+
+```python
+from baloo.github.models import DiscussionThread
+from datetime import datetime, timezone
+
+def test_discussion_thread_has_node_id_field():
+    thread = DiscussionThread(
+        id=1,
+        path="foo.py",
+        line=10,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+    )
+    assert thread.node_id is None
+
+def test_discussion_thread_node_id_can_be_set():
+    thread = DiscussionThread(
+        id=1,
+        path="foo.py",
+        line=10,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+        node_id="PRT_kwDOBQ",
+    )
+    assert thread.node_id == "PRT_kwDOBQ"
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_discussions.py::test_discussion_thread_has_node_id_field tests/github/test_discussions.py::test_discussion_thread_node_id_can_be_set -v
+```
+
+Expected: `AttributeError` or `ValidationError` — field doesn't exist yet.
+
+- [ ] **Step 3: Add `node_id` to `DiscussionThread`**
+
+In `baloo/github/models.py`, find `DiscussionThread` (currently around line 110) and add one field:
+
+```python
+class DiscussionThread(BaseModel):
+    """Represents an inline review thread."""
+
+    id: int
+    path: str | None
+    line: int | None
+    comments: list[DiscussionComment]
+    is_baloo_thread: bool = False
+    awaiting_response: bool = False
+    resolved: bool = False
+    outdated: bool = False
+    last_activity: datetime
+    root_comment_id: int | None = None
+    node_id: str | None = None  # GraphQL thread node ID for resolveReviewThread mutation
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_discussions.py::test_discussion_thread_has_node_id_field tests/github/test_discussions.py::test_discussion_thread_node_id_can_be_set -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing test for `_apply_resolved_thread_state` writing `node_id`**
+
+In `tests/github/test_discussions.py`, add:
+
+```python
+from baloo.github.api_client import _apply_resolved_thread_state
+
+def _make_thread(root_comment_id: int) -> DiscussionThread:
+    return DiscussionThread(
+        id=root_comment_id,
+        path="foo.py",
+        line=1,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=root_comment_id,
+    )
+
+def test_apply_resolved_thread_state_writes_node_id():
+    thread = _make_thread(root_comment_id=42)
+    node_id_map = {42: "PRT_kwDOBQ"}
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids=set(),
+        outdated_ids=None,
+        thread_node_ids=node_id_map,
+    )
+    assert thread.node_id == "PRT_kwDOBQ"
+
+def test_apply_resolved_thread_state_node_id_missing_from_map():
+    thread = _make_thread(root_comment_id=99)
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids=set(),
+        thread_node_ids={},
+    )
+    assert thread.node_id is None
+
+def test_apply_resolved_thread_state_existing_behaviour_preserved():
+    """Resolved flag still gets set correctly alongside node_id."""
+    thread = _make_thread(root_comment_id=7)
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids={7},
+        thread_node_ids={7: "PRT_abc"},
+    )
+    assert thread.resolved is True
+    assert thread.node_id == "PRT_abc"
+```
+
+- [ ] **Step 6: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_discussions.py::test_apply_resolved_thread_state_writes_node_id tests/github/test_discussions.py::test_apply_resolved_thread_state_node_id_missing_from_map tests/github/test_discussions.py::test_apply_resolved_thread_state_existing_behaviour_preserved -v
+```
+
+Expected: `TypeError` — `_apply_resolved_thread_state` doesn't accept `thread_node_ids` yet.
+
+- [ ] **Step 7: Extend `_apply_resolved_thread_state` to accept and write `node_id`**
+
+In `baloo/github/api_client.py`, update `_apply_resolved_thread_state` (around line 111):
+
+```python
+def _apply_resolved_thread_state(
+    discussion_threads: list[DiscussionThread],
+    resolved_ids: set[int],
+    outdated_ids: set[int] | None = None,
+    thread_node_ids: dict[int, str] | None = None,
+) -> None:
+    """Overlay GitHub's authoritative resolved/outdated state onto REST-built threads."""
+    for thread in discussion_threads:
+        if thread_node_ids and thread.root_comment_id is not None:
+            thread.node_id = thread_node_ids.get(thread.root_comment_id)
+        if thread.root_comment_id in resolved_ids:
+            thread.resolved = True
+            thread.awaiting_response = False
+        elif outdated_ids and thread.root_comment_id in outdated_ids:
+            thread.outdated = True
+            thread.awaiting_response = False
+```
+
+- [ ] **Step 8: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_discussions.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Update GraphQL query to fetch thread node ID**
+
+In `baloo/github/api_client.py`, find `fetch_resolved_thread_ids` (around line 736). Update:
+1. The query string — add `id` on the thread node
+2. The return type — add `dict[int, str]` third element
+3. The parsing loop — populate a `node_id_map`
+4. The call site in `get_pr_context` — unpack the third value and pass to `_apply_resolved_thread_state`
+
+Change the query from:
+```python
+        query = """
+        query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pr) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  isResolved
+                  isOutdated
+                  comments(first: 1) {
+                    nodes { databaseId }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+```
+
+To:
+```python
+        query = """
+        query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pr) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  comments(first: 1) {
+                    nodes { databaseId }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+```
+
+Change the return type annotation from `tuple[set[int], set[int]]` to `tuple[set[int], set[int], dict[int, str]]`.
+
+Add `node_id_map: dict[int, str] = {}` after the `outdated_ids` declaration. In the loop that processes nodes:
+
+```python
+                    for node in threads_data.get("nodes", []):
+                        if node is None:
+                            continue
+                        comments = node.get("comments", {}).get("nodes", [])
+                        if not comments or not comments[0].get("databaseId"):
+                            continue
+                        db_id = comments[0]["databaseId"]
+                        thread_node_id = node.get("id")
+                        if thread_node_id:
+                            node_id_map[db_id] = thread_node_id
+                        if node.get("isResolved"):
+                            resolved_ids.add(db_id)
+                        elif node.get("isOutdated"):
+                            outdated_ids.add(db_id)
+```
+
+Change the return statement from `return resolved_ids, outdated_ids` to `return resolved_ids, outdated_ids, node_id_map`.
+
+In the `except` block at the end of the function, change the return from `return set(), set()` to `return set(), set(), {}`.
+
+- [ ] **Step 10: Update `get_pr_context` call site**
+
+In `get_pr_context` (around line 236), change:
+
+```python
+            resolved_ids, outdated_ids = await self.fetch_resolved_thread_ids(
+                repo_full_name, pr_number
+            )
+            _apply_resolved_thread_state(discussion_threads, resolved_ids, outdated_ids)
+```
+
+To:
+
+```python
+            resolved_ids, outdated_ids, thread_node_ids = await self.fetch_resolved_thread_ids(
+                repo_full_name, pr_number
+            )
+            _apply_resolved_thread_state(
+                discussion_threads, resolved_ids, outdated_ids, thread_node_ids
+            )
+```
+
+- [ ] **Step 11: Run full test suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all existing tests pass (the new third return value is ignored by any existing callers that only unpack two values — but check for `ValueError: too many values to unpack` if any test mocks this function).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add baloo/github/models.py baloo/github/api_client.py tests/github/test_discussions.py
+git commit -m "feat: add node_id to DiscussionThread and fetch via GraphQL"
+```
+
+---
+
+## Task 2: Add `resolve_review_thread` GraphQL mutation
+
+**Files:**
+- Modify: `baloo/github/api_client.py`
+- Test: `tests/github/test_api_client_resolve.py` (new file)
+
+### Background
+
+GitHub's GraphQL API exposes `resolveReviewThread(input: {threadId: ID!})`. The `threadId` must be the thread's GraphQL node ID (the `id` field we now store as `DiscussionThread.node_id`). There is no REST equivalent.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/github/test_api_client_resolve.py`:
+
+```python
+"""Tests for resolve_review_thread GraphQL mutation."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from baloo.github.api_client import GitHubAPIClient
+
+
+@pytest.fixture
+def client():
+    with patch("baloo.github.api_client.get_installation_token", return_value="tok"):
+        return GitHubAPIClient(installation_id=1)
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_success(client):
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "data": {"resolveReviewThread": {"thread": {"id": "PRT_x", "isResolved": True}}}
+    }
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_http
+
+        result = await client.resolve_review_thread("PRT_x")
+
+    assert result is True
+    call_kwargs = mock_http.post.call_args
+    body = call_kwargs[1]["json"]
+    assert "resolveReviewThread" in body["query"]
+    assert body["variables"]["threadId"] == "PRT_x"
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_graphql_error_returns_false(client):
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"errors": [{"message": "not found"}]}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_http
+
+        result = await client.resolve_review_thread("PRT_bad")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_http_exception_returns_false(client):
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(side_effect=Exception("network error"))
+        mock_client_cls.return_value = mock_http
+
+        result = await client.resolve_review_thread("PRT_x")
+
+    assert result is False
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_api_client_resolve.py -v
+```
+
+Expected: `AttributeError: 'GitHubAPIClient' object has no attribute 'resolve_review_thread'`
+
+- [ ] **Step 3: Implement `resolve_review_thread`**
+
+In `baloo/github/api_client.py`, add after the `reply_to_review_comment` method (around line 570):
+
+```python
+    async def resolve_review_thread(self, thread_node_id: str) -> bool:
+        """Resolve a pull request review thread via GraphQL mutation.
+
+        Args:
+            thread_node_id: The GraphQL node ID of the thread (PullRequestReviewThread.id).
+
+        Returns:
+            True on success, False on any error (fail-open — a failed resolve is not fatal).
+        """
+        mutation = """
+        mutation($threadId: ID!) {
+          resolveReviewThread(input: {threadId: $threadId}) {
+            thread { id isResolved }
+          }
+        }
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "https://api.github.com/graphql",
+                    headers=self._get_headers(),
+                    json={"query": mutation, "variables": {"threadId": thread_node_id}},
+                )
+                response.raise_for_status()
+                body = response.json()
+                if "errors" in body:
+                    logger.warning(
+                        "GraphQL error resolving thread %s: %s",
+                        thread_node_id,
+                        body["errors"],
+                    )
+                    return False
+                return True
+        except Exception as exc:
+            logger.warning("Failed to resolve thread %s: %s", thread_node_id, exc)
+            return False
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_api_client_resolve.py -v
+```
+
+Expected: all 3 pass.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add baloo/github/api_client.py tests/github/test_api_client_resolve.py
+git commit -m "feat: add resolve_review_thread GraphQL mutation"
+```
+
+---
+
+## Task 3: `_comment_from_thread` helper
+
+**Files:**
+- Modify: `baloo/github/webhook_handler.py`
+- Test: `tests/github/test_webhook_handler.py` (add to existing file)
+
+### Background
+
+The FP verifier operates on `ReviewComment` objects. Awaiting threads need to be reconstructed into `ReviewComment` to be passed through. The Baloo comment format is:
+
+```
+**[HIGH] Security** - **Title**
+**Category:** Security
+**Severity:** HIGH
+
+Body...
+```
+
+We parse severity from the `[SEVERITY]` bracket and category from the word immediately after it.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/github/test_webhook_handler.py` (or create a new `tests/github/test_comment_from_thread.py` if the existing file is very large — check first), add:
+
+```python
+from datetime import datetime, timezone
+from baloo.github.models import DiscussionComment, DiscussionThread
+from baloo.github.webhook_handler import _comment_from_thread
+from baloo.github.models import ReviewSeverity, FindingCategory
+
+
+def _make_thread(body: str, path: str = "app.py", line: int = 42) -> DiscussionThread:
+    comment = DiscussionComment(
+        id=1,
+        author="baloo-code-reviewer[bot]",
+        body=body,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        source="review_comment",
+        is_baloo=True,
+        path=path,
+        line=line,
+    )
+    return DiscussionThread(
+        id=100,
+        path=path,
+        line=line,
+        comments=[comment],
+        is_baloo_thread=True,
+        awaiting_response=True,
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=1,
+        node_id="PRT_kwDOBQ",
+    )
+
+
+def test_comment_from_thread_extracts_path_and_line():
+    thread = _make_thread("**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad stuff")
+    comment = _comment_from_thread(thread)
+    assert comment.path == "app.py"
+    assert comment.line == 42
+
+
+def test_comment_from_thread_extracts_severity_high():
+    thread = _make_thread("**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nBody")
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.HIGH
+
+
+def test_comment_from_thread_extracts_severity_critical():
+    thread = _make_thread("**[CRITICAL] Bugs** - **Title**\n**Category:** Bugs\n**Severity:** CRITICAL\n\nBody")
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.CRITICAL
+
+
+def test_comment_from_thread_extracts_category_security():
+    thread = _make_thread("**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nBody")
+    comment = _comment_from_thread(thread)
+    assert comment.category == FindingCategory.SECURITY
+
+
+def test_comment_from_thread_defaults_on_unparseable_body():
+    thread = _make_thread("Some freeform text with no severity markers")
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.MEDIUM
+    assert comment.category == FindingCategory.QUALITY
+
+
+def test_comment_from_thread_preserves_full_body():
+    body = "**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nDetailed finding text."
+    thread = _make_thread(body)
+    comment = _comment_from_thread(thread)
+    assert comment.body == body
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_comment_from_thread" -v
+```
+
+Expected: `ImportError` — `_comment_from_thread` not defined yet.
+
+- [ ] **Step 3: Implement `_comment_from_thread`**
+
+In `baloo/github/webhook_handler.py`, add near the other private helpers (after `_extract_issue_signature`, around line 350):
+
+```python
+import re as _re
+
+_SEVERITY_RE = _re.compile(r"\*\*\[(\w+)\]\s+\w+\*\*")
+_CATEGORY_RE = _re.compile(r"\*\*\[(?:\w+)\]\s+(\w[\w ]*?)\*\*")
+
+_CATEGORY_MAP: dict[str, FindingCategory] = {
+    "security": FindingCategory.SECURITY,
+    "bugs": FindingCategory.BUGS,
+    "silent failures": FindingCategory.SILENT_FAILURES,
+    "guidelines": FindingCategory.GUIDELINES,
+    "performance": FindingCategory.PERFORMANCE,
+    "quality": FindingCategory.QUALITY,
+}
+
+
+def _comment_from_thread(thread: DiscussionThread) -> ReviewComment:
+    """Reconstruct a ReviewComment from a Baloo DiscussionThread for re-verification.
+
+    Parses severity and category from the root comment body. Falls back to
+    MEDIUM/QUALITY if the body doesn't match the expected format.
+    """
+    body = thread.comments[0].body if thread.comments else ""
+
+    severity = ReviewSeverity.MEDIUM
+    m = _SEVERITY_RE.search(body)
+    if m:
+        try:
+            severity = ReviewSeverity(m.group(1).upper())
+        except ValueError:
+            pass
+
+    category = FindingCategory.QUALITY
+    m2 = _CATEGORY_RE.search(body)
+    if m2:
+        category = _CATEGORY_MAP.get(m2.group(1).lower().strip(), FindingCategory.QUALITY)
+
+    return ReviewComment(
+        path=thread.path or "",
+        line=thread.line or 0,
+        body=body,
+        severity=severity,
+        category=category,
+    )
+```
+
+Also add `FindingCategory` to the imports from `baloo.github.models` at the top of `webhook_handler.py` if not already present.
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_comment_from_thread" -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add baloo/github/webhook_handler.py tests/github/test_webhook_handler.py
+git commit -m "feat: add _comment_from_thread helper for thread re-verification"
+```
+
+---
+
+## Task 4: Thread re-verification pass and resolution actions
+
+**Files:**
+- Modify: `baloo/github/webhook_handler.py`
+- Test: `tests/github/test_webhook_handler.py`
+
+### Background
+
+After the thread-matching loop, we collect awaiting threads that the review agent didn't re-file. We run these through `FPVerifier.verify()` concurrently with the new-findings pass. For each `fp` verdict we: (1) reply to the thread, (2) call `resolve_review_thread`, (3) subtract from the awaiting count.
+
+The key change to the pipeline in `webhook_handler.py` is in the `_run_pr_review` function (or equivalent), around line 958 where `decision_comments` is assigned. The re-verification pass runs in parallel with the FP pass for new findings using `asyncio.gather`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/github/test_webhook_handler.py`:
+
+```python
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+
+import pytest
+
+from baloo.github.models import (
+    DiscussionComment,
+    DiscussionThread,
+    FileChange,
+    PRContext,
+    PRDiscussionContext,
+    PRMetadata,
+    ReviewComment,
+    ReviewSeverity,
+    FindingCategory,
+)
+from baloo.processor.fp_verifier import FPVerificationResult, FPRejection, FPStats
+
+
+def _make_awaiting_thread(root_comment_id: int = 1, node_id: str = "PRT_x") -> DiscussionThread:
+    comment = DiscussionComment(
+        id=root_comment_id,
+        author="baloo-code-reviewer[bot]",
+        body="**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad query.",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        source="review_comment",
+        is_baloo=True,
+        path="app.py",
+        line=10,
+    )
+    return DiscussionThread(
+        id=root_comment_id,
+        path="app.py",
+        line=10,
+        comments=[comment],
+        is_baloo_thread=True,
+        awaiting_response=True,
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=root_comment_id,
+        node_id=node_id,
+    )
+
+
+def _make_pr_context(awaiting_threads: list[DiscussionThread] | None = None) -> PRContext:
+    return PRContext(
+        metadata=PRMetadata(
+            repo_full_name="org/repo",
+            pr_number=1,
+            title="Fix stuff",
+            description=None,
+            author="dev",
+            base_branch="main",
+            head_branch="fix/it",
+            head_sha="abc123",
+            files_changed=[FileChange(filename="app.py", status="modified", additions=1, deletions=1, changes=2)],
+        ),
+        discussion=PRDiscussionContext(
+            threads=awaiting_threads or [],
+            awaiting_response_count=len(awaiting_threads) if awaiting_threads else 0,
+        ),
+        diff="diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -10,1 +10,1 @@\n-bad\n+good\n",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_fp_verdict_triggers_reply_and_resolve():
+    """An fp verdict on an awaiting thread causes reply + resolve."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread()
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    fp_result = FPVerificationResult(
+        verified=[],
+        rejected=[FPRejection(
+            comment=ReviewComment(path="app.py", line=10, body="body", severity=ReviewSeverity.HIGH, category=FindingCategory.SECURITY),
+            reason="code was fixed",
+            model="claude-haiku",
+        )],
+        stats=FPStats(),
+    )
+
+    mock_api = AsyncMock()
+    mock_api.reply_to_review_comment = AsyncMock(return_value=True)
+    mock_api.resolve_review_thread = AsyncMock(return_value=True)
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as MockVerifier:
+        mock_verifier_instance = AsyncMock()
+        mock_verifier_instance.verify = AsyncMock(return_value=fp_result)
+        MockVerifier.return_value = mock_verifier_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    assert resolved_count == 1
+    mock_api.reply_to_review_comment.assert_called_once_with(
+        "org/repo",
+        1,  # root_comment_id
+        "Looks like this was addressed in the latest commit. Resolving.",
+    )
+    mock_api.resolve_review_thread.assert_called_once_with("PRT_x")
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_real_verdict_no_action():
+    """A real verdict leaves the thread untouched."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread()
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    fp_result = FPVerificationResult(
+        verified=[ReviewComment(path="app.py", line=10, body="body", severity=ReviewSeverity.HIGH, category=FindingCategory.SECURITY)],
+        rejected=[],
+        stats=FPStats(),
+    )
+
+    mock_api = AsyncMock()
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as MockVerifier:
+        mock_verifier_instance = AsyncMock()
+        mock_verifier_instance.verify = AsyncMock(return_value=fp_result)
+        MockVerifier.return_value = mock_verifier_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    assert resolved_count == 0
+    mock_api.reply_to_review_comment.assert_not_called()
+    mock_api.resolve_review_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_skips_threads_without_node_id():
+    """Threads with no node_id are excluded from re-verification."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread(node_id=None)
+    thread.node_id = None
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    mock_api = AsyncMock()
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as MockVerifier:
+        mock_verifier_instance = AsyncMock()
+        mock_verifier_instance.verify = AsyncMock(return_value=FPVerificationResult())
+        MockVerifier.return_value = mock_verifier_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    # Verifier called with empty list (thread filtered out)
+    call_args = mock_verifier_instance.verify.call_args[0][0]
+    assert call_args == []
+    assert resolved_count == 0
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_empty_list_returns_zero():
+    """No awaiting threads → no verifier call, returns 0."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    pr_context = _make_pr_context()
+    mock_api = AsyncMock()
+
+    resolved_count = await _reverify_awaiting_threads(
+        awaiting_threads=[],
+        pr_context=pr_context,
+        api_client=mock_api,
+    )
+
+    assert resolved_count == 0
+    mock_api.reply_to_review_comment.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_reverify_threads" -v
+```
+
+Expected: `ImportError` — `_reverify_awaiting_threads` not defined.
+
+- [ ] **Step 3: Implement `_reverify_awaiting_threads`**
+
+In `baloo/github/webhook_handler.py`, add after `_comment_from_thread` (same area, around line 370):
+
+```python
+async def _reverify_awaiting_threads(
+    awaiting_threads: list[DiscussionThread],
+    pr_context: PRContext,
+    api_client,
+) -> int:
+    """Re-verify awaiting Baloo threads against the new diff.
+
+    For each thread where the LLM says the issue is no longer present (fp verdict),
+    post a resolution reply and resolve the GitHub thread.
+
+    Returns:
+        Number of threads resolved.
+    """
+    if not awaiting_threads:
+        return 0
+
+    # Only re-verify threads that have a node_id (needed to resolve)
+    eligible = [t for t in awaiting_threads if t.node_id]
+
+    if not eligible:
+        logger.info("No awaiting threads with node_id — skipping re-verification")
+        return 0
+
+    # Reconstruct ReviewComment objects from thread root comments
+    comments = [_comment_from_thread(t) for t in eligible]
+
+    verifier = FPVerifier()
+    fp_result = await verifier.verify(comments, pr_context)
+
+    # fp_result.rejected = findings the verifier says are no longer present
+    resolved_count = 0
+    rejected_paths_lines = {(r.comment.path, r.comment.line) for r in fp_result.rejected}
+
+    for thread in eligible:
+        if (thread.path, thread.line) not in rejected_paths_lines:
+            continue
+
+        logger.info(
+            "Thread re-verified as fixed: %s:%s (thread node %s)",
+            thread.path,
+            thread.line,
+            thread.node_id,
+        )
+
+        repo = pr_context.repo_full_name
+        pr_number = pr_context.pr_number
+
+        # Reply first (best-effort), then resolve
+        if thread.root_comment_id is not None:
+            await api_client.reply_to_review_comment(
+                repo,
+                thread.root_comment_id,
+                "Looks like this was addressed in the latest commit. Resolving.",
+            )
+
+        await api_client.resolve_review_thread(thread.node_id)
+        resolved_count += 1
+
+    return resolved_count
+```
+
+Add `FPVerifier` to the imports at the top of `webhook_handler.py`:
+
+```python
+from baloo.processor.fp_verifier import FPVerifier
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_reverify_threads" -v
+```
+
+Expected: all 4 pass.
+
+- [ ] **Step 5: Wire `_reverify_awaiting_threads` into the review pipeline**
+
+In `webhook_handler.py`, find the section after the thread-matching loop where `decision_comments` is assigned (around line 958). The awaiting threads that were NOT re-filed are the ones counted as `skipped_duplicates`. We need to collect them.
+
+In the thread-matching loop (around line 948–950), change from:
+
+```python
+                if thread.awaiting_response:
+                    skipped_duplicates += 1
+                    continue
+```
+
+To:
+
+```python
+                if thread.awaiting_response:
+                    skipped_duplicates += 1
+                    awaiting_not_refiled.append(thread)
+                    continue
+```
+
+And add `awaiting_not_refiled: list[DiscussionThread] = []` in the initialisation block near `skipped_duplicates = 0` (around line 897).
+
+After `decision_comments = fresh_comments + [...]` (around line 958), add the concurrent re-verification:
+
+```python
+            # Run FP verifier on new findings and re-verification of awaiting threads concurrently
+            fp_verifier_task = asyncio.ensure_future(
+                fp_verifier.verify(decision_comments, pr_context)
+            ) if decision_comments else None
+
+            reverify_task = asyncio.ensure_future(
+                _reverify_awaiting_threads(
+                    awaiting_not_refiled, pr_context, github_client
+                )
+            )
+
+            if fp_verifier_task:
+                fp_result = await fp_verifier_task
+                decision_comments = fp_result.verified
+            auto_resolved_count = await reverify_task
+```
+
+> **Note:** In the current codebase, the FP verifier pass for new findings is called earlier in the function (before the thread-matching loop) as `fp_result = await fp_verifier.verify(review_result.comments, pr_context)`. Do NOT move that call. Instead, after the thread-matching loop, call `_reverify_awaiting_threads` as a plain `await` (no concurrent wrapper needed since the new-findings FP pass already completed). The `asyncio.ensure_future` pattern shown above is only needed if you restructure to run them truly concurrently — acceptable either way.
+
+Adjust the awaiting count used in the decision block. Find:
+
+```python
+            awaiting_threads = pr_context.awaiting_response_threads
+```
+
+Change to:
+
+```python
+            awaiting_threads = pr_context.awaiting_response_threads - auto_resolved_count
+```
+
+Update the summary text for resolved threads. Find where `awaiting_threads` is mentioned in the summary (around line 996):
+
+```python
+            if awaiting_threads:
+                summary_text += (
+                    f"\n\n⏳ {awaiting_threads} Baloo thread(s) remain open from earlier reviews."
+                )
+```
+
+Add before it:
+
+```python
+            if auto_resolved_count:
+                summary_text += (
+                    f"\n\n✅ Auto-resolved {auto_resolved_count} previously flagged thread(s) "
+                    "that look fixed in this commit."
+                )
+```
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add baloo/github/webhook_handler.py tests/github/test_webhook_handler.py
+git commit -m "feat: auto-resolve fixed Baloo threads via FP re-verification"
+```
+
+---
+
+## Task 5: End-to-end smoke test and PR
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run full test suite with coverage**
+
+```bash
+uv run pytest tests/ -q --tb=short
+```
+
+Expected: all pass, no regressions.
+
+- [ ] **Step 2: Lint**
+
+```bash
+uv run ruff check baloo tests
+```
+
+Fix any issues found.
+
+- [ ] **Step 3: Format**
+
+```bash
+uv run black baloo tests
+```
+
+Commit any formatting changes.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat: auto-resolve fixed Baloo threads via LLM re-verification" \
+  --body "..."
+```
+
+PR description should explain: what was observed (PR #30 stuck in changes_requested with 0 new findings), what was built, how it works, test coverage.

--- a/docs/superpowers/specs/2026-05-04-thread-auto-resolution-design.md
+++ b/docs/superpowers/specs/2026-05-04-thread-auto-resolution-design.md
@@ -1,0 +1,130 @@
+# Thread Auto-Resolution Design
+
+**Date:** 2026-05-04
+**Status:** Approved
+
+## Problem
+
+When Baloo flags an issue on a PR and the developer fixes it in a follow-up commit, Baloo silently stops re-filing the finding but never acknowledges the fix. The GitHub thread stays open, `awaiting_response=True`, and the decision engine keeps setting `request_changes=True` even when the latest review finds zero new issues. The PR is stuck.
+
+Observed on PR #30: 4 reviews, 3 findings fixed across 3 commits, final review found 0 issues — yet the PR was still marked `changes_requested` and all 3 threads left unresolved at merge.
+
+The `finding_outcomes` signals confirm this: `code_changed_near_line=true`, `thread_resolved=false` on all findings.
+
+## Out of scope (deferred)
+
+Human responses on Baloo threads (developer replies to a finding) — will be designed after gathering real examples of how developers actually respond.
+
+## Design
+
+### 1. Data model: `DiscussionThread.node_id`
+
+Add one field to `DiscussionThread`:
+
+```python
+node_id: str | None = None  # GraphQL thread node ID for resolveReviewThread mutation
+```
+
+This is the GraphQL `id` on the `PullRequestReviewThread` node, distinct from the REST `databaseId` used today.
+
+### 2. GraphQL query update
+
+`fetch_resolved_thread_ids` in `api_client.py` adds `id` to the thread nodes:
+
+```graphql
+nodes {
+  id          # NEW — thread node ID for mutation
+  isResolved
+  isOutdated
+  comments(first: 1) {
+    nodes { databaseId }
+  }
+}
+```
+
+`_apply_resolved_thread_state` is extended to write `node_id` onto each matched thread alongside the existing `resolved`/`outdated` flags.
+
+### 3. New API method: `resolve_review_thread`
+
+```python
+async def resolve_review_thread(self, thread_node_id: str) -> bool
+```
+
+Calls the GraphQL mutation:
+
+```graphql
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}
+```
+
+Returns `True` on success. On error: logs a warning and returns `False` — a failed resolve is not fatal, the reply comment was already posted.
+
+### 4. Re-verification pass
+
+After the existing thread-matching loop in `webhook_handler.py`, collect threads eligible for re-verification:
+
+- `is_baloo_thread=True`
+- `awaiting_response=True`
+- Not matched to any new finding (i.e., the review agent did not re-file this finding)
+- `node_id` is set (needed to resolve)
+- Not already `resolved` or `outdated`
+
+Reconstruct a `ReviewComment` from each thread's root comment (`body`, `path`, `line`, `severity`, `category`). Pass the batch to `FPVerifier.verify()` — the existing verifier, same Haiku model, same prompt, but with the new diff as context.
+
+`fp` verdict = issue no longer present in current code = fixed.
+`real` verdict = issue still present = leave thread open.
+
+The re-verification batch runs **concurrently** with the new-findings FP verifier pass (they are independent).
+
+### 5. Actions on `fp` verdict
+
+For each thread where re-verification returns `fp`:
+
+1. `reply_to_review_comment(root_comment_id, "Looks like this was addressed in the latest commit. Resolving.")`
+2. `resolve_review_thread(node_id)`
+3. Update `finding_outcomes` row for this finding: set `thread_resolved=True` in signals (if row exists)
+4. Remove thread from the `awaiting_response` count fed to the decision engine
+
+Step 4 prevents the `if awaiting_threads and not request_changes and not decision_comments: request_changes = True` block from firing when all previously open threads are now resolved.
+
+### 6. Pipeline position
+
+```
+review agent runs
+        |
+thread matching (existing)
+  fresh / duplicate / resolved / responded / outdated
+        |
+        +---> FP verifier: new findings     (existing, concurrent)
+        |
+        +---> FP verifier: awaiting threads (new, concurrent)
+                    |
+                  fp -> reply + resolve + update outcome
+                  real -> leave open
+        |
+post new findings
+resolve fixed threads
+        |
+decision engine
+```
+
+## Edge cases
+
+**Thread has no `node_id`** (GraphQL fetch failed): skip re-verification for that thread. Logged as a warning. PR behaviour unchanged from today.
+
+**`reply_to_review_comment` returns `False`** (thread outdated/404): still attempt `resolve_review_thread`. If that also fails, log and move on — don't block the review.
+
+**Re-verification returns `real` but developer already fixed it** (false negative from verifier): thread stays open. Harmless — developer can manually resolve, or next push will re-verify.
+
+**New finding matches the same location as an awaiting thread**: existing dedup logic handles this (`skipped_duplicates`). Thread is not eligible for re-verification.
+
+## Testing
+
+- Unit: `test_resolve_review_thread` — mock GraphQL mutation, verify correct node ID sent
+- Unit: `test_thread_reverification_fp_verdict` — mock FPVerifier returning fp, assert reply + resolve called
+- Unit: `test_thread_reverification_real_verdict` — assert no reply/resolve called
+- Unit: `test_awaiting_count_excludes_resolved_threads` — verify decision engine sees 0 awaiting after resolution
+- Integration: reconstruct `ReviewComment` from a `DiscussionThread` root comment — verify fields round-trip correctly

--- a/tests/github/test_api_client_resolve.py
+++ b/tests/github/test_api_client_resolve.py
@@ -1,0 +1,86 @@
+"""Tests for resolve_review_thread GraphQL mutation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from baloo.github.api_client import GitHubAPIClient
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_success():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "data": {"resolveReviewThread": {"thread": {"id": "PRT_x", "isResolved": True}}}
+    }
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_cls,
+        patch(
+            "baloo.github.auth.GitHubAuth.get_installation_token",
+            return_value="tok",
+        ),
+    ):
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_http
+
+        client = GitHubAPIClient(installation_id=1)
+        result = await client.resolve_review_thread("PRT_x")
+
+    assert result is True
+    call_kwargs = mock_http.post.call_args
+    body = call_kwargs[1]["json"]
+    assert "resolveReviewThread" in body["query"]
+    assert body["variables"]["threadId"] == "PRT_x"
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_graphql_error_returns_false():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"errors": [{"message": "not found"}]}
+
+    with (
+        patch("httpx.AsyncClient") as mock_client_cls,
+        patch(
+            "baloo.github.auth.GitHubAuth.get_installation_token",
+            return_value="tok",
+        ),
+    ):
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_http
+
+        client = GitHubAPIClient(installation_id=1)
+        result = await client.resolve_review_thread("PRT_bad")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_http_exception_returns_false():
+    with (
+        patch("httpx.AsyncClient") as mock_client_cls,
+        patch(
+            "baloo.github.auth.GitHubAuth.get_installation_token",
+            return_value="tok",
+        ),
+    ):
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(side_effect=Exception("network error"))
+        mock_client_cls.return_value = mock_http
+
+        client = GitHubAPIClient(installation_id=1)
+        result = await client.resolve_review_thread("PRT_x")
+
+    assert result is False

--- a/tests/github/test_comment_from_thread.py
+++ b/tests/github/test_comment_from_thread.py
@@ -1,0 +1,83 @@
+"""Tests for _comment_from_thread helper."""
+
+from datetime import datetime, timezone
+
+from baloo.github.models import (
+    DiscussionComment,
+    DiscussionThread,
+    FindingCategory,
+    ReviewSeverity,
+)
+from baloo.github.webhook_handler import _comment_from_thread
+
+
+def _make_thread(body: str, path: str = "app.py", line: int = 42) -> DiscussionThread:
+    comment = DiscussionComment(
+        id=1,
+        author="baloo-code-reviewer[bot]",
+        body=body,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        source="review_comment",
+        is_baloo=True,
+        path=path,
+        line=line,
+    )
+    return DiscussionThread(
+        id=100,
+        path=path,
+        line=line,
+        comments=[comment],
+        is_baloo_thread=True,
+        awaiting_response=True,
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=1,
+        node_id="PRT_kwDOBQ",
+    )
+
+
+def test_comment_from_thread_extracts_path_and_line():
+    thread = _make_thread(
+        "**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad stuff"
+    )
+    comment = _comment_from_thread(thread)
+    assert comment.path == "app.py"
+    assert comment.line == 42
+
+
+def test_comment_from_thread_extracts_severity_high():
+    thread = _make_thread(
+        "**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nBody"
+    )
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.HIGH
+
+
+def test_comment_from_thread_extracts_severity_critical():
+    thread = _make_thread(
+        "**[CRITICAL] Bugs** - **Title**\n**Category:** Bugs\n**Severity:** CRITICAL\n\nBody"
+    )
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.CRITICAL
+
+
+def test_comment_from_thread_extracts_category_security():
+    thread = _make_thread(
+        "**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nBody"
+    )
+    comment = _comment_from_thread(thread)
+    assert comment.category == FindingCategory.SECURITY
+
+
+def test_comment_from_thread_defaults_on_unparseable_body():
+    thread = _make_thread("Some freeform text with no severity markers")
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.MEDIUM
+    assert comment.category == FindingCategory.QUALITY
+
+
+def test_comment_from_thread_preserves_full_body():
+    body = "**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nDetailed finding text."
+    thread = _make_thread(body)
+    comment = _comment_from_thread(thread)
+    assert comment.body == body

--- a/tests/github/test_discussions.py
+++ b/tests/github/test_discussions.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 
+from baloo.github.api_client import _apply_resolved_thread_state
 from baloo.github.discussions import (
     build_discussion_comment,
     build_discussion_digest,
@@ -150,6 +151,73 @@ def test_developer_reply_not_resolved_not_awaiting():
     # Not resolved — developer responded but didn't use resolution keywords.
     # The webhook handler skips these threads (not re-reviewed).
     assert thread.resolved is False
+
+
+def test_discussion_thread_has_node_id_field():
+    thread = DiscussionThread(
+        id=1,
+        path="foo.py",
+        line=10,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+    )
+    assert thread.node_id is None
+
+
+def test_discussion_thread_node_id_can_be_set():
+    thread = DiscussionThread(
+        id=1,
+        path="foo.py",
+        line=10,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+        node_id="PRT_kwDOBQ",
+    )
+    assert thread.node_id == "PRT_kwDOBQ"
+
+
+def _make_thread_for_state_test(root_comment_id: int) -> DiscussionThread:
+    return DiscussionThread(
+        id=root_comment_id,
+        path="foo.py",
+        line=1,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=root_comment_id,
+    )
+
+
+def test_apply_resolved_thread_state_writes_node_id():
+    thread = _make_thread_for_state_test(root_comment_id=42)
+    node_id_map = {42: "PRT_kwDOBQ"}
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids=set(),
+        outdated_ids=None,
+        thread_node_ids=node_id_map,
+    )
+    assert thread.node_id == "PRT_kwDOBQ"
+
+
+def test_apply_resolved_thread_state_node_id_missing_from_map():
+    thread = _make_thread_for_state_test(root_comment_id=99)
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids=set(),
+        thread_node_ids={},
+    )
+    assert thread.node_id is None
+
+
+def test_apply_resolved_thread_state_existing_behaviour_preserved():
+    thread = _make_thread_for_state_test(root_comment_id=7)
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids={7},
+        thread_node_ids={7: "PRT_abc"},
+    )
+    assert thread.resolved is True
+    assert thread.node_id == "PRT_abc"
 
 
 def test_build_general_discussion_includes_reviews():

--- a/tests/github/test_resolved_threads.py
+++ b/tests/github/test_resolved_threads.py
@@ -34,6 +34,7 @@ def _graphql_response(nodes: list[dict], has_next: bool = False, cursor: str = "
 
 def _thread_node(comment_db_id: int, is_resolved: bool, is_outdated: bool = False) -> dict:
     return {
+        "id": f"PRT_node_{comment_db_id}",
         "isResolved": is_resolved,
         "isOutdated": is_outdated,
         "comments": {"nodes": [{"databaseId": comment_db_id}]},
@@ -77,9 +78,10 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 42)
 
-        resolved_ids, outdated_ids, _ = ids
+        resolved_ids, outdated_ids, node_id_map = ids
         assert resolved_ids == {100, 300}
         assert outdated_ids == set()
+        assert node_id_map == {100: "PRT_node_100", 200: "PRT_node_200", 300: "PRT_node_300"}
 
     @pytest.mark.asyncio
     async def test_paginates(self):
@@ -177,7 +179,10 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == (set(), set(), {})
+        resolved_ids, outdated_ids, node_id_map = ids
+        assert resolved_ids == set()
+        assert outdated_ids == set()
+        assert node_id_map == {100: "PRT_node_100", 200: "PRT_node_200"}
 
     @pytest.mark.asyncio
     async def test_separates_outdated_from_resolved(self):

--- a/tests/github/test_resolved_threads.py
+++ b/tests/github/test_resolved_threads.py
@@ -77,7 +77,7 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 42)
 
-        resolved_ids, outdated_ids = ids
+        resolved_ids, outdated_ids, _ = ids
         assert resolved_ids == {100, 300}
         assert outdated_ids == set()
 
@@ -103,7 +103,7 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        resolved_ids, outdated_ids = ids
+        resolved_ids, outdated_ids, _ = ids
         assert resolved_ids == {10, 20}
         assert outdated_ids == set()
         assert call_count == 2
@@ -122,7 +122,7 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == (set(), set())
+        assert ids == (set(), set(), {})
 
     @pytest.mark.asyncio
     async def test_returns_empty_on_http_error(self):
@@ -140,7 +140,7 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == (set(), set())
+        assert ids == (set(), set(), {})
 
     @pytest.mark.asyncio
     async def test_logs_exception_type_when_resolved_thread_fetch_fails(self, caplog):
@@ -155,7 +155,7 @@ class TestFetchResolvedThreadIds:
             with caplog.at_level("WARNING", logger="baloo.github.api_client"):
                 ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == (set(), set())
+        assert ids == (set(), set(), {})
         assert "TimeoutException" in caplog.text
 
     @pytest.mark.asyncio
@@ -177,7 +177,7 @@ class TestFetchResolvedThreadIds:
             client = GitHubAPIClient(installation_id=1)
             ids = await client.fetch_resolved_thread_ids("owner/repo", 1)
 
-        assert ids == (set(), set())
+        assert ids == (set(), set(), {})
 
     @pytest.mark.asyncio
     async def test_separates_outdated_from_resolved(self):
@@ -197,7 +197,7 @@ class TestFetchResolvedThreadIds:
             mock_client_cls.return_value = mock_client
 
             client = GitHubAPIClient(installation_id=1)
-            resolved_ids, outdated_ids = await client.fetch_resolved_thread_ids("owner/repo", 42)
+            resolved_ids, outdated_ids, _ = await client.fetch_resolved_thread_ids("owner/repo", 42)
 
         assert resolved_ids == {100}
         assert outdated_ids == {200}

--- a/tests/github/test_reverify_threads.py
+++ b/tests/github/test_reverify_threads.py
@@ -204,3 +204,59 @@ async def test_reverify_empty_list_no_verifier_call():
 
     mock_verifier_cls.assert_not_called()
     assert resolved_count == 0
+
+
+@pytest.mark.asyncio
+async def test_awaiting_count_excludes_resolved_threads():
+    """Decision engine sees 0 awaiting after all threads are auto-resolved."""
+    # This test verifies the integration: that auto_resolved_count returned from
+    # _reverify_awaiting_threads correctly reduces the awaiting_threads count
+    # fed to the decision engine, preventing spurious request_changes=True.
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread(root_comment_id=99, node_id="PRT_awaiting")
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    fake_rejected = ReviewComment(
+        path="app.py",
+        line=10,
+        body="**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad query.",
+        severity=ReviewSeverity.HIGH,
+        category=FindingCategory.SECURITY,
+    )
+    fp_result = FPVerificationResult(
+        verified=[],
+        rejected=[
+            FPRejection(
+                comment=fake_rejected,
+                reason="issue addressed in latest commit",
+                model="haiku",
+                cost_usd=0.001,
+            )
+        ],
+        stats=FPStats(),
+    )
+
+    mock_api = AsyncMock()
+    mock_api.reply_to_review_comment = AsyncMock(return_value=True)
+    mock_api.resolve_review_thread = AsyncMock(return_value=True)
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as mock_verifier_cls:
+        mock_instance = AsyncMock()
+        mock_instance.verify = AsyncMock(return_value=fp_result)
+        mock_verifier_cls.return_value = mock_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    assert resolved_count == 1
+
+    # Simulate the decision engine logic: awaiting_threads - auto_resolved_count
+    awaiting_threads = pr_context.awaiting_response_threads
+    remaining = awaiting_threads - resolved_count
+    assert (
+        remaining == 0
+    ), f"Expected 0 remaining awaiting threads after auto-resolution, got {remaining}"

--- a/tests/github/test_reverify_threads.py
+++ b/tests/github/test_reverify_threads.py
@@ -181,9 +181,8 @@ async def test_reverify_skips_threads_without_node_id():
             api_client=mock_api,
         )
 
-    # Called with empty list (no eligible threads)
-    verify_call_comments = mock_instance.verify.call_args[0][0]
-    assert verify_call_comments == []
+    # Early return: verifier is never called when no eligible threads
+    mock_instance.verify.assert_not_called()
     assert resolved_count == 0
 
 

--- a/tests/github/test_reverify_threads.py
+++ b/tests/github/test_reverify_threads.py
@@ -1,0 +1,206 @@
+"""Tests for _reverify_awaiting_threads."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from baloo.github.models import (
+    DiscussionComment,
+    DiscussionThread,
+    FileChange,
+    FindingCategory,
+    PRContext,
+    PRDiscussionContext,
+    PRMetadata,
+    ReviewComment,
+    ReviewSeverity,
+)
+from baloo.processor.fp_verifier import FPRejection, FPStats, FPVerificationResult
+
+
+def _make_awaiting_thread(root_comment_id: int = 1, node_id: str = "PRT_x") -> DiscussionThread:
+    comment = DiscussionComment(
+        id=root_comment_id,
+        author="baloo-code-reviewer[bot]",
+        body="**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad query.",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        source="review_comment",
+        is_baloo=True,
+        path="app.py",
+        line=10,
+    )
+    return DiscussionThread(
+        id=root_comment_id,
+        path="app.py",
+        line=10,
+        comments=[comment],
+        is_baloo_thread=True,
+        awaiting_response=True,
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=root_comment_id,
+        node_id=node_id,
+    )
+
+
+def _make_pr_context(awaiting_threads: list[DiscussionThread] | None = None) -> PRContext:
+    return PRContext(
+        metadata=PRMetadata(
+            repo_full_name="org/repo",
+            pr_number=1,
+            title="Fix stuff",
+            description=None,
+            author="dev",
+            base_branch="main",
+            head_branch="fix/it",
+            head_sha="abc123",
+            files_changed=[
+                FileChange(
+                    filename="app.py",
+                    status="modified",
+                    additions=1,
+                    deletions=1,
+                    changes=2,
+                )
+            ],
+        ),
+        discussion=PRDiscussionContext(
+            threads=awaiting_threads or [],
+            awaiting_response_count=len(awaiting_threads) if awaiting_threads else 0,
+        ),
+        diff="diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -10,1 +10,1 @@\n-bad\n+good\n",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reverify_fp_verdict_triggers_reply_and_resolve():
+    """fp verdict → reply to thread + resolve."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread(root_comment_id=42, node_id="PRT_x")
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    fake_rejected = ReviewComment(
+        path="app.py",
+        line=10,
+        body="**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad query.",
+        severity=ReviewSeverity.HIGH,
+        category=FindingCategory.SECURITY,
+    )
+    fp_result = FPVerificationResult(
+        verified=[],
+        rejected=[
+            FPRejection(
+                comment=fake_rejected, reason="code was fixed", model="haiku", cost_usd=0.001
+            )
+        ],
+        stats=FPStats(),
+    )
+
+    mock_api = AsyncMock()
+    mock_api.reply_to_review_comment = AsyncMock(return_value=True)
+    mock_api.resolve_review_thread = AsyncMock(return_value=True)
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as mock_verifier_cls:
+        mock_instance = AsyncMock()
+        mock_instance.verify = AsyncMock(return_value=fp_result)
+        mock_verifier_cls.return_value = mock_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    assert resolved_count == 1
+    mock_api.reply_to_review_comment.assert_called_once_with(
+        "org/repo",
+        42,
+        "Looks like this was addressed in the latest commit. Resolving.",
+    )
+    mock_api.resolve_review_thread.assert_called_once_with("PRT_x")
+
+
+@pytest.mark.asyncio
+async def test_reverify_real_verdict_no_action():
+    """real verdict → thread untouched."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread()
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    kept_comment = ReviewComment(
+        path="app.py",
+        line=10,
+        body="body",
+        severity=ReviewSeverity.HIGH,
+        category=FindingCategory.SECURITY,
+    )
+    fp_result = FPVerificationResult(verified=[kept_comment], rejected=[], stats=FPStats())
+
+    mock_api = AsyncMock()
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as mock_verifier_cls:
+        mock_instance = AsyncMock()
+        mock_instance.verify = AsyncMock(return_value=fp_result)
+        mock_verifier_cls.return_value = mock_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    assert resolved_count == 0
+    mock_api.reply_to_review_comment.assert_not_called()
+    mock_api.resolve_review_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reverify_skips_threads_without_node_id():
+    """Threads missing node_id are excluded."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread(node_id=None)
+    thread.node_id = None
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    mock_api = AsyncMock()
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as mock_verifier_cls:
+        mock_instance = AsyncMock()
+        mock_instance.verify = AsyncMock(return_value=FPVerificationResult())
+        mock_verifier_cls.return_value = mock_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    # Called with empty list (no eligible threads)
+    verify_call_comments = mock_instance.verify.call_args[0][0]
+    assert verify_call_comments == []
+    assert resolved_count == 0
+
+
+@pytest.mark.asyncio
+async def test_reverify_empty_list_no_verifier_call():
+    """Empty awaiting_threads returns 0 immediately."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    pr_context = _make_pr_context()
+    mock_api = AsyncMock()
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as mock_verifier_cls:
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    mock_verifier_cls.assert_not_called()
+    assert resolved_count == 0

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -1353,4 +1353,5 @@ async def test_fidelity_and_agent_review_run_concurrently_when_fidelity_enabled(
 
     assert fidelity_analysis_called, "_run_fidelity_analysis was not called"
     mock_agent.review_pr.assert_awaited_once()
-    mock_gather.assert_called_once()
+    # gather is now called at least twice: once for fidelity+agent, once for both FP passes
+    mock_gather.assert_called()


### PR DESCRIPTION
## Summary

When Baloo flags an issue and the developer fixes it in a follow-up commit, Baloo now automatically detects the fix, posts a reply, and resolves the GitHub thread — unblocking the PR from a stuck `changes_requested` state.

Previously: after 3 commits fixing 3 Baloo findings, the PR remained `changes_requested` with all threads left open (observed on PR #30).

## What changed

- **`DiscussionThread.node_id`** — new field storing the GraphQL thread node ID needed for the resolve mutation
- **`fetch_resolved_thread_ids`** — extended to also return `node_id` map; `_apply_resolved_thread_state` writes it onto each thread
- **`resolve_review_thread`** — new GraphQL mutation method on `GitHubAPIClient`
- **`_comment_from_thread`** — reconstructs a `ReviewComment` from a thread's root comment (for re-verification)
- **`_reverify_awaiting_threads`** — runs `FPVerifier` on awaiting threads not matched by new findings; `fp` verdict → reply + resolve + update `finding_outcomes`
- Both FP verifier passes (new findings + awaiting threads) run **concurrently** via `asyncio.gather`
- `awaiting_threads` count fed to the decision engine is reduced by the auto-resolved count, preventing spurious `request_changes=True`

## Out of scope (deferred)

Human responses on Baloo threads (developer replies to a finding) — will be designed after gathering real examples.

## Test plan

- [x] `uv run pytest` — 470 tests, 0 failures
- [x] `uv run ruff check baloo tests` — clean
- [x] `uv run black --check baloo tests` — clean
- [x] New test files: `test_api_client_resolve.py`, `test_comment_from_thread.py`, `test_reverify_threads.py`
- [x] `test_reverify_fp_verdict_triggers_reply_and_resolve` — fp verdict calls reply + resolve
- [x] `test_reverify_real_verdict_no_action` — real verdict takes no action
- [x] `test_awaiting_count_excludes_resolved_threads` — decision engine sees 0 awaiting after resolution