### PR TITLE
fix(api): add pr_number to reply_to_review_comment URL

### DIFF
--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -538,6 +538,7 @@ class GitHubAPIClient:
     async def reply_to_review_comment(
         self,
         repo_full_name: str,
+        pr_number: int,
         review_comment_id: int,
         comment: str,
     ) -> bool:
@@ -546,6 +547,7 @@ class GitHubAPIClient:
 
         Args:
             repo_full_name: Repository full name (owner/repo)
+            pr_number: Pull request number
             review_comment_id: ID of the review comment to reply to
             comment: Comment body
 
@@ -553,20 +555,17 @@ class GitHubAPIClient:
             True if reply was successful, False if comment is outdated (404)
         """
         async with httpx.AsyncClient() as client:
-            reply_url = (
-                f"{self.base_url}/repos/{repo_full_name}/pulls/comments/{review_comment_id}/replies"
-            )
+            reply_url = f"{self.base_url}/repos/{repo_full_name}/pulls/{pr_number}/comments/{review_comment_id}/replies"
             response = await client.post(
                 reply_url,
                 headers=self._get_headers(),
                 json={"body": comment},
             )
 
-            # Handle outdated comments (GitHub returns 404 when comment line is null)
             if response.status_code == 404:
                 logger.warning(
-                    f"Cannot reply to comment {review_comment_id} - comment is outdated "
-                    f"(line no longer exists in latest commit)"
+                    f"Cannot reply to comment {review_comment_id} on PR #{pr_number} - "
+                    f"GitHub returned 404 (comment may be outdated or deleted)"
                 )
                 return False
 

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -477,6 +477,7 @@ async def _reverify_awaiting_threads(
             try:
                 replied = await api_client.reply_to_review_comment(
                     repo,
+                    pr_context.pr_number,
                     thread.root_comment_id,
                     "Looks like this was addressed in the latest commit. Resolving.",
                 )
@@ -978,6 +979,7 @@ async def _process_thread_reply(
             if result.reply:
                 await github_client.reply_to_review_comment(
                     repo_full_name,
+                    pr_number,
                     in_reply_to_id,
                     result.reply,
                 )
@@ -1433,6 +1435,7 @@ async def process_pr_review(
                 )
                 success = await github_client.reply_to_review_comment(
                     repo_full_name,
+                    pr_number,
                     thread.root_comment_id or thread.id,
                     reply_body,
                 )

--- a/tests/agent/test_thread_integration.py
+++ b/tests/agent/test_thread_integration.py
@@ -102,7 +102,7 @@ async def test_process_thread_reply_concede_writes_signal():
 
     # Verify reply was posted
     mock_client.reply_to_review_comment.assert_called_once_with(
-        "org/repo", 100, "Got it, makes sense for retry loops."
+        "org/repo", 1, 100, "Got it, makes sense for retry loops."
     )
 
     # Verify feedback signal was written

--- a/tests/github/test_reverify_threads.py
+++ b/tests/github/test_reverify_threads.py
@@ -118,6 +118,7 @@ async def test_reverify_fp_verdict_triggers_reply_and_resolve():
     assert resolved_count == 1
     mock_api.reply_to_review_comment.assert_called_once_with(
         "org/repo",
+        1,
         42,
         "Looks like this was addressed in the latest commit. Resolving.",
     )


### PR DESCRIPTION
## Summary

- `reply_to_review_comment` was calling `/pulls/comments/{id}/replies` — a GitHub route that doesn't exist
- The correct endpoint is `/pulls/{pr_number}/comments/{id}/replies`
- GitHub returned 404 on every call, which was logged with the misleading message _"comment is outdated (line no longer exists in latest commit)"_
- Added `pr_number` parameter to the function, updated the URL, updated all 3 call sites, and updated tests

## Test plan

- [ ] Existing tests pass (`test_thread_integration`, `test_reverify_threads`)
- [ ] Verify thread replies are posted successfully on a live PR