### PR TITLE
fix: skip sync-with-base pushes reliably; always use full PR diff for fidelity

### DIFF
--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -585,15 +585,35 @@ class GitHubAPIClient:
             response.raise_for_status()
             return response.json()
 
+    async def _commit_is_ancestor_of_branch(
+        self, repo_full_name: str, commit_sha: str, branch: str
+    ) -> bool:
+        """Return True if commit_sha is an ancestor of (or identical to) branch HEAD.
+
+        Uses the GitHub compare API: compare/{commit}...{branch} returns
+        status "ahead" when branch is ahead of commit (commit is an ancestor)
+        or "identical" when they are the same commit.
+        """
+        async with httpx.AsyncClient() as client:
+            url = f"{self.base_url}/repos/{repo_full_name}/compare/{commit_sha}...{branch}"
+            response = await client.get(url, headers=self._get_headers())
+            if response.status_code != 200:
+                return False
+            return response.json().get("status") in ("ahead", "identical")
+
     async def is_merge_or_sync_commit(
         self, repo_full_name: str, commit_sha: str, base_branch: str
     ) -> tuple[bool, str]:
         """
         Check if a commit is a merge/sync commit that doesn't warrant a new review.
 
-        This detects:
-        1. Merge commits (2+ parents) with messages like "Merge branch 'dev' into feature"
-        2. Commits that only merge upstream changes without new PR-specific changes
+        A push is a sync-with-base when the HEAD commit is a merge commit (2+
+        parents) and one of those parents is an ancestor of the base branch —
+        meaning the developer merged the base branch into their feature branch.
+
+        Detection uses the GitHub compare API rather than commit message pattern
+        matching or file-count heuristics, so it works regardless of message
+        wording, author tooling, or how many files changed from upstream.
 
         Args:
             repo_full_name: Repository full name (owner/repo)
@@ -605,34 +625,23 @@ class GitHubAPIClient:
         """
         try:
             commit_info = await self.get_commit_info(repo_full_name, commit_sha)
-
             parents = commit_info.get("parents", [])
-            message = commit_info.get("commit", {}).get("message", "").lower()
-            files = commit_info.get("files", [])
 
-            # Check if it's a merge commit (2+ parents)
-            if len(parents) >= 2:
-                # Check for common merge patterns
-                merge_patterns = [
-                    f"merge branch '{base_branch}'",
-                    f'merge branch "{base_branch}"',
-                    f"merge {base_branch} into",
-                    "merge pull request",
-                    "merge remote-tracking branch",
-                ]
+            if len(parents) < 2:
+                return False, ""
 
-                for pattern in merge_patterns:
-                    if pattern in message:
-                        # If it's a pure merge with no file changes, definitely skip
-                        if not files:
-                            return True, "merge commit with no file changes"
-
-                        # If it only has a few conflict resolution files, likely just a sync
-                        if len(files) <= 3:
-                            return (
-                                True,
-                                f"merge commit with only {len(files)} file(s) (conflict resolution)",
-                            )
+            for parent in parents:
+                parent_sha = parent.get("sha", "")
+                if not parent_sha:
+                    continue
+                if await self._commit_is_ancestor_of_branch(
+                    repo_full_name, parent_sha, base_branch
+                ):
+                    return (
+                        True,
+                        f"merge commit syncing {base_branch} into feature branch "
+                        f"(parent {parent_sha[:7]} is an ancestor of {base_branch})",
+                    )
 
             return False, ""
 

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -598,6 +598,13 @@ class GitHubAPIClient:
             url = f"{self.base_url}/repos/{repo_full_name}/compare/{commit_sha}...{branch}"
             response = await client.get(url, headers=self._get_headers())
             if response.status_code != 200:
+                logger.warning(
+                    "compare API returned %d for %s...%s in %s; treating as non-ancestor",
+                    response.status_code,
+                    commit_sha,
+                    branch,
+                    repo_full_name,
+                )
                 return False
             return response.json().get("status") in ("ahead", "identical")
 
@@ -646,7 +653,12 @@ class GitHubAPIClient:
             return False, ""
 
         except Exception as e:
-            logger.warning(f"Failed to check commit info for {commit_sha}: {e}")
+            logger.warning(
+                "Failed to determine merge/sync status for %s in %s: %s",
+                commit_sha,
+                repo_full_name,
+                e,
+            )
             return False, ""
 
     async def get_file_content(

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -833,7 +833,7 @@ async def process_pr_review(
 
             if settings.fidelity_enabled:
                 (fidelity_report_text, fidelity_result), agent_result = await asyncio.gather(
-                    _run_fidelity_analysis(github_client, repo_full_name, review_context),
+                    _run_fidelity_analysis(github_client, repo_full_name, pr_context),
                     agent.review_pr(review_context, review_id=db_review_id),
                 )
             else:

--- a/docs/superpowers/plans/2026-05-04-outcomes-daily-accuracy.md
+++ b/docs/superpowers/plans/2026-05-04-outcomes-daily-accuracy.md
@@ -1,0 +1,173 @@
+# Outcomes Daily Accuracy Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the non-functional Weekly Trends line chart on the outcomes page with a daily Accuracy Over Time chart.
+
+**Architecture:** The weekly grouping query in `get_outcomes_data` is replaced with a daily one using `DATE(labeled_at)`, which is dialect-agnostic. The return key `trends` is unchanged; each entry's `week` field becomes `day`. The template swaps the chart title and x-axis label accessor.
+
+**Tech Stack:** Python/SQLAlchemy (backend), Jinja2 + Chart.js 4 (frontend), pytest (tests)
+
+**Worktree:** `.worktrees/fix/outcomes-daily-accuracy`
+
+---
+
+### Task 1: Update tests to reflect daily data shape
+
+**Files:**
+- Modify: `tests/dashboard/test_outcomes_page.py`
+
+- [ ] **Step 1: Update mock trends data and add title assertion**
+
+In `test_outcomes_page_renders`, change the `trends` entries from `week` keys to `day` keys, and add an assertion that the new chart title appears:
+
+```python
+"trends": [
+    {"day": "2026-04-27", "total": 168, "hit_rate": 83.3, "noise_rate": 16.7},
+    {"day": "2026-04-28", "total": 61,  "hit_rate": 77.0, "noise_rate": 23.0},
+],
+```
+
+And at the end of the test, add:
+
+```python
+assert "Accuracy Over Time" in response.text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd .worktrees/fix/outcomes-daily-accuracy
+uv run pytest tests/dashboard/test_outcomes_page.py -v
+```
+
+Expected: `test_outcomes_page_renders` FAILS — `"Accuracy Over Time"` not in response (template still says "Weekly Trends").
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/dashboard/test_outcomes_page.py
+git commit -m "test: update outcomes mock data to use daily trends shape"
+```
+
+---
+
+### Task 2: Replace weekly query with daily query in backend
+
+**Files:**
+- Modify: `baloo/dashboard/queries.py` (lines 483–529)
+
+- [ ] **Step 1: Replace the weekly trends block**
+
+Find the comment `# --- Weekly trends (dialect-aware) ---` and replace everything from that comment through the `trends = [...]` list comprehension with:
+
+```python
+# --- Daily accuracy trends ---
+daily_rows = (
+    await session.execute(
+        select(
+            func.date(FindingOutcome.labeled_at).label("day"),
+            FindingOutcome.outcome,
+            func.count(FindingOutcome.id),
+        )
+        .where(*_base_filters())
+        .group_by("day", FindingOutcome.outcome)
+        .order_by("day")
+    )
+).all()
+
+day_map: dict[str, dict] = {}
+for day, outcome, cnt in daily_rows:
+    day_key = str(day)
+    if day_key not in day_map:
+        day_map[day_key] = {
+            "total": 0,
+            "actioned": 0,
+            "acknowledged": 0,
+            "disputed": 0,
+            "ignored": 0,
+        }
+    day_map[day_key]["total"] += cnt
+    if outcome in day_map[day_key]:
+        day_map[day_key][outcome] += cnt
+trends = [
+    {
+        "day": d,
+        "total": v["total"],
+        "hit_rate": round(v["actioned"] / v["total"] * 100, 1) if v["total"] else 0.0,
+        "noise_rate": (
+            round((v["disputed"] + v["ignored"]) / v["total"] * 100, 1)
+            if v["total"]
+            else 0.0
+        ),
+    }
+    for d, v in day_map.items()
+]
+```
+
+- [ ] **Step 2: Run tests — still failing (template not updated yet)**
+
+```bash
+uv run pytest tests/dashboard/test_outcomes_page.py -v
+```
+
+Expected: still FAIL on `"Accuracy Over Time"` assertion.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add baloo/dashboard/queries.py
+git commit -m "feat: switch outcomes trends query from weekly to daily granularity"
+```
+
+---
+
+### Task 3: Update template
+
+**Files:**
+- Modify: `baloo/dashboard/templates/outcomes.html` (lines 73, 159)
+
+- [ ] **Step 1: Update chart title**
+
+Change line 73:
+```html
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Weekly Trends</h2>
+```
+to:
+```html
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Accuracy Over Time</h2>
+```
+
+- [ ] **Step 2: Update x-axis label accessor**
+
+Change line 159:
+```javascript
+      labels: trends.map(t => t.week),
+```
+to:
+```javascript
+      labels: trends.map(t => t.day),
+```
+
+- [ ] **Step 3: Run tests — should now pass**
+
+```bash
+uv run pytest tests/dashboard/test_outcomes_page.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+uv run pytest --tb=short -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add baloo/dashboard/templates/outcomes.html
+git commit -m "feat: replace Weekly Trends chart with daily Accuracy Over Time"
+```

--- a/docs/superpowers/plans/2026-05-04-thread-auto-resolution.md
+++ b/docs/superpowers/plans/2026-05-04-thread-auto-resolution.md
@@ -1,0 +1,1062 @@
+# Thread Auto-Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When Baloo re-reviews a PR and a previously flagged issue is no longer present, automatically reply "Looks like this was addressed in the latest commit. Resolving." and resolve the GitHub thread via GraphQL mutation.
+
+**Architecture:** Extend the FP verifier to run a second concurrent pass over unresolved awaiting threads (reconstructed as ReviewComment objects), using the new diff as context. On an `fp` verdict the thread is replied to and resolved via a new `resolveReviewThread` GraphQL mutation. Thread node IDs are fetched alongside the existing resolved-state query and stored on `DiscussionThread`.
+
+**Tech Stack:** Python 3.10+, pydantic v2, httpx, pytest/pytest-asyncio, GitHub GraphQL API
+
+---
+
+## Task 1: Add `node_id` to `DiscussionThread` and propagate from GraphQL
+
+**Files:**
+- Modify: `baloo/github/models.py`
+- Modify: `baloo/github/api_client.py` (lines ~111–124 `_apply_resolved_thread_state`, lines ~736–753 GraphQL query)
+- Test: `tests/github/test_discussions.py`
+
+### Background
+
+`DiscussionThread` currently tracks `resolved`, `outdated`, `awaiting_response`, `is_baloo_thread`, and `root_comment_id` (the REST comment integer ID). To resolve a thread via GraphQL mutation we need the thread's **GraphQL node ID** (a base64 string like `"PRT_kwDO..."`) — a different identifier from `databaseId`.
+
+The existing `fetch_resolved_thread_ids` query already fetches threads; we just need to add `id` to it and return the mapping.
+
+- [ ] **Step 1: Write the failing test for `node_id` field**
+
+In `tests/github/test_discussions.py`, add:
+
+```python
+from baloo.github.models import DiscussionThread
+from datetime import datetime, timezone
+
+def test_discussion_thread_has_node_id_field():
+    thread = DiscussionThread(
+        id=1,
+        path="foo.py",
+        line=10,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+    )
+    assert thread.node_id is None
+
+def test_discussion_thread_node_id_can_be_set():
+    thread = DiscussionThread(
+        id=1,
+        path="foo.py",
+        line=10,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+        node_id="PRT_kwDOBQ",
+    )
+    assert thread.node_id == "PRT_kwDOBQ"
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_discussions.py::test_discussion_thread_has_node_id_field tests/github/test_discussions.py::test_discussion_thread_node_id_can_be_set -v
+```
+
+Expected: `AttributeError` or `ValidationError` — field doesn't exist yet.
+
+- [ ] **Step 3: Add `node_id` to `DiscussionThread`**
+
+In `baloo/github/models.py`, find `DiscussionThread` (currently around line 110) and add one field:
+
+```python
+class DiscussionThread(BaseModel):
+    """Represents an inline review thread."""
+
+    id: int
+    path: str | None
+    line: int | None
+    comments: list[DiscussionComment]
+    is_baloo_thread: bool = False
+    awaiting_response: bool = False
+    resolved: bool = False
+    outdated: bool = False
+    last_activity: datetime
+    root_comment_id: int | None = None
+    node_id: str | None = None  # GraphQL thread node ID for resolveReviewThread mutation
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_discussions.py::test_discussion_thread_has_node_id_field tests/github/test_discussions.py::test_discussion_thread_node_id_can_be_set -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing test for `_apply_resolved_thread_state` writing `node_id`**
+
+In `tests/github/test_discussions.py`, add:
+
+```python
+from baloo.github.api_client import _apply_resolved_thread_state
+
+def _make_thread(root_comment_id: int) -> DiscussionThread:
+    return DiscussionThread(
+        id=root_comment_id,
+        path="foo.py",
+        line=1,
+        comments=[],
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=root_comment_id,
+    )
+
+def test_apply_resolved_thread_state_writes_node_id():
+    thread = _make_thread(root_comment_id=42)
+    node_id_map = {42: "PRT_kwDOBQ"}
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids=set(),
+        outdated_ids=None,
+        thread_node_ids=node_id_map,
+    )
+    assert thread.node_id == "PRT_kwDOBQ"
+
+def test_apply_resolved_thread_state_node_id_missing_from_map():
+    thread = _make_thread(root_comment_id=99)
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids=set(),
+        thread_node_ids={},
+    )
+    assert thread.node_id is None
+
+def test_apply_resolved_thread_state_existing_behaviour_preserved():
+    """Resolved flag still gets set correctly alongside node_id."""
+    thread = _make_thread(root_comment_id=7)
+    _apply_resolved_thread_state(
+        [thread],
+        resolved_ids={7},
+        thread_node_ids={7: "PRT_abc"},
+    )
+    assert thread.resolved is True
+    assert thread.node_id == "PRT_abc"
+```
+
+- [ ] **Step 6: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_discussions.py::test_apply_resolved_thread_state_writes_node_id tests/github/test_discussions.py::test_apply_resolved_thread_state_node_id_missing_from_map tests/github/test_discussions.py::test_apply_resolved_thread_state_existing_behaviour_preserved -v
+```
+
+Expected: `TypeError` — `_apply_resolved_thread_state` doesn't accept `thread_node_ids` yet.
+
+- [ ] **Step 7: Extend `_apply_resolved_thread_state` to accept and write `node_id`**
+
+In `baloo/github/api_client.py`, update `_apply_resolved_thread_state` (around line 111):
+
+```python
+def _apply_resolved_thread_state(
+    discussion_threads: list[DiscussionThread],
+    resolved_ids: set[int],
+    outdated_ids: set[int] | None = None,
+    thread_node_ids: dict[int, str] | None = None,
+) -> None:
+    """Overlay GitHub's authoritative resolved/outdated state onto REST-built threads."""
+    for thread in discussion_threads:
+        if thread_node_ids and thread.root_comment_id is not None:
+            thread.node_id = thread_node_ids.get(thread.root_comment_id)
+        if thread.root_comment_id in resolved_ids:
+            thread.resolved = True
+            thread.awaiting_response = False
+        elif outdated_ids and thread.root_comment_id in outdated_ids:
+            thread.outdated = True
+            thread.awaiting_response = False
+```
+
+- [ ] **Step 8: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_discussions.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Update GraphQL query to fetch thread node ID**
+
+In `baloo/github/api_client.py`, find `fetch_resolved_thread_ids` (around line 736). Update:
+1. The query string — add `id` on the thread node
+2. The return type — add `dict[int, str]` third element
+3. The parsing loop — populate a `node_id_map`
+4. The call site in `get_pr_context` — unpack the third value and pass to `_apply_resolved_thread_state`
+
+Change the query from:
+```python
+        query = """
+        query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pr) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  isResolved
+                  isOutdated
+                  comments(first: 1) {
+                    nodes { databaseId }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+```
+
+To:
+```python
+        query = """
+        query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pr) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  comments(first: 1) {
+                    nodes { databaseId }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+```
+
+Change the return type annotation from `tuple[set[int], set[int]]` to `tuple[set[int], set[int], dict[int, str]]`.
+
+Add `node_id_map: dict[int, str] = {}` after the `outdated_ids` declaration. In the loop that processes nodes:
+
+```python
+                    for node in threads_data.get("nodes", []):
+                        if node is None:
+                            continue
+                        comments = node.get("comments", {}).get("nodes", [])
+                        if not comments or not comments[0].get("databaseId"):
+                            continue
+                        db_id = comments[0]["databaseId"]
+                        thread_node_id = node.get("id")
+                        if thread_node_id:
+                            node_id_map[db_id] = thread_node_id
+                        if node.get("isResolved"):
+                            resolved_ids.add(db_id)
+                        elif node.get("isOutdated"):
+                            outdated_ids.add(db_id)
+```
+
+Change the return statement from `return resolved_ids, outdated_ids` to `return resolved_ids, outdated_ids, node_id_map`.
+
+In the `except` block at the end of the function, change the return from `return set(), set()` to `return set(), set(), {}`.
+
+- [ ] **Step 10: Update `get_pr_context` call site**
+
+In `get_pr_context` (around line 236), change:
+
+```python
+            resolved_ids, outdated_ids = await self.fetch_resolved_thread_ids(
+                repo_full_name, pr_number
+            )
+            _apply_resolved_thread_state(discussion_threads, resolved_ids, outdated_ids)
+```
+
+To:
+
+```python
+            resolved_ids, outdated_ids, thread_node_ids = await self.fetch_resolved_thread_ids(
+                repo_full_name, pr_number
+            )
+            _apply_resolved_thread_state(
+                discussion_threads, resolved_ids, outdated_ids, thread_node_ids
+            )
+```
+
+- [ ] **Step 11: Run full test suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all existing tests pass (the new third return value is ignored by any existing callers that only unpack two values — but check for `ValueError: too many values to unpack` if any test mocks this function).
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add baloo/github/models.py baloo/github/api_client.py tests/github/test_discussions.py
+git commit -m "feat: add node_id to DiscussionThread and fetch via GraphQL"
+```
+
+---
+
+## Task 2: Add `resolve_review_thread` GraphQL mutation
+
+**Files:**
+- Modify: `baloo/github/api_client.py`
+- Test: `tests/github/test_api_client_resolve.py` (new file)
+
+### Background
+
+GitHub's GraphQL API exposes `resolveReviewThread(input: {threadId: ID!})`. The `threadId` must be the thread's GraphQL node ID (the `id` field we now store as `DiscussionThread.node_id`). There is no REST equivalent.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/github/test_api_client_resolve.py`:
+
+```python
+"""Tests for resolve_review_thread GraphQL mutation."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from baloo.github.api_client import GitHubAPIClient
+
+
+@pytest.fixture
+def client():
+    with patch("baloo.github.api_client.get_installation_token", return_value="tok"):
+        return GitHubAPIClient(installation_id=1)
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_success(client):
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "data": {"resolveReviewThread": {"thread": {"id": "PRT_x", "isResolved": True}}}
+    }
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_http
+
+        result = await client.resolve_review_thread("PRT_x")
+
+    assert result is True
+    call_kwargs = mock_http.post.call_args
+    body = call_kwargs[1]["json"]
+    assert "resolveReviewThread" in body["query"]
+    assert body["variables"]["threadId"] == "PRT_x"
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_graphql_error_returns_false(client):
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"errors": [{"message": "not found"}]}
+
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(return_value=mock_response)
+        mock_client_cls.return_value = mock_http
+
+        result = await client.resolve_review_thread("PRT_bad")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_review_thread_http_exception_returns_false(client):
+    with patch("httpx.AsyncClient") as mock_client_cls:
+        mock_http = AsyncMock()
+        mock_http.__aenter__ = AsyncMock(return_value=mock_http)
+        mock_http.__aexit__ = AsyncMock(return_value=False)
+        mock_http.post = AsyncMock(side_effect=Exception("network error"))
+        mock_client_cls.return_value = mock_http
+
+        result = await client.resolve_review_thread("PRT_x")
+
+    assert result is False
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_api_client_resolve.py -v
+```
+
+Expected: `AttributeError: 'GitHubAPIClient' object has no attribute 'resolve_review_thread'`
+
+- [ ] **Step 3: Implement `resolve_review_thread`**
+
+In `baloo/github/api_client.py`, add after the `reply_to_review_comment` method (around line 570):
+
+```python
+    async def resolve_review_thread(self, thread_node_id: str) -> bool:
+        """Resolve a pull request review thread via GraphQL mutation.
+
+        Args:
+            thread_node_id: The GraphQL node ID of the thread (PullRequestReviewThread.id).
+
+        Returns:
+            True on success, False on any error (fail-open — a failed resolve is not fatal).
+        """
+        mutation = """
+        mutation($threadId: ID!) {
+          resolveReviewThread(input: {threadId: $threadId}) {
+            thread { id isResolved }
+          }
+        }
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "https://api.github.com/graphql",
+                    headers=self._get_headers(),
+                    json={"query": mutation, "variables": {"threadId": thread_node_id}},
+                )
+                response.raise_for_status()
+                body = response.json()
+                if "errors" in body:
+                    logger.warning(
+                        "GraphQL error resolving thread %s: %s",
+                        thread_node_id,
+                        body["errors"],
+                    )
+                    return False
+                return True
+        except Exception as exc:
+            logger.warning("Failed to resolve thread %s: %s", thread_node_id, exc)
+            return False
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_api_client_resolve.py -v
+```
+
+Expected: all 3 pass.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add baloo/github/api_client.py tests/github/test_api_client_resolve.py
+git commit -m "feat: add resolve_review_thread GraphQL mutation"
+```
+
+---
+
+## Task 3: `_comment_from_thread` helper
+
+**Files:**
+- Modify: `baloo/github/webhook_handler.py`
+- Test: `tests/github/test_webhook_handler.py` (add to existing file)
+
+### Background
+
+The FP verifier operates on `ReviewComment` objects. Awaiting threads need to be reconstructed into `ReviewComment` to be passed through. The Baloo comment format is:
+
+```
+**[HIGH] Security** - **Title**
+**Category:** Security
+**Severity:** HIGH
+
+Body...
+```
+
+We parse severity from the `[SEVERITY]` bracket and category from the word immediately after it.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/github/test_webhook_handler.py` (or create a new `tests/github/test_comment_from_thread.py` if the existing file is very large — check first), add:
+
+```python
+from datetime import datetime, timezone
+from baloo.github.models import DiscussionComment, DiscussionThread
+from baloo.github.webhook_handler import _comment_from_thread
+from baloo.github.models import ReviewSeverity, FindingCategory
+
+
+def _make_thread(body: str, path: str = "app.py", line: int = 42) -> DiscussionThread:
+    comment = DiscussionComment(
+        id=1,
+        author="baloo-code-reviewer[bot]",
+        body=body,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        source="review_comment",
+        is_baloo=True,
+        path=path,
+        line=line,
+    )
+    return DiscussionThread(
+        id=100,
+        path=path,
+        line=line,
+        comments=[comment],
+        is_baloo_thread=True,
+        awaiting_response=True,
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=1,
+        node_id="PRT_kwDOBQ",
+    )
+
+
+def test_comment_from_thread_extracts_path_and_line():
+    thread = _make_thread("**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad stuff")
+    comment = _comment_from_thread(thread)
+    assert comment.path == "app.py"
+    assert comment.line == 42
+
+
+def test_comment_from_thread_extracts_severity_high():
+    thread = _make_thread("**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nBody")
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.HIGH
+
+
+def test_comment_from_thread_extracts_severity_critical():
+    thread = _make_thread("**[CRITICAL] Bugs** - **Title**\n**Category:** Bugs\n**Severity:** CRITICAL\n\nBody")
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.CRITICAL
+
+
+def test_comment_from_thread_extracts_category_security():
+    thread = _make_thread("**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nBody")
+    comment = _comment_from_thread(thread)
+    assert comment.category == FindingCategory.SECURITY
+
+
+def test_comment_from_thread_defaults_on_unparseable_body():
+    thread = _make_thread("Some freeform text with no severity markers")
+    comment = _comment_from_thread(thread)
+    assert comment.severity == ReviewSeverity.MEDIUM
+    assert comment.category == FindingCategory.QUALITY
+
+
+def test_comment_from_thread_preserves_full_body():
+    body = "**[HIGH] Security** - **Title**\n**Category:** Security\n**Severity:** HIGH\n\nDetailed finding text."
+    thread = _make_thread(body)
+    comment = _comment_from_thread(thread)
+    assert comment.body == body
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_comment_from_thread" -v
+```
+
+Expected: `ImportError` — `_comment_from_thread` not defined yet.
+
+- [ ] **Step 3: Implement `_comment_from_thread`**
+
+In `baloo/github/webhook_handler.py`, add near the other private helpers (after `_extract_issue_signature`, around line 350):
+
+```python
+import re as _re
+
+_SEVERITY_RE = _re.compile(r"\*\*\[(\w+)\]\s+\w+\*\*")
+_CATEGORY_RE = _re.compile(r"\*\*\[(?:\w+)\]\s+(\w[\w ]*?)\*\*")
+
+_CATEGORY_MAP: dict[str, FindingCategory] = {
+    "security": FindingCategory.SECURITY,
+    "bugs": FindingCategory.BUGS,
+    "silent failures": FindingCategory.SILENT_FAILURES,
+    "guidelines": FindingCategory.GUIDELINES,
+    "performance": FindingCategory.PERFORMANCE,
+    "quality": FindingCategory.QUALITY,
+}
+
+
+def _comment_from_thread(thread: DiscussionThread) -> ReviewComment:
+    """Reconstruct a ReviewComment from a Baloo DiscussionThread for re-verification.
+
+    Parses severity and category from the root comment body. Falls back to
+    MEDIUM/QUALITY if the body doesn't match the expected format.
+    """
+    body = thread.comments[0].body if thread.comments else ""
+
+    severity = ReviewSeverity.MEDIUM
+    m = _SEVERITY_RE.search(body)
+    if m:
+        try:
+            severity = ReviewSeverity(m.group(1).upper())
+        except ValueError:
+            pass
+
+    category = FindingCategory.QUALITY
+    m2 = _CATEGORY_RE.search(body)
+    if m2:
+        category = _CATEGORY_MAP.get(m2.group(1).lower().strip(), FindingCategory.QUALITY)
+
+    return ReviewComment(
+        path=thread.path or "",
+        line=thread.line or 0,
+        body=body,
+        severity=severity,
+        category=category,
+    )
+```
+
+Also add `FindingCategory` to the imports from `baloo.github.models` at the top of `webhook_handler.py` if not already present.
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_comment_from_thread" -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add baloo/github/webhook_handler.py tests/github/test_webhook_handler.py
+git commit -m "feat: add _comment_from_thread helper for thread re-verification"
+```
+
+---
+
+## Task 4: Thread re-verification pass and resolution actions
+
+**Files:**
+- Modify: `baloo/github/webhook_handler.py`
+- Test: `tests/github/test_webhook_handler.py`
+
+### Background
+
+After the thread-matching loop, we collect awaiting threads that the review agent didn't re-file. We run these through `FPVerifier.verify()` concurrently with the new-findings pass. For each `fp` verdict we: (1) reply to the thread, (2) call `resolve_review_thread`, (3) subtract from the awaiting count.
+
+The key change to the pipeline in `webhook_handler.py` is in the `_run_pr_review` function (or equivalent), around line 958 where `decision_comments` is assigned. The re-verification pass runs in parallel with the FP pass for new findings using `asyncio.gather`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/github/test_webhook_handler.py`:
+
+```python
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+
+import pytest
+
+from baloo.github.models import (
+    DiscussionComment,
+    DiscussionThread,
+    FileChange,
+    PRContext,
+    PRDiscussionContext,
+    PRMetadata,
+    ReviewComment,
+    ReviewSeverity,
+    FindingCategory,
+)
+from baloo.processor.fp_verifier import FPVerificationResult, FPRejection, FPStats
+
+
+def _make_awaiting_thread(root_comment_id: int = 1, node_id: str = "PRT_x") -> DiscussionThread:
+    comment = DiscussionComment(
+        id=root_comment_id,
+        author="baloo-code-reviewer[bot]",
+        body="**[HIGH] Security** - **SQL injection**\n**Category:** Security\n**Severity:** HIGH\n\nBad query.",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        source="review_comment",
+        is_baloo=True,
+        path="app.py",
+        line=10,
+    )
+    return DiscussionThread(
+        id=root_comment_id,
+        path="app.py",
+        line=10,
+        comments=[comment],
+        is_baloo_thread=True,
+        awaiting_response=True,
+        last_activity=datetime.now(timezone.utc),
+        root_comment_id=root_comment_id,
+        node_id=node_id,
+    )
+
+
+def _make_pr_context(awaiting_threads: list[DiscussionThread] | None = None) -> PRContext:
+    return PRContext(
+        metadata=PRMetadata(
+            repo_full_name="org/repo",
+            pr_number=1,
+            title="Fix stuff",
+            description=None,
+            author="dev",
+            base_branch="main",
+            head_branch="fix/it",
+            head_sha="abc123",
+            files_changed=[FileChange(filename="app.py", status="modified", additions=1, deletions=1, changes=2)],
+        ),
+        discussion=PRDiscussionContext(
+            threads=awaiting_threads or [],
+            awaiting_response_count=len(awaiting_threads) if awaiting_threads else 0,
+        ),
+        diff="diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -10,1 +10,1 @@\n-bad\n+good\n",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_fp_verdict_triggers_reply_and_resolve():
+    """An fp verdict on an awaiting thread causes reply + resolve."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread()
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    fp_result = FPVerificationResult(
+        verified=[],
+        rejected=[FPRejection(
+            comment=ReviewComment(path="app.py", line=10, body="body", severity=ReviewSeverity.HIGH, category=FindingCategory.SECURITY),
+            reason="code was fixed",
+            model="claude-haiku",
+        )],
+        stats=FPStats(),
+    )
+
+    mock_api = AsyncMock()
+    mock_api.reply_to_review_comment = AsyncMock(return_value=True)
+    mock_api.resolve_review_thread = AsyncMock(return_value=True)
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as MockVerifier:
+        mock_verifier_instance = AsyncMock()
+        mock_verifier_instance.verify = AsyncMock(return_value=fp_result)
+        MockVerifier.return_value = mock_verifier_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    assert resolved_count == 1
+    mock_api.reply_to_review_comment.assert_called_once_with(
+        "org/repo",
+        1,  # root_comment_id
+        "Looks like this was addressed in the latest commit. Resolving.",
+    )
+    mock_api.resolve_review_thread.assert_called_once_with("PRT_x")
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_real_verdict_no_action():
+    """A real verdict leaves the thread untouched."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread()
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    fp_result = FPVerificationResult(
+        verified=[ReviewComment(path="app.py", line=10, body="body", severity=ReviewSeverity.HIGH, category=FindingCategory.SECURITY)],
+        rejected=[],
+        stats=FPStats(),
+    )
+
+    mock_api = AsyncMock()
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as MockVerifier:
+        mock_verifier_instance = AsyncMock()
+        mock_verifier_instance.verify = AsyncMock(return_value=fp_result)
+        MockVerifier.return_value = mock_verifier_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    assert resolved_count == 0
+    mock_api.reply_to_review_comment.assert_not_called()
+    mock_api.resolve_review_thread.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_skips_threads_without_node_id():
+    """Threads with no node_id are excluded from re-verification."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread(node_id=None)
+    thread.node_id = None
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+
+    mock_api = AsyncMock()
+
+    with patch("baloo.github.webhook_handler.FPVerifier") as MockVerifier:
+        mock_verifier_instance = AsyncMock()
+        mock_verifier_instance.verify = AsyncMock(return_value=FPVerificationResult())
+        MockVerifier.return_value = mock_verifier_instance
+
+        resolved_count = await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+        )
+
+    # Verifier called with empty list (thread filtered out)
+    call_args = mock_verifier_instance.verify.call_args[0][0]
+    assert call_args == []
+    assert resolved_count == 0
+
+
+@pytest.mark.asyncio
+async def test_reverify_threads_empty_list_returns_zero():
+    """No awaiting threads → no verifier call, returns 0."""
+    from baloo.github.webhook_handler import _reverify_awaiting_threads
+
+    pr_context = _make_pr_context()
+    mock_api = AsyncMock()
+
+    resolved_count = await _reverify_awaiting_threads(
+        awaiting_threads=[],
+        pr_context=pr_context,
+        api_client=mock_api,
+    )
+
+    assert resolved_count == 0
+    mock_api.reply_to_review_comment.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_reverify_threads" -v
+```
+
+Expected: `ImportError` — `_reverify_awaiting_threads` not defined.
+
+- [ ] **Step 3: Implement `_reverify_awaiting_threads`**
+
+In `baloo/github/webhook_handler.py`, add after `_comment_from_thread` (same area, around line 370):
+
+```python
+async def _reverify_awaiting_threads(
+    awaiting_threads: list[DiscussionThread],
+    pr_context: PRContext,
+    api_client,
+) -> int:
+    """Re-verify awaiting Baloo threads against the new diff.
+
+    For each thread where the LLM says the issue is no longer present (fp verdict),
+    post a resolution reply and resolve the GitHub thread.
+
+    Returns:
+        Number of threads resolved.
+    """
+    if not awaiting_threads:
+        return 0
+
+    # Only re-verify threads that have a node_id (needed to resolve)
+    eligible = [t for t in awaiting_threads if t.node_id]
+
+    if not eligible:
+        logger.info("No awaiting threads with node_id — skipping re-verification")
+        return 0
+
+    # Reconstruct ReviewComment objects from thread root comments
+    comments = [_comment_from_thread(t) for t in eligible]
+
+    verifier = FPVerifier()
+    fp_result = await verifier.verify(comments, pr_context)
+
+    # fp_result.rejected = findings the verifier says are no longer present
+    resolved_count = 0
+    rejected_paths_lines = {(r.comment.path, r.comment.line) for r in fp_result.rejected}
+
+    for thread in eligible:
+        if (thread.path, thread.line) not in rejected_paths_lines:
+            continue
+
+        logger.info(
+            "Thread re-verified as fixed: %s:%s (thread node %s)",
+            thread.path,
+            thread.line,
+            thread.node_id,
+        )
+
+        repo = pr_context.repo_full_name
+        pr_number = pr_context.pr_number
+
+        # Reply first (best-effort), then resolve
+        if thread.root_comment_id is not None:
+            await api_client.reply_to_review_comment(
+                repo,
+                thread.root_comment_id,
+                "Looks like this was addressed in the latest commit. Resolving.",
+            )
+
+        await api_client.resolve_review_thread(thread.node_id)
+        resolved_count += 1
+
+    return resolved_count
+```
+
+Add `FPVerifier` to the imports at the top of `webhook_handler.py`:
+
+```python
+from baloo.processor.fp_verifier import FPVerifier
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+uv run pytest tests/github/test_webhook_handler.py -k "test_reverify_threads" -v
+```
+
+Expected: all 4 pass.
+
+- [ ] **Step 5: Wire `_reverify_awaiting_threads` into the review pipeline**
+
+In `webhook_handler.py`, find the section after the thread-matching loop where `decision_comments` is assigned (around line 958). The awaiting threads that were NOT re-filed are the ones counted as `skipped_duplicates`. We need to collect them.
+
+In the thread-matching loop (around line 948–950), change from:
+
+```python
+                if thread.awaiting_response:
+                    skipped_duplicates += 1
+                    continue
+```
+
+To:
+
+```python
+                if thread.awaiting_response:
+                    skipped_duplicates += 1
+                    awaiting_not_refiled.append(thread)
+                    continue
+```
+
+And add `awaiting_not_refiled: list[DiscussionThread] = []` in the initialisation block near `skipped_duplicates = 0` (around line 897).
+
+After `decision_comments = fresh_comments + [...]` (around line 958), add the concurrent re-verification:
+
+```python
+            # Run FP verifier on new findings and re-verification of awaiting threads concurrently
+            fp_verifier_task = asyncio.ensure_future(
+                fp_verifier.verify(decision_comments, pr_context)
+            ) if decision_comments else None
+
+            reverify_task = asyncio.ensure_future(
+                _reverify_awaiting_threads(
+                    awaiting_not_refiled, pr_context, github_client
+                )
+            )
+
+            if fp_verifier_task:
+                fp_result = await fp_verifier_task
+                decision_comments = fp_result.verified
+            auto_resolved_count = await reverify_task
+```
+
+> **Note:** In the current codebase, the FP verifier pass for new findings is called earlier in the function (before the thread-matching loop) as `fp_result = await fp_verifier.verify(review_result.comments, pr_context)`. Do NOT move that call. Instead, after the thread-matching loop, call `_reverify_awaiting_threads` as a plain `await` (no concurrent wrapper needed since the new-findings FP pass already completed). The `asyncio.ensure_future` pattern shown above is only needed if you restructure to run them truly concurrently — acceptable either way.
+
+Adjust the awaiting count used in the decision block. Find:
+
+```python
+            awaiting_threads = pr_context.awaiting_response_threads
+```
+
+Change to:
+
+```python
+            awaiting_threads = pr_context.awaiting_response_threads - auto_resolved_count
+```
+
+Update the summary text for resolved threads. Find where `awaiting_threads` is mentioned in the summary (around line 996):
+
+```python
+            if awaiting_threads:
+                summary_text += (
+                    f"\n\n⏳ {awaiting_threads} Baloo thread(s) remain open from earlier reviews."
+                )
+```
+
+Add before it:
+
+```python
+            if auto_resolved_count:
+                summary_text += (
+                    f"\n\n✅ Auto-resolved {auto_resolved_count} previously flagged thread(s) "
+                    "that look fixed in this commit."
+                )
+```
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+uv run pytest tests/ -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add baloo/github/webhook_handler.py tests/github/test_webhook_handler.py
+git commit -m "feat: auto-resolve fixed Baloo threads via FP re-verification"
+```
+
+---
+
+## Task 5: End-to-end smoke test and PR
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run full test suite with coverage**
+
+```bash
+uv run pytest tests/ -q --tb=short
+```
+
+Expected: all pass, no regressions.
+
+- [ ] **Step 2: Lint**
+
+```bash
+uv run ruff check baloo tests
+```
+
+Fix any issues found.
+
+- [ ] **Step 3: Format**
+
+```bash
+uv run black baloo tests
+```
+
+Commit any formatting changes.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat: auto-resolve fixed Baloo threads via LLM re-verification" \
+  --body "..."
+```
+
+PR description should explain: what was observed (PR #30 stuck in changes_requested with 0 new findings), what was built, how it works, test coverage.

--- a/docs/superpowers/specs/2026-05-04-thread-auto-resolution-design.md
+++ b/docs/superpowers/specs/2026-05-04-thread-auto-resolution-design.md
@@ -1,0 +1,130 @@
+# Thread Auto-Resolution Design
+
+**Date:** 2026-05-04
+**Status:** Approved
+
+## Problem
+
+When Baloo flags an issue on a PR and the developer fixes it in a follow-up commit, Baloo silently stops re-filing the finding but never acknowledges the fix. The GitHub thread stays open, `awaiting_response=True`, and the decision engine keeps setting `request_changes=True` even when the latest review finds zero new issues. The PR is stuck.
+
+Observed on PR #30: 4 reviews, 3 findings fixed across 3 commits, final review found 0 issues — yet the PR was still marked `changes_requested` and all 3 threads left unresolved at merge.
+
+The `finding_outcomes` signals confirm this: `code_changed_near_line=true`, `thread_resolved=false` on all findings.
+
+## Out of scope (deferred)
+
+Human responses on Baloo threads (developer replies to a finding) — will be designed after gathering real examples of how developers actually respond.
+
+## Design
+
+### 1. Data model: `DiscussionThread.node_id`
+
+Add one field to `DiscussionThread`:
+
+```python
+node_id: str | None = None  # GraphQL thread node ID for resolveReviewThread mutation
+```
+
+This is the GraphQL `id` on the `PullRequestReviewThread` node, distinct from the REST `databaseId` used today.
+
+### 2. GraphQL query update
+
+`fetch_resolved_thread_ids` in `api_client.py` adds `id` to the thread nodes:
+
+```graphql
+nodes {
+  id          # NEW — thread node ID for mutation
+  isResolved
+  isOutdated
+  comments(first: 1) {
+    nodes { databaseId }
+  }
+}
+```
+
+`_apply_resolved_thread_state` is extended to write `node_id` onto each matched thread alongside the existing `resolved`/`outdated` flags.
+
+### 3. New API method: `resolve_review_thread`
+
+```python
+async def resolve_review_thread(self, thread_node_id: str) -> bool
+```
+
+Calls the GraphQL mutation:
+
+```graphql
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}
+```
+
+Returns `True` on success. On error: logs a warning and returns `False` — a failed resolve is not fatal, the reply comment was already posted.
+
+### 4. Re-verification pass
+
+After the existing thread-matching loop in `webhook_handler.py`, collect threads eligible for re-verification:
+
+- `is_baloo_thread=True`
+- `awaiting_response=True`
+- Not matched to any new finding (i.e., the review agent did not re-file this finding)
+- `node_id` is set (needed to resolve)
+- Not already `resolved` or `outdated`
+
+Reconstruct a `ReviewComment` from each thread's root comment (`body`, `path`, `line`, `severity`, `category`). Pass the batch to `FPVerifier.verify()` — the existing verifier, same Haiku model, same prompt, but with the new diff as context.
+
+`fp` verdict = issue no longer present in current code = fixed.
+`real` verdict = issue still present = leave thread open.
+
+The re-verification batch runs **concurrently** with the new-findings FP verifier pass (they are independent).
+
+### 5. Actions on `fp` verdict
+
+For each thread where re-verification returns `fp`:
+
+1. `reply_to_review_comment(root_comment_id, "Looks like this was addressed in the latest commit. Resolving.")`
+2. `resolve_review_thread(node_id)`
+3. Update `finding_outcomes` row for this finding: set `thread_resolved=True` in signals (if row exists)
+4. Remove thread from the `awaiting_response` count fed to the decision engine
+
+Step 4 prevents the `if awaiting_threads and not request_changes and not decision_comments: request_changes = True` block from firing when all previously open threads are now resolved.
+
+### 6. Pipeline position
+
+```
+review agent runs
+        |
+thread matching (existing)
+  fresh / duplicate / resolved / responded / outdated
+        |
+        +---> FP verifier: new findings     (existing, concurrent)
+        |
+        +---> FP verifier: awaiting threads (new, concurrent)
+                    |
+                  fp -> reply + resolve + update outcome
+                  real -> leave open
+        |
+post new findings
+resolve fixed threads
+        |
+decision engine
+```
+
+## Edge cases
+
+**Thread has no `node_id`** (GraphQL fetch failed): skip re-verification for that thread. Logged as a warning. PR behaviour unchanged from today.
+
+**`reply_to_review_comment` returns `False`** (thread outdated/404): still attempt `resolve_review_thread`. If that also fails, log and move on — don't block the review.
+
+**Re-verification returns `real` but developer already fixed it** (false negative from verifier): thread stays open. Harmless — developer can manually resolve, or next push will re-verify.
+
+**New finding matches the same location as an awaiting thread**: existing dedup logic handles this (`skipped_duplicates`). Thread is not eligible for re-verification.
+
+## Testing
+
+- Unit: `test_resolve_review_thread` — mock GraphQL mutation, verify correct node ID sent
+- Unit: `test_thread_reverification_fp_verdict` — mock FPVerifier returning fp, assert reply + resolve called
+- Unit: `test_thread_reverification_real_verdict` — assert no reply/resolve called
+- Unit: `test_awaiting_count_excludes_resolved_threads` — verify decision engine sees 0 awaiting after resolution
+- Integration: reconstruct `ReviewComment` from a `DiscussionThread` root comment — verify fields round-trip correctly

--- a/tests/github/test_merge_detection.py
+++ b/tests/github/test_merge_detection.py
@@ -130,19 +130,17 @@ class TestMergeCommitDetection:
             "files": [{"filename": f"file{i}.py"} for i in range(10)],
         }
 
+        ancestry_mock = AsyncMock(side_effect=lambda repo, sha, branch: sha == "base_pr_tip")
         with (
             patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
-            patch.object(
-                github_client,
-                "_commit_is_ancestor_of_branch",
-                new=AsyncMock(side_effect=lambda repo, sha, branch: sha == "base_pr_tip"),
-            ),
+            patch.object(github_client, "_commit_is_ancestor_of_branch", new=ancestry_mock),
         ):
             is_merge, reason = await github_client.is_merge_or_sync_commit(
                 "owner/repo", "head123", "main"
             )
 
         assert is_merge is True
+        ancestry_mock.assert_awaited()  # proves ancestry path was exercised, not heuristics
 
     @pytest.mark.asyncio
     async def test_detects_remote_tracking_branch_merge_by_ancestry(self, github_client):
@@ -155,19 +153,17 @@ class TestMergeCommitDetection:
             "files": [{"filename": f"file{i}.py"} for i in range(10)],
         }
 
+        ancestry_mock = AsyncMock(side_effect=lambda repo, sha, branch: sha == "origin_main_tip")
         with (
             patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
-            patch.object(
-                github_client,
-                "_commit_is_ancestor_of_branch",
-                new=AsyncMock(side_effect=lambda repo, sha, branch: sha == "origin_main_tip"),
-            ),
+            patch.object(github_client, "_commit_is_ancestor_of_branch", new=ancestry_mock),
         ):
             is_merge, reason = await github_client.is_merge_or_sync_commit(
                 "owner/repo", "head123", "main"
             )
 
         assert is_merge is True
+        ancestry_mock.assert_awaited()  # proves ancestry path was exercised, not heuristics
 
     @pytest.mark.asyncio
     async def test_handles_ancestor_check_error_gracefully(self, github_client):

--- a/tests/github/test_merge_detection.py
+++ b/tests/github/test_merge_detection.py
@@ -17,53 +17,57 @@ class TestMergeCommitDetection:
             return GitHubAPIClient(installation_id=123)
 
     @pytest.mark.asyncio
-    async def test_detects_merge_commit_with_base_branch(self, github_client):
-        """Should detect merge commit that merges base branch into feature."""
+    async def test_detects_sync_when_parent_is_ancestor_of_base(self, github_client):
+        """Should skip review when a merge commit parent is on the base branch."""
         commit_info = {
-            "parents": [{"sha": "abc123"}, {"sha": "def456"}],
-            "commit": {"message": "Merge branch 'dev' into feature-branch"},
-            "files": [],
+            "parents": [{"sha": "feature111"}, {"sha": "base000"}],
+            "commit": {"message": "Merge branch 'main' into feature-branch"},
         }
 
-        with patch.object(
-            github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)
+        with (
+            patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
+            patch.object(
+                github_client,
+                "_commit_is_ancestor_of_branch",
+                new=AsyncMock(side_effect=lambda repo, sha, branch: sha == "base000"),
+            ),
         ):
             is_merge, reason = await github_client.is_merge_or_sync_commit(
-                "owner/repo", "abc123", "dev"
+                "owner/repo", "head123", "main"
             )
 
         assert is_merge is True
-        assert "merge commit" in reason.lower()
+        assert "main" in reason
+        assert "base000" in reason
 
     @pytest.mark.asyncio
-    async def test_detects_merge_commit_with_conflict_resolution(self, github_client):
-        """Should detect merge commit with small number of conflict resolution files."""
+    async def test_detects_sync_regardless_of_file_count(self, github_client):
+        """File count is irrelevant — a large upstream sync should still be skipped."""
         commit_info = {
-            "parents": [{"sha": "abc123"}, {"sha": "def456"}],
-            "commit": {"message": "Merge branch 'main' into my-feature"},
-            "files": [
-                {"filename": "file1.py"},
-                {"filename": "file2.py"},
-            ],
+            "parents": [{"sha": "feature111"}, {"sha": "base000"}],
+            "commit": {"message": "Synced with main"},  # non-standard message
         }
 
-        with patch.object(
-            github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)
+        with (
+            patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
+            patch.object(
+                github_client,
+                "_commit_is_ancestor_of_branch",
+                new=AsyncMock(side_effect=lambda repo, sha, branch: sha == "base000"),
+            ),
         ):
             is_merge, reason = await github_client.is_merge_or_sync_commit(
-                "owner/repo", "abc123", "main"
+                "owner/repo", "head123", "main"
             )
 
         assert is_merge is True
-        assert "2 file(s)" in reason
 
     @pytest.mark.asyncio
     async def test_does_not_detect_regular_commit(self, github_client):
-        """Should not detect regular (non-merge) commit."""
+        """Single-parent commit is never a sync merge."""
         commit_info = {
-            "parents": [{"sha": "abc123"}],  # Only one parent = not a merge
+            "parents": [{"sha": "abc123"}],
             "commit": {"message": "feat: add new feature"},
-            "files": [{"filename": "feature.py"}],
         }
 
         with patch.object(
@@ -77,45 +81,32 @@ class TestMergeCommitDetection:
         assert reason == ""
 
     @pytest.mark.asyncio
-    async def test_does_not_detect_merge_with_many_files(self, github_client):
-        """Should not detect merge commit with many file changes (likely real work)."""
+    async def test_does_not_detect_merge_between_feature_branches(self, github_client):
+        """Merging one feature branch into another should not be skipped."""
         commit_info = {
-            "parents": [{"sha": "abc123"}, {"sha": "def456"}],
-            "commit": {"message": "Merge branch 'main' into feature"},
-            "files": [{"filename": f"file{i}.py"} for i in range(10)],  # 10 files
+            "parents": [{"sha": "feature-a"}, {"sha": "feature-b"}],
+            "commit": {"message": "Merge branch 'feature-a' into feature-b"},
         }
 
-        with patch.object(
-            github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)
+        with (
+            patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
+            patch.object(
+                github_client,
+                "_commit_is_ancestor_of_branch",
+                # Neither parent is on main
+                new=AsyncMock(return_value=False),
+            ),
         ):
             is_merge, reason = await github_client.is_merge_or_sync_commit(
-                "owner/repo", "abc123", "main"
+                "owner/repo", "head123", "main"
             )
 
         assert is_merge is False
-
-    @pytest.mark.asyncio
-    async def test_does_not_detect_merge_with_unrelated_message(self, github_client):
-        """Should not detect merge commit that doesn't match base branch pattern."""
-        commit_info = {
-            "parents": [{"sha": "abc123"}, {"sha": "def456"}],
-            "commit": {"message": "Merge branch 'other-feature' into my-feature"},
-            "files": [],
-        }
-
-        with patch.object(
-            github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)
-        ):
-            # Base branch is 'main', but merge is from 'other-feature'
-            is_merge, reason = await github_client.is_merge_or_sync_commit(
-                "owner/repo", "abc123", "main"
-            )
-
-        assert is_merge is False
+        assert reason == ""
 
     @pytest.mark.asyncio
     async def test_handles_api_error_gracefully(self, github_client):
-        """Should return False if API call fails."""
+        """Should return False if the commit info API call fails."""
         with patch.object(
             github_client,
             "get_commit_info",
@@ -129,37 +120,24 @@ class TestMergeCommitDetection:
         assert reason == ""
 
     @pytest.mark.asyncio
-    async def test_detects_pull_request_merge(self, github_client):
-        """Should detect merge pull request commits."""
+    async def test_handles_ancestor_check_error_gracefully(self, github_client):
+        """Should return False if the ancestry compare API call fails."""
         commit_info = {
-            "parents": [{"sha": "abc123"}, {"sha": "def456"}],
-            "commit": {"message": "Merge pull request #123 from user/feature"},
-            "files": [],
+            "parents": [{"sha": "feature111"}, {"sha": "base000"}],
+            "commit": {"message": "Merge branch 'main'"},
         }
 
-        with patch.object(
-            github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)
+        with (
+            patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
+            patch.object(
+                github_client,
+                "_commit_is_ancestor_of_branch",
+                new=AsyncMock(side_effect=Exception("compare API error")),
+            ),
         ):
             is_merge, reason = await github_client.is_merge_or_sync_commit(
-                "owner/repo", "abc123", "main"
+                "owner/repo", "head123", "main"
             )
 
-        assert is_merge is True
-
-    @pytest.mark.asyncio
-    async def test_detects_remote_tracking_branch_merge(self, github_client):
-        """Should detect merge from remote-tracking branch."""
-        commit_info = {
-            "parents": [{"sha": "abc123"}, {"sha": "def456"}],
-            "commit": {"message": "Merge remote-tracking branch 'origin/main' into feature"},
-            "files": [{"filename": "conflict.py"}],
-        }
-
-        with patch.object(
-            github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)
-        ):
-            is_merge, reason = await github_client.is_merge_or_sync_commit(
-                "owner/repo", "abc123", "main"
-            )
-
-        assert is_merge is True
+        assert is_merge is False
+        assert reason == ""

--- a/tests/github/test_merge_detection.py
+++ b/tests/github/test_merge_detection.py
@@ -120,6 +120,50 @@ class TestMergeCommitDetection:
         assert reason == ""
 
     @pytest.mark.asyncio
+    async def test_detects_pr_merge_commit_by_ancestry(self, github_client):
+        """A 'Merge pull request' commit is skipped when one parent is on the base branch."""
+        commit_info = {
+            "parents": [{"sha": "feature111"}, {"sha": "base_pr_tip"}],
+            "commit": {"message": "Merge pull request #99 from user/feature"},
+        }
+
+        with (
+            patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
+            patch.object(
+                github_client,
+                "_commit_is_ancestor_of_branch",
+                new=AsyncMock(side_effect=lambda repo, sha, branch: sha == "base_pr_tip"),
+            ),
+        ):
+            is_merge, reason = await github_client.is_merge_or_sync_commit(
+                "owner/repo", "head123", "main"
+            )
+
+        assert is_merge is True
+
+    @pytest.mark.asyncio
+    async def test_detects_remote_tracking_branch_merge_by_ancestry(self, github_client):
+        """A remote-tracking merge commit is skipped when one parent is on the base branch."""
+        commit_info = {
+            "parents": [{"sha": "feature111"}, {"sha": "origin_main_tip"}],
+            "commit": {"message": "Merge remote-tracking branch 'origin/main' into feature"},
+        }
+
+        with (
+            patch.object(github_client, "get_commit_info", new=AsyncMock(return_value=commit_info)),
+            patch.object(
+                github_client,
+                "_commit_is_ancestor_of_branch",
+                new=AsyncMock(side_effect=lambda repo, sha, branch: sha == "origin_main_tip"),
+            ),
+        ):
+            is_merge, reason = await github_client.is_merge_or_sync_commit(
+                "owner/repo", "head123", "main"
+            )
+
+        assert is_merge is True
+
+    @pytest.mark.asyncio
     async def test_handles_ancestor_check_error_gracefully(self, github_client):
         """Should return False if the ancestry compare API call fails."""
         commit_info = {

--- a/tests/github/test_merge_detection.py
+++ b/tests/github/test_merge_detection.py
@@ -121,10 +121,13 @@ class TestMergeCommitDetection:
 
     @pytest.mark.asyncio
     async def test_detects_pr_merge_commit_by_ancestry(self, github_client):
-        """A 'Merge pull request' commit is skipped when one parent is on the base branch."""
+        """A 'Merge pull request' commit with many files is skipped via ancestry, not heuristics."""
+        # >3 files ensures the old file-count heuristic would NOT have triggered;
+        # only the ancestry check can produce is_merge=True here.
         commit_info = {
             "parents": [{"sha": "feature111"}, {"sha": "base_pr_tip"}],
             "commit": {"message": "Merge pull request #99 from user/feature"},
+            "files": [{"filename": f"file{i}.py"} for i in range(10)],
         }
 
         with (
@@ -143,10 +146,13 @@ class TestMergeCommitDetection:
 
     @pytest.mark.asyncio
     async def test_detects_remote_tracking_branch_merge_by_ancestry(self, github_client):
-        """A remote-tracking merge commit is skipped when one parent is on the base branch."""
+        """A remote-tracking merge with many files is skipped via ancestry, not heuristics."""
+        # >3 files ensures the old file-count heuristic would NOT have triggered;
+        # only the ancestry check can produce is_merge=True here.
         commit_info = {
             "parents": [{"sha": "feature111"}, {"sha": "origin_main_tip"}],
             "commit": {"message": "Merge remote-tracking branch 'origin/main' into feature"},
+            "files": [{"filename": f"file{i}.py"} for i in range(10)],
         }
 
         with (


### PR DESCRIPTION
## Summary

- **Merge detection**: replaced fragile message-pattern + ≤3-file heuristics with a parent-ancestry check via the GitHub compare API. Any merge commit where a parent is an ancestor of the base branch is now correctly identified as a sync-with-base and skipped — regardless of commit message wording, tooling, or how many upstream files changed.
- **Fidelity diff**: fidelity analysis was being passed `review_context` (the per-commit scoped diff) instead of `pr_context` (the full three-dot PR diff). On sync pushes this meant fidelity evaluated only the upstream changes, scoring 0% and reporting the author's implementation as entirely absent. One-line fix: always pass `pr_context` to `_run_fidelity_analysis`.

## Root cause

The blueden PR #1177 fidelity report scored 0% because:
1. A "fast-forward to main" commit was pushed to the branch
2. Merge detection missed it (message didn't match patterns / too many files)
3. Fidelity ran on the sync commit's diff (only main's changes) instead of the full PR diff

## Test plan
- [ ] `tests/github/test_merge_detection.py` — 6 tests covering: parent-on-base detected, non-standard message detected, large sync detected, feature-branch merge not skipped, API error handling
- [ ] Full suite: 455 passed