### PR TITLE
feat: AST-enriched context for the review agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ nikui_results/
 
 # docs/plans — previously ignored, now tracked for feature design docs
 node_modules/
+extensions/node_modules/
 .husky/_/
 
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,10 @@ RUN pip install --no-cache-dir -e .
 # Install PI coding agent globally (provides the 'pi' CLI)
 RUN npm install -g @mariozechner/pi-coding-agent
 
+# Install AST tools extension dependencies
+COPY extensions/package.json /app/extensions/package.json
+RUN cd /app/extensions && npm install --production
+
 # Copy application code
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN pip install --no-cache-dir -e .
 RUN npm install -g @mariozechner/pi-coding-agent
 
 # Install AST tools extension dependencies
-COPY extensions/package.json /app/extensions/package.json
-RUN cd /app/extensions && npm install --production
+COPY extensions/package.json extensions/package-lock.json /app/extensions/
+RUN cd /app/extensions && npm ci --production
 
 # Copy application code
 COPY . .

--- a/baloo/agent/config.py
+++ b/baloo/agent/config.py
@@ -3,7 +3,7 @@
 import logging
 
 from baloo.agent.pi_runtime import PIAgentOptions
-from baloo.agent.prompts import REVIEW_SYSTEM_PROMPT
+from baloo.agent.prompts import AST_TOOLS_PROMPT_SECTION, REVIEW_SYSTEM_PROMPT
 from baloo.config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -26,6 +26,14 @@ MODEL_MAP = {name: spec[1] for name, spec in MODEL_REGISTRY.items()}
 MAX_TURNS = {name: spec[2] for name, spec in MODEL_REGISTRY.items()}
 
 
+def _build_system_prompt() -> str:
+    """Build the system prompt, conditionally including the AST tools section."""
+    prompt = REVIEW_SYSTEM_PROMPT
+    if settings.ast_tools_enabled:
+        prompt += AST_TOOLS_PROMPT_SECTION
+    return prompt
+
+
 def get_agent_options(model: str = None, thinking_level: str | None = None) -> PIAgentOptions:
     """
     Get PI agent configuration options.
@@ -41,6 +49,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
         PIAgentOptions configured for read-only code review
     """
     level = thinking_level or settings.pi_thinking_level
+    system_prompt = _build_system_prompt()
 
     # 1. Short name lookup
     if model and model in MODEL_REGISTRY:
@@ -48,7 +57,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
         return PIAgentOptions(
             model=model_id,
             provider=provider,
-            system_prompt=REVIEW_SYSTEM_PROMPT,
+            system_prompt=system_prompt,
             thinking_level=level,
             max_turns=max_turns,
         )
@@ -59,7 +68,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
         return PIAgentOptions(
             model=model_id,
             provider=provider,
-            system_prompt=REVIEW_SYSTEM_PROMPT,
+            system_prompt=system_prompt,
             thinking_level=level,
             max_turns=20,
         )
@@ -69,7 +78,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
         return PIAgentOptions(
             model=model,
             provider="anthropic",
-            system_prompt=REVIEW_SYSTEM_PROMPT,
+            system_prompt=system_prompt,
             thinking_level=level,
             max_turns=20,
         )
@@ -81,7 +90,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
         return PIAgentOptions(
             model=model_id,
             provider=provider,
-            system_prompt=REVIEW_SYSTEM_PROMPT,
+            system_prompt=system_prompt,
             thinking_level=level,
             max_turns=max_turns,
         )
@@ -89,7 +98,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
     return PIAgentOptions(
         model=default_model,
         provider=settings.agent_provider,
-        system_prompt=REVIEW_SYSTEM_PROMPT,
+        system_prompt=system_prompt,
         thinking_level=level,
         max_turns=20,
     )

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -16,10 +16,11 @@ import re
 import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from baloo.agent.costs import normalize_usage
-from baloo.config.settings import get_settings
+from baloo.config.settings import get_settings, settings
 
 logger = logging.getLogger(__name__)
 
@@ -421,31 +422,9 @@ class PIAgentBase:
             "max_turns_reached": result.max_turns_reached,
         }
 
-    # -----------------------------------------------------------------
-    # Main query interface
-    # -----------------------------------------------------------------
-
-    async def run_query(self, query: str, review_logger: Any = None) -> tuple[Any, dict[str, Any]]:
-        """Run a query through the PI agent and return structured output + metadata.
-
-        Returns:
-            Tuple of (parsed_json_output_or_None, metadata_dict)
-        """
-        settings = get_settings()
-        start_time = time.time()
-        result = PIRunResult()
-
-        from baloo.agent.logger import ReviewLogger
-
-        if review_logger is None:
-            review_logger = ReviewLogger(review_id=None)
-
-        await review_logger.agent_started(
-            model=self.options.model, thinking_level=self.options.thinking_level
-        )
-
+    def _build_pi_command(self) -> list[str]:
+        """Build the PI CLI command list."""
         pi_binary = settings.pi_binary_path or "pi"
-        cwd = self.options.cwd or None
 
         cmd = [
             pi_binary,
@@ -460,10 +439,44 @@ class PIAgentBase:
         if self.options.no_tools:
             cmd.append("--no-tools")
         else:
-            # Read-only tools only — no bash, no write, no edit
             cmd.extend(["--tools", "read,grep,find,ls"])
-        # Inject system prompt
+
+            # Load AST tools extension when enabled
+            if settings.ast_tools_enabled:
+                ext_path = (
+                    Path(__file__).resolve().parent.parent.parent
+                    / "extensions"
+                    / "baloo-ast-tools.ts"
+                )
+                cmd.extend(["--extension", str(ext_path)])
+
         cmd.extend(["--system-prompt", self.options.system_prompt])
+        return cmd
+
+    # -----------------------------------------------------------------
+    # Main query interface
+    # -----------------------------------------------------------------
+
+    async def run_query(self, query: str, review_logger: Any = None) -> tuple[Any, dict[str, Any]]:
+        """Run a query through the PI agent and return structured output + metadata.
+
+        Returns:
+            Tuple of (parsed_json_output_or_None, metadata_dict)
+        """
+        start_time = time.time()
+        result = PIRunResult()
+
+        from baloo.agent.logger import ReviewLogger
+
+        if review_logger is None:
+            review_logger = ReviewLogger(review_id=None)
+
+        await review_logger.agent_started(
+            model=self.options.model, thinking_level=self.options.thinking_level
+        )
+
+        cmd = self._build_pi_command()
+        cwd = self.options.cwd or None
 
         logger.info(
             "%s: spawning PI process (model=%s, thinking=%s)",

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from baloo.agent.costs import normalize_usage
-from baloo.config.settings import get_settings, settings
+from baloo.config.settings import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -424,7 +424,8 @@ class PIAgentBase:
 
     def _build_pi_command(self) -> list[str]:
         """Build the PI CLI command list."""
-        pi_binary = settings.pi_binary_path or "pi"
+        s = get_settings()
+        pi_binary = s.pi_binary_path or "pi"
 
         cmd = [
             pi_binary,
@@ -442,7 +443,7 @@ class PIAgentBase:
             cmd.extend(["--tools", "read,grep,find,ls"])
 
             # Load AST tools extension when enabled
-            if settings.ast_tools_enabled:
+            if s.ast_tools_enabled:
                 ext_path = (
                     Path(__file__).resolve().parent.parent.parent
                     / "extensions"

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -29,6 +29,14 @@ Flag only issues **introduced or made worse by this PR's changes**. Pre-existing
 ## Workflow
 1. Read changed files (full context with read tool) 2. grep for security patterns 3. find/ls for tests/configs
 
+## AST Tools
+You have structural code analysis tools available alongside read/grep/find/ls:
+- **ast_outline**: Get the symbol structure of a file (functions, classes, methods with line ranges). Use to understand what scope a diff hunk lives in.
+- **ast_grep**: Search for code patterns by structure using metavariables ($VAR matches any expression, $$$ matches multiple). Examples: `except $ERR: pass`, `subprocess.run($$$, shell=True)`. Use to find related patterns across the codebase.
+- **ast_symbols**: Find where a symbol is defined and referenced. Use to follow call chains and verify change impact before assigning severity.
+
+Use these selectively — not on every file, but when you need structural context to verify a finding's scope, severity, or impact.
+
 ## Critical Rules to Prevent False Positives
 - **ALWAYS use read tool** before claiming code is missing/undefined
 - **NEVER flag code as missing** without verifying the entire file

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -21,13 +21,7 @@ REVIEW_SEVERITY_GUIDELINES = """## Severity Guidelines
 - **LOW**: Style or minor polish improvements
 """
 
-REVIEW_SYSTEM_PROMPT = f"""You are Baloo, expert code reviewer. Use read/grep/find/ls tools proactively.
-
-## Scope
-Flag only issues **introduced or made worse by this PR's changes**. Pre-existing issues in unchanged code are out of scope — the diff is your boundary. Read full files for context, but anchor every finding to a changed line.
-
-## Workflow
-1. Read changed files (full context with read tool) 2. grep for security patterns 3. find/ls for tests/configs
+AST_TOOLS_PROMPT_SECTION = """
 
 ## AST Tools
 You have structural code analysis tools available alongside read/grep/find/ls:
@@ -36,6 +30,15 @@ You have structural code analysis tools available alongside read/grep/find/ls:
 - **ast_symbols**: Find where a symbol is defined and referenced. Use to follow call chains and verify change impact before assigning severity.
 
 Use these selectively — not on every file, but when you need structural context to verify a finding's scope, severity, or impact.
+"""
+
+REVIEW_SYSTEM_PROMPT = f"""You are Baloo, expert code reviewer. Use read/grep/find/ls tools proactively.
+
+## Scope
+Flag only issues **introduced or made worse by this PR's changes**. Pre-existing issues in unchanged code are out of scope — the diff is your boundary. Read full files for context, but anchor every finding to a changed line.
+
+## Workflow
+1. Read changed files (full context with read tool) 2. grep for security patterns 3. find/ls for tests/configs
 
 ## Critical Rules to Prevent False Positives
 - **ALWAYS use read tool** before claiming code is missing/undefined

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -143,6 +143,12 @@ class Settings(BaseSettings):
         description="Days before unmatched feedback signals expire",
     )
 
+    # AST Tools Configuration
+    ast_tools_enabled: bool = Field(
+        default=True,
+        description="Enable AST analysis tools (outline, grep, symbols) for the review agent",
+    )
+
     # Fidelity Report Configuration
     fidelity_enabled: bool = Field(
         default=True,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,33 +7,12 @@ of findings and produces a single merged review, keeping findings both models
 agree on and adjudicating conflicts.  Goal: higher recall without more false
 positives.
 
-## 2. Conversational thread agent
-When a developer replies to a Baloo inline comment (`pull_request_review_comment`
-event), don't re-review the whole PR.  Instead, run a lightweight
-thread-reply agent that:
-- Sees only the specific thread (Baloo's finding + developer's response)
-- Decides: acknowledge, clarify, or concede
-- Posts a targeted reply in the same thread
+## ~~2. Conversational thread agent~~ ✅ Shipped
+Implemented in PR #36. See [docs/features/thread-agent.md](features/thread-agent.md).
 
-Also use this as a **feedback loop**: if the developer says "this is a false
-positive" or "this is intentional", log it and use the signal to improve
-prompts and the FP-reduction pass over time.
+## 3. AST-enriched context for the review agent — 🚧 In Progress
+PI extension providing structural code analysis tools (ast_outline, ast_grep, ast_symbols)
+via `@ast-grep/napi`. The agent can query file structure, search patterns by syntax tree,
+and follow symbol definitions/references to improve finding accuracy.
 
-> Comment-triggered events (`issue_comment`, `pull_request_review_comment`,
-> `pull_request_review`) are currently disabled in the webhook handler.
-> Re-enable selectively when implementing this feature.
-
-## 3. AST-enriched context for the review agent
-Before the PI agent reviews a PR, parse changed files into ASTs and provide
-structural context alongside the raw diff.  This gives the agent:
-- Function/class boundaries for each hunk ("this change is inside `AuthService.validate_token`")
-- Call-graph snippets (callers/callees of changed functions)
-- Symbol cross-references (where else is this function/variable used?)
-
-Inspired by GitNexus-style semantic analysis.  Implementation path:
-1. Run a lightweight AST parser (tree-sitter) on the changed files
-2. Extract scope info, symbol table, and call edges
-3. Inject a structured summary into the agent prompt as additional context
-4. Optionally expose as a PI tool so the agent can query the AST on demand
-
-Language support: start with Python + TypeScript, expand based on repo usage.
+Language support: Python, TypeScript/JavaScript, and Go.

--- a/extensions/baloo-ast-tools.ts
+++ b/extensions/baloo-ast-tools.ts
@@ -17,6 +17,14 @@ registerDynamicLanguage({ python, go });
 
 type LangId = Lang | string;
 
+const LANG_EXTS: Record<string, string[]> = {
+  python: [".py", ".pyi"],
+  typescript: [".ts"],
+  tsx: [".tsx"],
+  javascript: [".js", ".jsx"],
+  go: [".go"],
+};
+
 const EXT_TO_LANG: Record<string, LangId> = {
   ".py": "python",
   ".pyi": "python",
@@ -267,6 +275,33 @@ export function collectFiles(dirPath: string, extensions: string[]): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// Language resolver for ast_grep
+// ---------------------------------------------------------------------------
+
+function resolveLang(lang: string): LangId {
+  const map: Record<string, LangId> = {
+    python: "python",
+    typescript: Lang.TypeScript,
+    tsx: Lang.Tsx,
+    javascript: Lang.JavaScript,
+    go: "go",
+  };
+  return map[lang] ?? lang;
+}
+
+// ---------------------------------------------------------------------------
+// Directories to skip during file collection for ast_grep
+// ---------------------------------------------------------------------------
+
+const SKIP_DIRS = new Set([
+  "__pycache__",
+  ".venv",
+  "venv",
+  "dist",
+  "build",
+]);
+
+// ---------------------------------------------------------------------------
 // Extension entry point
 // ---------------------------------------------------------------------------
 
@@ -324,6 +359,147 @@ export default function balooAstTools(pi: ExtensionAPI): void {
       return {
         content: [{ type: "text" as const, text }],
         details: { symbolCount },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "ast_grep",
+    label: "AST Grep",
+    description:
+      "Search for code patterns by structure using ast-grep. " +
+      "Use $VAR to match any single expression/identifier, $$$ for multiple arguments or statements. " +
+      "Examples: 'except $ERR: pass', 'subprocess.run($$$, shell=True)', 'if err != nil { return $$$, $ERR }'. " +
+      "Supports Python, TypeScript, JavaScript, and Go.",
+    parameters: Type.Object({
+      pattern: Type.String({ description: "ast-grep pattern with metavariables ($VAR, $$$)" }),
+      language: Type.String({ description: "Language: python, typescript, javascript, tsx, go" }),
+      path: Type.Optional(Type.String({ description: "File or directory to search (defaults to cwd)" })),
+    }),
+    async execute(
+      _toolCallId: string,
+      params: { pattern: string; language: string; path?: string },
+      _signal: AbortSignal,
+      _onUpdate: unknown,
+      ctx: { cwd?: string },
+    ) {
+      const { pattern, language } = params;
+      const searchPath = params.path ?? ctx.cwd ?? ".";
+      const langId = resolveLang(language);
+      const extensions = LANG_EXTS[language];
+
+      if (!extensions) {
+        return {
+          content: [{ type: "text" as const, text: `Unsupported language: ${language}` }],
+        };
+      }
+
+      // Collect files, skipping extra directories beyond what collectFiles already skips
+      function collectFilesFiltered(dirPath: string, exts: string[]): string[] {
+        const results: string[] = [];
+        try {
+          const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+          for (const entry of entries) {
+            const fullPath = path.join(dirPath, entry.name);
+            if (entry.isDirectory()) {
+              if (
+                entry.name.startsWith(".") ||
+                entry.name === "node_modules" ||
+                SKIP_DIRS.has(entry.name)
+              ) {
+                continue;
+              }
+              results.push(...collectFilesFiltered(fullPath, exts));
+            } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+              results.push(fullPath);
+            }
+          }
+        } catch {
+          // Ignore unreadable directories
+        }
+        return results;
+      }
+
+      // Determine if searchPath is a file or directory
+      let files: string[];
+      try {
+        const stat = fs.statSync(searchPath);
+        if (stat.isFile()) {
+          files = [searchPath];
+        } else {
+          files = collectFilesFiltered(searchPath, extensions);
+        }
+      } catch {
+        return {
+          content: [{ type: "text" as const, text: `Path not found: ${searchPath}` }],
+        };
+      }
+
+      // Cap at 500 files
+      if (files.length > 500) {
+        files = files.slice(0, 500);
+      }
+
+      const MAX_MATCHES = 30;
+      const matchLines: string[] = [];
+      let totalMatches = 0;
+
+      outer: for (const filePath of files) {
+        const source = readFileText(filePath);
+        if (source === null) continue;
+
+        let tree;
+        try {
+          tree = parse(langId, source);
+        } catch {
+          continue;
+        }
+
+        const sourceLines = source.split("\n");
+        let matches;
+        try {
+          matches = tree.root().findAll(pattern);
+        } catch {
+          continue;
+        }
+
+        for (const node of matches) {
+          if (totalMatches >= MAX_MATCHES) break outer;
+
+          const range = node.range();
+          const matchLine = range.start.line; // 0-indexed
+          const displayLine = matchLine + 1;  // 1-indexed for display
+
+          // Collect context: 1 line before, the match line, 1 line after
+          const contextStart = Math.max(0, matchLine - 1);
+          const contextEnd = Math.min(sourceLines.length - 1, matchLine + 1);
+          const contextText = sourceLines
+            .slice(contextStart, contextEnd + 1)
+            .map((l, i) => `  ${l}`)
+            .join("\n");
+
+          matchLines.push(`${filePath}:${displayLine}\n${contextText}`);
+          totalMatches++;
+        }
+      }
+
+      if (totalMatches === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No matches for pattern \`${pattern}\` in ${searchPath}`,
+            },
+          ],
+        };
+      }
+
+      const header = `Found ${totalMatches} match(es):\n`;
+      const text = header + "\n" + matchLines.join("\n\n");
+
+      return {
+        content: [{ type: "text" as const, text }],
+        details: { matchCount: totalMatches },
       };
     },
   });

--- a/extensions/baloo-ast-tools.ts
+++ b/extensions/baloo-ast-tools.ts
@@ -47,7 +47,8 @@ export function detectLanguage(filePath: string): LangId | null {
 export function readFileText(filePath: string): string | null {
   try {
     return fs.readFileSync(filePath, "utf-8");
-  } catch {
+  } catch (err) {
+    console.error(`[ast-tools] Failed to read ${filePath}: ${err}`);
     return null;
   }
 }
@@ -443,6 +444,7 @@ export default function balooAstTools(pi: ExtensionAPI): void {
       const MAX_MATCHES = 30;
       const matchLines: string[] = [];
       let totalMatches = 0;
+      let firstFileProcessed = false;
 
       outer: for (const filePath of files) {
         const source = readFileText(filePath);
@@ -459,9 +461,20 @@ export default function balooAstTools(pi: ExtensionAPI): void {
         let matches;
         try {
           matches = tree.root().findAll(pattern);
-        } catch {
+        } catch (err) {
+          if (!firstFileProcessed) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Invalid pattern \`${pattern}\`: ${err}`,
+                },
+              ],
+            };
+          }
           continue;
         }
+        firstFileProcessed = true;
 
         for (const node of matches) {
           if (totalMatches >= MAX_MATCHES) break outer;
@@ -662,13 +675,15 @@ export default function balooAstTools(pi: ExtensionAPI): void {
         }
 
         // --- Text-based reference search ---
+        const escapedName = symbolName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const symbolRegex = new RegExp(`\\b${escapedName}\\b`);
         if (references.length < MAX_REFS) {
           for (let i = 0; i < sourceLines.length; i++) {
             if (references.length >= MAX_REFS) break;
             const lineNum = i + 1;
             const key = `${filePath}:${lineNum}`;
             if (defLineSet.has(key)) continue; // already a definition
-            if (sourceLines[i].includes(symbolName)) {
+            if (symbolRegex.test(sourceLines[i])) {
               references.push({
                 file: filePath,
                 line: lineNum,

--- a/extensions/baloo-ast-tools.ts
+++ b/extensions/baloo-ast-tools.ts
@@ -1,0 +1,330 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { registerDynamicLanguage, parse, Lang, type SgNode } from "@ast-grep/napi";
+import python from "@ast-grep/lang-python";
+import go from "@ast-grep/lang-go";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Language registration — Python and Go are dynamic; TS/JS are built-in.
+// ---------------------------------------------------------------------------
+registerDynamicLanguage({ python, go });
+
+// ---------------------------------------------------------------------------
+// Language detection
+// ---------------------------------------------------------------------------
+
+type LangId = Lang | string;
+
+const EXT_TO_LANG: Record<string, LangId> = {
+  ".py": "python",
+  ".pyi": "python",
+  ".ts": Lang.TypeScript,
+  ".tsx": Lang.Tsx,
+  ".js": Lang.JavaScript,
+  ".jsx": Lang.JavaScript,
+  ".go": "go",
+};
+
+export function detectLanguage(filePath: string): LangId | null {
+  const ext = path.extname(filePath).toLowerCase();
+  return EXT_TO_LANG[ext] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// File reading helper
+// ---------------------------------------------------------------------------
+
+export function readFileText(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol node kinds per language
+// ---------------------------------------------------------------------------
+
+const SYMBOL_KINDS: Record<string, string[]> = {
+  python: ["function_definition", "class_definition", "decorated_definition"],
+  [Lang.TypeScript]: [
+    "function_declaration",
+    "class_declaration",
+    "method_definition",
+    "arrow_function",
+    "interface_declaration",
+    "type_alias_declaration",
+  ],
+  [Lang.Tsx]: [
+    "function_declaration",
+    "class_declaration",
+    "method_definition",
+    "arrow_function",
+    "interface_declaration",
+    "type_alias_declaration",
+  ],
+  [Lang.JavaScript]: [
+    "function_declaration",
+    "class_declaration",
+    "method_definition",
+    "arrow_function",
+  ],
+  go: [
+    "function_declaration",
+    "method_declaration",
+    "type_declaration",
+    "type_spec",
+  ],
+};
+
+// Node kinds that carry a symbol name.
+const NAME_KINDS = new Set([
+  "identifier",
+  "name",
+  "property_identifier",
+  "type_identifier",
+]);
+
+// ---------------------------------------------------------------------------
+// Symbol extraction
+// ---------------------------------------------------------------------------
+
+export interface SymbolInfo {
+  kind: string;
+  name: string;
+  startLine: number; // 1-indexed
+  endLine: number; // 1-indexed
+  children: SymbolInfo[];
+}
+
+/**
+ * Walk the AST and collect symbol definitions up to `maxDepth` levels deep.
+ */
+function walkSymbols(
+  node: SgNode,
+  lang: string,
+  depth: number,
+  maxDepth: number,
+): SymbolInfo[] {
+  if (depth > maxDepth) return [];
+
+  const kindsList = SYMBOL_KINDS[lang];
+  if (!kindsList) return [];
+
+  const symbols: SymbolInfo[] = [];
+
+  for (const child of node.children()) {
+    const k = child.kind() as string;
+
+    if (!kindsList.includes(k)) {
+      // Not a symbol node — but recurse into it because symbols may be nested
+      // (e.g. inside module bodies, namespace blocks, etc.)
+      const nested = walkSymbols(child, lang, depth, maxDepth);
+      symbols.push(...nested);
+      continue;
+    }
+
+    // Handle Python decorated_definition: the actual def/class is inside.
+    if (k === "decorated_definition") {
+      const inner = findInnerDefinition(child, lang);
+      if (inner) {
+        const range = child.range();
+        const sym: SymbolInfo = {
+          kind: inner.kind() as string,
+          name: extractName(inner),
+          startLine: range.start.line + 1,
+          endLine: range.end.line + 1,
+          children: walkSymbols(inner, lang, depth + 1, maxDepth),
+        };
+        symbols.push(sym);
+      }
+      continue;
+    }
+
+    const range = child.range();
+    const sym: SymbolInfo = {
+      kind: k,
+      name: extractName(child),
+      startLine: range.start.line + 1,
+      endLine: range.end.line + 1,
+      children: walkSymbols(child, lang, depth + 1, maxDepth),
+    };
+    symbols.push(sym);
+  }
+
+  return symbols;
+}
+
+/**
+ * For a `decorated_definition` node, find the inner function/class definition.
+ */
+function findInnerDefinition(
+  node: SgNode,
+  lang: string,
+): SgNode | null {
+  const kindsList = SYMBOL_KINDS[lang];
+  if (!kindsList) return null;
+  for (const child of node.children()) {
+    const k = child.kind() as string;
+    if (k !== "decorated_definition" && kindsList.includes(k)) {
+      return child;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the name of a symbol node by looking for name-bearing child nodes.
+ */
+function extractName(node: SgNode): string {
+  for (const child of node.children()) {
+    if (NAME_KINDS.has(child.kind() as string)) {
+      return child.text();
+    }
+  }
+  return "<anonymous>";
+}
+
+/**
+ * Parse a file and extract all symbols.
+ */
+export function extractSymbols(
+  filePath: string,
+  maxDepth: number = 2,
+): { lang: string; symbols: SymbolInfo[] } | string {
+  const lang = detectLanguage(filePath);
+  if (!lang) {
+    return `Unsupported file type: ${path.extname(filePath) || "(no extension)"}`;
+  }
+
+  const source = readFileText(filePath);
+  if (source === null) {
+    return `Could not read file: ${filePath}`;
+  }
+
+  const tree = parse(lang, source);
+  const root = tree.root();
+  const symbols = walkSymbols(root, lang as string, 1, maxDepth);
+
+  return { lang: lang as string, symbols };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+function formatSymbols(
+  symbols: SymbolInfo[],
+  indent: string = "  ",
+): string {
+  const lines: string[] = [];
+  for (const sym of symbols) {
+    const range = `${sym.startLine}-${sym.endLine}`;
+    const kindLabel = sym.kind.replace(/_/g, " ");
+    lines.push(`${indent}${range.padEnd(8)} ${kindLabel} ${sym.name}`);
+    if (sym.children.length > 0) {
+      lines.push(formatSymbols(sym.children, indent + "  "));
+    }
+  }
+  return lines.join("\n");
+}
+
+function countSymbols(symbols: SymbolInfo[]): number {
+  let count = symbols.length;
+  for (const sym of symbols) {
+    count += countSymbols(sym.children);
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Collect files helper (for potential multi-file use by later tools)
+// ---------------------------------------------------------------------------
+
+export function collectFiles(dirPath: string, extensions: string[]): string[] {
+  const results: string[] = [];
+  try {
+    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        // Skip hidden dirs and node_modules
+        if (entry.name.startsWith(".") || entry.name === "node_modules") {
+          continue;
+        }
+        results.push(...collectFiles(fullPath, extensions));
+      } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
+        results.push(fullPath);
+      }
+    }
+  } catch {
+    // Ignore unreadable directories
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+export default function balooAstTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "ast_outline",
+    label: "AST Outline",
+    description:
+      "List all symbols (functions, classes, methods, interfaces, type aliases) in a file with their line ranges. " +
+      "Useful for quickly understanding a file's structure without reading the full source.",
+    parameters: Type.Object({
+      path: Type.String({ description: "File path to outline" }),
+      max_depth: Type.Optional(
+        Type.Number({
+          description: "Max nesting depth (default 2)",
+          default: 2,
+        }),
+      ),
+    }),
+    async execute(
+      _toolCallId: string,
+      params: { path: string; max_depth?: number },
+      _signal: AbortSignal,
+      _onUpdate: unknown,
+      _ctx: unknown,
+    ) {
+      const filePath = params.path;
+      const maxDepth = params.max_depth ?? 2;
+
+      const result = extractSymbols(filePath, maxDepth);
+
+      if (typeof result === "string") {
+        // Error message
+        return {
+          content: [{ type: "text" as const, text: result }],
+          details: { symbolCount: 0 },
+        };
+      }
+
+      const { lang, symbols } = result;
+
+      if (symbols.length === 0) {
+        const text = `${filePath} (${lang})\n  No symbols found.`;
+        return {
+          content: [{ type: "text" as const, text }],
+          details: { symbolCount: 0 },
+        };
+      }
+
+      const header = `${filePath} (${lang})`;
+      const body = formatSymbols(symbols);
+      const text = `${header}\n${body}`;
+      const symbolCount = countSymbols(symbols);
+
+      return {
+        content: [{ type: "text" as const, text }],
+        details: { symbolCount },
+      };
+    },
+  });
+}

--- a/extensions/baloo-ast-tools.ts
+++ b/extensions/baloo-ast-tools.ts
@@ -503,4 +503,215 @@ export default function balooAstTools(pi: ExtensionAPI): void {
       };
     },
   });
+
+  pi.registerTool({
+    name: "ast_symbols",
+    label: "AST Symbols",
+    description:
+      "Find where a symbol is defined and referenced across the codebase. " +
+      "Definitions are located via AST patterns (precise); references are located via text search (line contains symbol name). " +
+      "Useful for understanding how a function, class, or variable is used throughout the project.",
+    parameters: Type.Object({
+      name: Type.String({ description: "Symbol name to search for (e.g. 'validate_token')" }),
+      language: Type.String({ description: "Language: python, typescript, javascript, tsx, go" }),
+      path: Type.Optional(Type.String({ description: "Directory to search (defaults to cwd)" })),
+    }),
+    async execute(
+      _toolCallId: string,
+      params: { name: string; language: string; path?: string },
+      _signal: AbortSignal,
+      _onUpdate: unknown,
+      ctx: { cwd?: string },
+    ) {
+      const { name: symbolName, language } = params;
+      const searchPath = params.path ?? ctx.cwd ?? ".";
+      const langId = resolveLang(language);
+      const extensions = LANG_EXTS[language];
+
+      if (!extensions) {
+        return {
+          content: [{ type: "text" as const, text: `Unsupported language: ${language}` }],
+        };
+      }
+
+      // Collect files using the filtered variant (skips hidden dirs, node_modules, SKIP_DIRS)
+      function collectFilesFiltered(dirPath: string, exts: string[]): string[] {
+        const results: string[] = [];
+        try {
+          const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+          for (const entry of entries) {
+            const fullPath = path.join(dirPath, entry.name);
+            if (entry.isDirectory()) {
+              if (
+                entry.name.startsWith(".") ||
+                entry.name === "node_modules" ||
+                SKIP_DIRS.has(entry.name)
+              ) {
+                continue;
+              }
+              results.push(...collectFilesFiltered(fullPath, exts));
+            } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+              results.push(fullPath);
+            }
+          }
+        } catch {
+          // Ignore unreadable directories
+        }
+        return results;
+      }
+
+      // Determine if searchPath is a file or directory
+      let files: string[];
+      try {
+        const stat = fs.statSync(searchPath);
+        if (stat.isFile()) {
+          files = [searchPath];
+        } else {
+          files = collectFilesFiltered(searchPath, extensions);
+        }
+      } catch {
+        return {
+          content: [{ type: "text" as const, text: `Path not found: ${searchPath}` }],
+        };
+      }
+
+      // Build language-specific definition patterns
+      const defPatterns: string[] = [];
+      if (language === "python") {
+        defPatterns.push(
+          `def ${symbolName}($$$)`,
+          `class ${symbolName}($$$)`,
+          `class ${symbolName}:`,
+          `${symbolName} = $VALUE`,
+        );
+      } else if (
+        language === "typescript" ||
+        language === "javascript" ||
+        language === "tsx"
+      ) {
+        defPatterns.push(
+          `function ${symbolName}($$$)`,
+          `class ${symbolName} $$$`,
+          `const ${symbolName} = $$$`,
+          `let ${symbolName} = $$$`,
+          `interface ${symbolName} $$$`,
+          `type ${symbolName} = $$$`,
+          `export function ${symbolName}($$$)`,
+          `export class ${symbolName} $$$`,
+          `export const ${symbolName} = $$$`,
+        );
+      } else if (language === "go") {
+        defPatterns.push(
+          `func ${symbolName}($$$)`,
+          `func ($RECV) ${symbolName}($$$)`,
+          `type ${symbolName} $$$`,
+          `var ${symbolName} $$$`,
+        );
+      }
+
+      const MAX_DEFS = 20;
+      const MAX_REFS = 20;
+
+      interface SymbolMatch {
+        file: string;
+        line: number; // 1-indexed
+        text: string; // trimmed line text
+      }
+
+      const definitions: SymbolMatch[] = [];
+      // Track (file, line) pairs that are definitions, to exclude from references
+      const defLineSet = new Set<string>();
+      const references: SymbolMatch[] = [];
+
+      for (const filePath of files) {
+        const source = readFileText(filePath);
+        if (source === null) continue;
+
+        let tree;
+        try {
+          tree = parse(langId, source);
+        } catch {
+          continue;
+        }
+
+        const root = tree.root();
+        const sourceLines = source.split("\n");
+
+        // --- AST-based definition search ---
+        for (const pattern of defPatterns) {
+          if (definitions.length >= MAX_DEFS) break;
+          let matches;
+          try {
+            matches = root.findAll(pattern);
+          } catch {
+            continue;
+          }
+          for (const node of matches) {
+            if (definitions.length >= MAX_DEFS) break;
+            const lineIdx = node.range().start.line; // 0-indexed
+            const lineNum = lineIdx + 1; // 1-indexed
+            const key = `${filePath}:${lineNum}`;
+            if (defLineSet.has(key)) continue;
+            defLineSet.add(key);
+            definitions.push({
+              file: filePath,
+              line: lineNum,
+              text: (sourceLines[lineIdx] ?? "").trimEnd(),
+            });
+          }
+        }
+
+        // --- Text-based reference search ---
+        if (references.length < MAX_REFS) {
+          for (let i = 0; i < sourceLines.length; i++) {
+            if (references.length >= MAX_REFS) break;
+            const lineNum = i + 1;
+            const key = `${filePath}:${lineNum}`;
+            if (defLineSet.has(key)) continue; // already a definition
+            if (sourceLines[i].includes(symbolName)) {
+              references.push({
+                file: filePath,
+                line: lineNum,
+                text: sourceLines[i].trim(),
+              });
+            }
+          }
+        }
+      }
+
+      // --- Format output ---
+      const lines: string[] = [];
+      lines.push(`Symbol: ${symbolName}`);
+      lines.push("");
+
+      if (definitions.length === 0) {
+        lines.push("Defined in:");
+        lines.push("  (none found)");
+      } else {
+        lines.push("Defined in:");
+        for (const def of definitions) {
+          lines.push(`  ${def.file}:${def.line}  ${def.text}`);
+        }
+      }
+
+      lines.push("");
+
+      if (references.length === 0) {
+        lines.push("Referenced in:");
+        lines.push("  (none found)");
+      } else {
+        lines.push("Referenced in:");
+        for (const ref of references) {
+          lines.push(`  ${ref.file}:${ref.line}   ${ref.text}`);
+        }
+      }
+
+      const text = lines.join("\n");
+
+      return {
+        content: [{ type: "text" as const, text }],
+        details: { definitions: definitions.length, references: references.length },
+      };
+    },
+  });
 }

--- a/extensions/package-lock.json
+++ b/extensions/package-lock.json
@@ -1,0 +1,265 @@
+{
+  "name": "baloo-ast-tools",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "baloo-ast-tools",
+      "version": "1.0.0",
+      "dependencies": {
+        "@ast-grep/lang-go": "^0.0.6",
+        "@ast-grep/lang-python": "^0.0.6",
+        "@ast-grep/napi": "^0.42.0",
+        "typebox": "^1.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.2",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@ast-grep/lang-go": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ast-grep/lang-go/-/lang-go-0.0.6.tgz",
+      "integrity": "sha512-PZap9Rp6t+YKbLjRnFRF5aGBX3/HV9s5Rp7ZPsCM+o3tlTZDo1IqDYnFu+Oeh5Razs2U8K8ccPSJ+GBxalVhWg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "@ast-grep/setup-lang": "0.0.6"
+      },
+      "peerDependencies": {
+        "tree-sitter-cli": "0.25.8"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ast-grep/lang-python": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ast-grep/lang-python/-/lang-python-0.0.6.tgz",
+      "integrity": "sha512-eF/bEBspmrxdVuPNihvZDyyJx5qtIpGEMz9l1nNQmrji7NZcUiRNC8WwzYyQCBdy1mj8HZ0Tn4I2q3gp/6Bkiw==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "@ast-grep/setup-lang": "0.0.6"
+      },
+      "peerDependencies": {
+        "tree-sitter-cli": "0.25.8"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ast-grep/napi": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi/-/napi-0.42.1.tgz",
+      "integrity": "sha512-+YEv9ElJi9azr8AYII79NxYXQRJsrUy1kUqZfxZfvPM7rhs3174mzB+qEE9Pl3sVKAJS5cevyT4lgLNV0AZK6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@ast-grep/napi-darwin-arm64": "0.42.1",
+        "@ast-grep/napi-darwin-x64": "0.42.1",
+        "@ast-grep/napi-linux-arm64-gnu": "0.42.1",
+        "@ast-grep/napi-linux-arm64-musl": "0.42.1",
+        "@ast-grep/napi-linux-x64-gnu": "0.42.1",
+        "@ast-grep/napi-linux-x64-musl": "0.42.1",
+        "@ast-grep/napi-win32-arm64-msvc": "0.42.1",
+        "@ast-grep/napi-win32-ia32-msvc": "0.42.1",
+        "@ast-grep/napi-win32-x64-msvc": "0.42.1"
+      }
+    },
+    "node_modules/@ast-grep/napi-darwin-arm64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.42.1.tgz",
+      "integrity": "sha512-VtO4DX20ODCfRBwv1I71lZx+qlrhlMbt9Rpo3LozoaUpHnLmyFMBSgpUal5KTd1SCKUK8ekJGgxpKWo27H4AVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-darwin-x64": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.42.1.tgz",
+      "integrity": "sha512-V2uaKP6QZLb60iFHK0IiXAcwSoUliiDJ3c1zLLzHnBFyCbTKC4b3L3XtkiyKsnpET+uzY7hQLpTIAhW5aOCX4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-arm64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.42.1.tgz",
+      "integrity": "sha512-wmt59yzvcZT4Z5XpxB1B1FoFrc32l0vmy2G7yrY2lG9qP2M157mWdp1T50h2XoYrotyRhCyLDXP70SiTZHZkaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-arm64-musl": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.42.1.tgz",
+      "integrity": "sha512-cnU+H0drvdkApQDJEcBsYGlPq2gk3l2Xxq0y8EmcxAXYXDNkz+Gc2vfvyM7ib2jD9Y51+cQIsb0RFzA2g9VnZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-x64-gnu": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.42.1.tgz",
+      "integrity": "sha512-gY+PtqbFtFlR8rCL9F6GEPuymqLhh2eG/e8Ly01Z/S5x3e357nNaF69xAvNRpYi/HnEUZ5cE1MzshDCjubqE1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-linux-x64-musl": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.42.1.tgz",
+      "integrity": "sha512-yDTlIgFOzglpzs3Ua9w43uVeEW4csf80F5/n2FqCK5pip4Iyfu21Q+M8iC9AmTRl/OGHVI48ieuPwOD9i1i6hA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-win32-arm64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.42.1.tgz",
+      "integrity": "sha512-6WQhKEfZmtfMSIOzluMoBaQhNqfRKXzj5y2YA2U0Y3x7HxNAZBO067y8xlSMddKFN/FtCwft8GFktFxqSYWl1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-win32-ia32-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.42.1.tgz",
+      "integrity": "sha512-ET2vRrsHo0e4JJbCrejzDcDPsfTmRaYK9VIpq1MqXXAUvLoiMly+cQYZ64MWdXTlgITKMXCYxhCbFPTn/9XZaQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/napi-win32-x64-msvc": {
+      "version": "0.42.1",
+      "resolved": "https://registry.npmjs.org/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.42.1.tgz",
+      "integrity": "sha512-NAeA2Q6jp7F9uXtSuG12c1xjTzipXFCTvuAcEBnsTwBXq0kdPV6H6Y4GZJVcDhsHk3TX4sGlQGkuV/6FT2Ngig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@ast-grep/setup-lang": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ast-grep/setup-lang/-/setup-lang-0.0.6.tgz",
+      "integrity": "sha512-aSYZNF5nGQMxnwiA3Lcc8zi0AtpGlug47ADgqCgP/2n7p922FbnW7vo1rbW4kKjW72B/3mDdN7uvYidv8JnPnw==",
+      "license": "ISC"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "baloo-ast-tools",
+  "version": "1.0.0",
+  "private": true,
+  "description": "AST analysis tools for Baloo's PI review agent",
+  "dependencies": {
+    "@ast-grep/napi": "^0.36.0",
+    "@ast-grep/lang-python": "^0.0.6",
+    "@ast-grep/lang-go": "^0.0.6"
+  }
+}

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -4,8 +4,13 @@
   "private": true,
   "description": "AST analysis tools for Baloo's PI review agent",
   "dependencies": {
-    "@ast-grep/napi": "^0.36.0",
+    "@ast-grep/lang-go": "^0.0.6",
     "@ast-grep/lang-python": "^0.0.6",
-    "@ast-grep/lang-go": "^0.0.6"
+    "@ast-grep/napi": "^0.42.0",
+    "typebox": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.2",
+    "typescript": "^6.0.3"
   }
 }

--- a/tests/agent/test_ast_tools_integration.py
+++ b/tests/agent/test_ast_tools_integration.py
@@ -1,0 +1,62 @@
+"""Tests for AST tools integration with PI runtime."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions
+
+
+def test_extension_flag_added_when_ast_tools_enabled():
+    """PI command includes --extension flag when ast_tools_enabled is True."""
+    options = PIAgentOptions(
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_prompt="test",
+    )
+    agent = PIAgentBase(options)
+
+    with patch("baloo.agent.pi_runtime.settings") as mock_settings:
+        mock_settings.ast_tools_enabled = True
+        mock_settings.pi_binary_path = None
+        cmd = agent._build_pi_command()
+
+    assert "--extension" in cmd
+    ext_idx = cmd.index("--extension")
+    ext_path = cmd[ext_idx + 1]
+    assert ext_path.endswith("baloo-ast-tools.ts")
+
+
+def test_extension_flag_omitted_when_ast_tools_disabled():
+    """PI command has no --extension flag when ast_tools_enabled is False."""
+    options = PIAgentOptions(
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_prompt="test",
+    )
+    agent = PIAgentBase(options)
+
+    with patch("baloo.agent.pi_runtime.settings") as mock_settings:
+        mock_settings.ast_tools_enabled = False
+        mock_settings.pi_binary_path = None
+        cmd = agent._build_pi_command()
+
+    assert "--extension" not in cmd
+
+
+def test_extension_flag_omitted_when_no_tools():
+    """PI command has no --extension when no_tools is True (e.g. thread agent)."""
+    options = PIAgentOptions(
+        model="claude-haiku-4-5-20251001",
+        provider="anthropic",
+        system_prompt="test",
+        no_tools=True,
+    )
+    agent = PIAgentBase(options)
+
+    with patch("baloo.agent.pi_runtime.settings") as mock_settings:
+        mock_settings.ast_tools_enabled = True
+        mock_settings.pi_binary_path = None
+        cmd = agent._build_pi_command()
+
+    assert "--extension" not in cmd

--- a/tests/agent/test_ast_tools_integration.py
+++ b/tests/agent/test_ast_tools_integration.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions
+
+
+def _make_mock_settings(**overrides):
+    """Create a mock settings object with sensible defaults."""
+    mock = MagicMock()
+    mock.ast_tools_enabled = overrides.get("ast_tools_enabled", False)
+    mock.pi_binary_path = overrides.get("pi_binary_path", None)
+    return mock
 
 
 def test_extension_flag_added_when_ast_tools_enabled():
@@ -16,9 +24,10 @@ def test_extension_flag_added_when_ast_tools_enabled():
     )
     agent = PIAgentBase(options)
 
-    with patch("baloo.agent.pi_runtime.settings") as mock_settings:
-        mock_settings.ast_tools_enabled = True
-        mock_settings.pi_binary_path = None
+    with patch(
+        "baloo.agent.pi_runtime.get_settings",
+        return_value=_make_mock_settings(ast_tools_enabled=True),
+    ):
         cmd = agent._build_pi_command()
 
     assert "--extension" in cmd
@@ -36,9 +45,10 @@ def test_extension_flag_omitted_when_ast_tools_disabled():
     )
     agent = PIAgentBase(options)
 
-    with patch("baloo.agent.pi_runtime.settings") as mock_settings:
-        mock_settings.ast_tools_enabled = False
-        mock_settings.pi_binary_path = None
+    with patch(
+        "baloo.agent.pi_runtime.get_settings",
+        return_value=_make_mock_settings(ast_tools_enabled=False),
+    ):
         cmd = agent._build_pi_command()
 
     assert "--extension" not in cmd
@@ -54,9 +64,10 @@ def test_extension_flag_omitted_when_no_tools():
     )
     agent = PIAgentBase(options)
 
-    with patch("baloo.agent.pi_runtime.settings") as mock_settings:
-        mock_settings.ast_tools_enabled = True
-        mock_settings.pi_binary_path = None
+    with patch(
+        "baloo.agent.pi_runtime.get_settings",
+        return_value=_make_mock_settings(ast_tools_enabled=True),
+    ):
         cmd = agent._build_pi_command()
 
     assert "--extension" not in cmd

--- a/tests/agent/test_config.py
+++ b/tests/agent/test_config.py
@@ -92,3 +92,11 @@ def test_thread_agent_settings_defaults():
     assert s.thread_agent_max_concurrent == 3
     assert s.feedback_signals_enabled is True
     assert s.feedback_signals_ttl_days == 180
+
+
+def test_ast_tools_settings_defaults():
+    """AST tools settings have correct defaults."""
+    from baloo.config.settings import Settings
+
+    s = Settings()
+    assert s.ast_tools_enabled is True

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -340,3 +340,12 @@ def test_feedback_signals_section_formats_signals():
     assert "except pass in retry loops" in result
     assert "@alice" in result
     assert "avoid re-flagging" in result
+
+
+def test_ast_tools_section_in_system_prompt():
+    """Review system prompt includes AST tools instructions."""
+    from baloo.agent.prompts import REVIEW_SYSTEM_PROMPT
+
+    assert "ast_outline" in REVIEW_SYSTEM_PROMPT
+    assert "ast_grep" in REVIEW_SYSTEM_PROMPT
+    assert "ast_symbols" in REVIEW_SYSTEM_PROMPT

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -342,10 +342,10 @@ def test_feedback_signals_section_formats_signals():
     assert "avoid re-flagging" in result
 
 
-def test_ast_tools_section_in_system_prompt():
-    """Review system prompt includes AST tools instructions."""
-    from baloo.agent.prompts import REVIEW_SYSTEM_PROMPT
+def test_ast_tools_section_in_prompt_section():
+    """AST tools prompt section contains tool names."""
+    from baloo.agent.prompts import AST_TOOLS_PROMPT_SECTION
 
-    assert "ast_outline" in REVIEW_SYSTEM_PROMPT
-    assert "ast_grep" in REVIEW_SYSTEM_PROMPT
-    assert "ast_symbols" in REVIEW_SYSTEM_PROMPT
+    assert "ast_outline" in AST_TOOLS_PROMPT_SECTION
+    assert "ast_grep" in AST_TOOLS_PROMPT_SECTION
+    assert "ast_symbols" in AST_TOOLS_PROMPT_SECTION


### PR DESCRIPTION
## Summary

- Adds 3 structural code analysis tools to the PI review agent via a custom TypeScript extension using `@ast-grep/napi`
- **ast_outline** — list all symbols in a file (functions, classes, methods) with line ranges
- **ast_grep** — structural pattern search using metavariables (`$VAR`, `$$$`)
- **ast_symbols** — find where a symbol is defined and referenced across the codebase
- Tools are loaded via PI's `--extension` flag, controlled by `AST_TOOLS_ENABLED` setting (default: true)
- Supports Python, TypeScript/JavaScript, and Go

## Why

The review agent sometimes misses issues or flags false positives because it doesn't understand function scope, call chains, or related patterns. These tools let the agent query structural context on-demand to make more accurate findings.

## Key changes

- `extensions/baloo-ast-tools.ts` — PI extension registering 3 read-only tools (~330 lines)
- `extensions/package.json` — `@ast-grep/napi`, `@ast-grep/lang-python`, `@ast-grep/lang-go`
- `baloo/agent/pi_runtime.py` — extracted `_build_pi_command()`, adds `--extension` flag
- `baloo/agent/prompts.py` — AST tools section in review system prompt
- `baloo/config/settings.py` — `ast_tools_enabled` setting
- `Dockerfile` — installs extension npm dependencies

## Test plan

- [x] 509 tests passing, no regressions
- [x] Config, runtime, and prompt tests added
- [x] Extension loads in PI without errors (smoke tested)
- [x] Python, TypeScript, and Go parsing verified working
- [ ] Live review with AST tools enabled on a real PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)