### PR TITLE
feat: [DEN-1663] add WEBHOOK_PRE_VERIFIED env var

### DIFF
--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -1,9 +1,12 @@
 """Configuration settings for Baloo using Pydantic."""
 
+import logging
 import os
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
@@ -147,6 +150,11 @@ def get_settings() -> Settings:
     global _settings
     if _settings is None:
         _settings = Settings()
+        if _settings.webhook_pre_verified:
+            logger.warning(
+                "WEBHOOK_PRE_VERIFIED is enabled — webhook signature verification is DISABLED. "
+                "Only use this when running behind a trusted proxy."
+            )
     return _settings
 
 

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -22,6 +22,10 @@ class Settings(BaseSettings):
     github_webhook_secret: str = Field(
         default="", description="GitHub webhook secret for signature validation"
     )
+    webhook_pre_verified: bool = Field(
+        default=False,
+        description="Skip webhook signature verification (set True when behind a trusted proxy)",
+    )
 
     # Anthropic Configuration
     anthropic_api_key: str = Field(default="", description="Anthropic API key for Claude")

--- a/baloo/github/auth.py
+++ b/baloo/github/auth.py
@@ -32,6 +32,9 @@ def verify_webhook_signature(payload_body: bytes, signature_header: str) -> bool
     """
     Verify that the webhook payload was sent from GitHub by validating its signature.
 
+    When WEBHOOK_PRE_VERIFIED is True, the signature check is skipped because
+    a trusted proxy (e.g., baloo-cloud) has already validated it.
+
     Args:
         payload_body: Raw request body bytes
         signature_header: X-Hub-Signature-256 header value
@@ -39,6 +42,9 @@ def verify_webhook_signature(payload_body: bytes, signature_header: str) -> bool
     Returns:
         True if signature is valid, False otherwise
     """
+    if settings.webhook_pre_verified:
+        return True
+
     if not signature_header:
         return False
 

--- a/baloo/github/auth.py
+++ b/baloo/github/auth.py
@@ -2,12 +2,15 @@
 
 import hashlib
 import hmac
+import logging
 import time
 from datetime import datetime, timedelta, timezone
 
 import jwt
 
 from baloo.config.settings import settings
+
+logger = logging.getLogger(__name__)
 
 
 def generate_jwt() -> str:
@@ -43,6 +46,7 @@ def verify_webhook_signature(payload_body: bytes, signature_header: str) -> bool
         True if signature is valid, False otherwise
     """
     if settings.webhook_pre_verified:
+        logger.debug("Webhook signature check skipped — WEBHOOK_PRE_VERIFIED is enabled")
         return True
 
     if not signature_header:

--- a/tests/github/test_auth.py
+++ b/tests/github/test_auth.py
@@ -1,0 +1,99 @@
+"""Tests for GitHub webhook signature verification and pre-verified mode (DEN-1663)."""
+
+import hashlib
+import hmac
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def webhook_secret():
+    return "test-webhook-secret"
+
+
+@pytest.fixture
+def payload():
+    return b'{"action": "opened", "pull_request": {"number": 1}}'
+
+
+@pytest.fixture
+def valid_signature(webhook_secret, payload):
+    """Generate a valid HMAC-SHA256 signature for the test payload."""
+    sig = hmac.new(
+        webhook_secret.encode("utf-8"),
+        payload,
+        hashlib.sha256,
+    ).hexdigest()
+    return f"sha256={sig}"
+
+
+@pytest.fixture(autouse=True)
+def reset_settings_fixture():
+    """Reset settings before and after each test to pick up env var changes."""
+    from baloo.config import settings as settings_module
+    settings_module.reset_settings()
+    yield
+    settings_module.reset_settings()
+
+
+def _verify(payload: bytes, signature: str) -> bool:
+    """Re-import auth module to pick up fresh settings."""
+    import baloo.github.auth as auth_module
+    importlib.reload(auth_module)
+    return auth_module.verify_webhook_signature(payload, signature)
+
+
+class TestVerifyWebhookSignature:
+    """Tests for verify_webhook_signature with normal signature validation."""
+
+    def test_valid_signature(self, monkeypatch, payload, valid_signature, webhook_secret):
+        """Valid signature returns True."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", webhook_secret)
+        monkeypatch.setenv("WEBHOOK_PRE_VERIFIED", "false")
+
+        assert _verify(payload, valid_signature) is True
+
+    def test_invalid_signature(self, monkeypatch, payload, webhook_secret):
+        """Invalid signature returns False."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", webhook_secret)
+        monkeypatch.setenv("WEBHOOK_PRE_VERIFIED", "false")
+
+        assert _verify(payload, "sha256=invalid") is False
+
+    def test_missing_signature_header(self, monkeypatch, payload, webhook_secret):
+        """Missing signature header returns False."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", webhook_secret)
+        monkeypatch.setenv("WEBHOOK_PRE_VERIFIED", "false")
+
+        assert _verify(payload, "") is False
+
+    def test_wrong_algorithm(self, monkeypatch, payload, webhook_secret):
+        """Non-sha256 algorithm returns False."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", webhook_secret)
+        monkeypatch.setenv("WEBHOOK_PRE_VERIFIED", "false")
+
+        assert _verify(payload, "sha1=abc123") is False
+
+
+class TestWebhookPreVerified:
+    """Tests for WEBHOOK_PRE_VERIFIED mode (DEN-1663)."""
+
+    def test_pre_verified_skips_signature_check(self, monkeypatch, payload):
+        """When WEBHOOK_PRE_VERIFIED=true, returns True without checking signature."""
+        monkeypatch.setenv("WEBHOOK_PRE_VERIFIED", "true")
+
+        assert _verify(payload, "") is True
+
+    def test_pre_verified_with_invalid_signature(self, monkeypatch, payload):
+        """When WEBHOOK_PRE_VERIFIED=true, invalid signature still returns True."""
+        monkeypatch.setenv("WEBHOOK_PRE_VERIFIED", "true")
+
+        assert _verify(payload, "sha256=tampered") is True
+
+    def test_pre_verified_default_is_false(self, monkeypatch, payload, webhook_secret):
+        """Default WEBHOOK_PRE_VERIFIED is False — signature check is active."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", webhook_secret)
+        monkeypatch.delenv("WEBHOOK_PRE_VERIFIED", raising=False)
+
+        assert _verify(payload, "sha256=invalid") is False

--- a/tests/github/test_auth.py
+++ b/tests/github/test_auth.py
@@ -32,6 +32,7 @@ def valid_signature(webhook_secret, payload):
 def reset_settings_fixture():
     """Reset settings before and after each test to pick up env var changes."""
     from baloo.config import settings as settings_module
+
     settings_module.reset_settings()
     yield
     settings_module.reset_settings()
@@ -40,6 +41,7 @@ def reset_settings_fixture():
 def _verify(payload: bytes, signature: str) -> bool:
     """Re-import auth module to pick up fresh settings."""
     import baloo.github.auth as auth_module
+
     importlib.reload(auth_module)
     return auth_module.verify_webhook_signature(payload, signature)
 


### PR DESCRIPTION
## Summary

Adds `WEBHOOK_PRE_VERIFIED` env var so baloo-bear can skip webhook signature verification when running behind a trusted proxy (baloo-cloud).

## Changes

- `baloo/config/settings.py`: New `webhook_pre_verified` bool setting (default: `false`)
- `baloo/github/auth.py`: Early return in `verify_webhook_signature()` when enabled
- `tests/github/test_auth.py`: 7 tests covering both paths

## Why

When baloo-bear runs behind the baloo-cloud proxy, the proxy already validates the webhook signature. Re-validation would fail because the signature was computed against the original request, not the forwarded one.

## Usage

```bash
WEBHOOK_PRE_VERIFIED=true  # Skip signature check (trusted proxy mode)
WEBHOOK_PRE_VERIFIED=false # Normal mode (default)
```

## Linear

https://linear.app/bluebearsecurity/issue/DEN-1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)