### PR TITLE
fix(agent): capture PI subprocess stderr for API error debugging

### DIFF
--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -499,22 +499,6 @@ class PIAgentBase:
             result = await self._drive_session(proc, query, start_time, review_logger)
         except Exception as exc:
             logger.error("%s: PI session error: %s", self.agent_name, exc)
-
-            # Capture stderr on exception to get API error context
-            if proc.stderr:
-                try:
-                    stderr_data = await asyncio.wait_for(proc.stderr.read(), timeout=0.5)
-                    if stderr_data:
-                        stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
-                        if stderr_text:
-                            logger.error(
-                                "%s: PI stderr on exception: %s",
-                                self.agent_name,
-                                stderr_text[:2000],
-                            )
-                except Exception:
-                    pass
-
             result.is_error = True
             result.error_message = str(exc)
             # Re-raise so callers (e.g. fallback logic) can catch and retry
@@ -528,20 +512,21 @@ class PIAgentBase:
                 await proc.wait()
             raise err from exc
         finally:
-            # Capture any remaining stderr before cleanup
+            # Capture stderr to surface API error details
             if proc.stderr:
                 try:
                     stderr_data = await asyncio.wait_for(proc.stderr.read(), timeout=0.5)
                     if stderr_data:
                         stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
                         if stderr_text and len(stderr_text) > 10:  # Skip trivial output
-                            logger.info(
-                                "%s: PI stderr at cleanup: %s",
+                            log_level = logger.error if result.is_error else logger.info
+                            log_level(
+                                "%s: PI stderr: %s",
                                 self.agent_name,
-                                stderr_text[:1000],
+                                stderr_text[:2000],
                             )
-                except Exception:
-                    pass
+                except Exception as stderr_err:
+                    logger.debug("%s: Failed to read stderr: %s", self.agent_name, stderr_err)
 
             # Ensure process is cleaned up
             if proc.returncode is None:
@@ -747,8 +732,10 @@ Serialized payload:
                                     self.agent_name,
                                     stderr_text[:1000],
                                 )
-                    except Exception:
-                        pass
+                    except Exception as stderr_err:
+                        logger.debug(
+                            "%s: Failed to read JSON retry stderr: %s", self.agent_name, stderr_err
+                        )
 
                 if proc.returncode is None:
                     proc.kill()
@@ -920,25 +907,5 @@ Serialized payload:
         result.assistant_text = last_assistant_text
         result.all_assistant_texts = all_assistant_texts
         result.num_turns = turn_count
-
-        # Capture stderr to surface API error details
-        if proc.stderr:
-            try:
-                stderr_data = await asyncio.wait_for(proc.stderr.read(), timeout=1.0)
-                if stderr_data:
-                    stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
-                    if stderr_text:
-                        log_level = logger.error if result.is_error else logger.warning
-                        log_level(
-                            "%s: PI stderr output: %s",
-                            self.agent_name,
-                            stderr_text[:2000],
-                        )
-                        if result.is_error and "error" in stderr_text.lower():
-                            result.error_message += f" | stderr: {stderr_text[:300]}"
-            except asyncio.TimeoutError:
-                pass
-            except Exception as stderr_err:
-                logger.debug("%s: Failed to read stderr: %s", self.agent_name, stderr_err)
 
         return result

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -499,6 +499,22 @@ class PIAgentBase:
             result = await self._drive_session(proc, query, start_time, review_logger)
         except Exception as exc:
             logger.error("%s: PI session error: %s", self.agent_name, exc)
+
+            # Capture stderr on exception to get API error context
+            if proc.stderr:
+                try:
+                    stderr_data = await asyncio.wait_for(proc.stderr.read(), timeout=0.5)
+                    if stderr_data:
+                        stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
+                        if stderr_text:
+                            logger.error(
+                                "%s: PI stderr on exception: %s",
+                                self.agent_name,
+                                stderr_text[:2000],
+                            )
+                except Exception:
+                    pass
+
             result.is_error = True
             result.error_message = str(exc)
             # Re-raise so callers (e.g. fallback logic) can catch and retry
@@ -512,6 +528,21 @@ class PIAgentBase:
                 await proc.wait()
             raise err from exc
         finally:
+            # Capture any remaining stderr before cleanup
+            if proc.stderr:
+                try:
+                    stderr_data = await asyncio.wait_for(proc.stderr.read(), timeout=0.5)
+                    if stderr_data:
+                        stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
+                        if stderr_text and len(stderr_text) > 10:  # Skip trivial output
+                            logger.info(
+                                "%s: PI stderr at cleanup: %s",
+                                self.agent_name,
+                                stderr_text[:1000],
+                            )
+                except Exception:
+                    pass
+
             # Ensure process is cleaned up
             if proc.returncode is None:
                 proc.kill()
@@ -703,6 +734,22 @@ Serialized payload:
                 result = await self._drive_session(proc, retry_prompt, start)
             finally:
                 self.options = original_opts
+
+                # Capture stderr from retry process
+                if proc.stderr:
+                    try:
+                        stderr_data = await asyncio.wait_for(proc.stderr.read(), timeout=0.5)
+                        if stderr_data:
+                            stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
+                            if stderr_text:
+                                logger.warning(
+                                    "%s: JSON retry stderr: %s",
+                                    self.agent_name,
+                                    stderr_text[:1000],
+                                )
+                    except Exception:
+                        pass
+
                 if proc.returncode is None:
                     proc.kill()
                     await proc.wait()
@@ -873,5 +920,25 @@ Serialized payload:
         result.assistant_text = last_assistant_text
         result.all_assistant_texts = all_assistant_texts
         result.num_turns = turn_count
+
+        # Capture stderr to surface API error details
+        if proc.stderr:
+            try:
+                stderr_data = await asyncio.wait_for(proc.stderr.read(), timeout=1.0)
+                if stderr_data:
+                    stderr_text = stderr_data.decode("utf-8", errors="replace").strip()
+                    if stderr_text:
+                        log_level = logger.error if result.is_error else logger.warning
+                        log_level(
+                            "%s: PI stderr output: %s",
+                            self.agent_name,
+                            stderr_text[:2000],
+                        )
+                        if result.is_error and "error" in stderr_text.lower():
+                            result.error_message += f" | stderr: {stderr_text[:300]}"
+            except asyncio.TimeoutError:
+                pass
+            except Exception as stderr_err:
+                logger.debug("%s: Failed to read stderr: %s", self.agent_name, stderr_err)
 
         return result


### PR DESCRIPTION
## Summary
Add comprehensive stderr logging to surface Anthropic API error details when agent failures occur. This addresses the "Agent returned error stop reason" failures with 0 tokens that occur in ~33% of reviews.

## Problem
Currently experiencing systematic failures (73/217 reviews, ~33%) with:
- Error: "Agent returned error stop reason"
- 0 tokens in/out (API rejects before processing)
- Happens in sync scope decider on synchronize webhooks
- Generic error message provides no debugging information

The actual API error details are sent to PI subprocess stderr but are never logged or surfaced.

## Solution
Capture stderr in 4 locations:
1. **_drive_session** - After event loop completes (normal flow)
2. **run_query exception handler** - When process crashes
3. **run_query finally block** - At process cleanup
4. **_retry_json** - During JSON repair attempts

This will expose actual API errors like:
- Content policy violations
- Rate limits
- Invalid request parameters
- Model-specific errors

## Changes
- Capture stderr with 0.5-1s timeout to avoid blocking
- Log at appropriate level (error/warning/info based on context)
- Append stderr to error_message when error conditions detected
- Gracefully handle stderr read failures

## Test Plan
- [ ] Deploy to staging/production
- [ ] Wait for next sync scope decider failure
- [ ] Check logs for actual API error message in stderr output
- [ ] Use error details to identify root cause (likely content policy)

## Notes
- No changes to business logic
- Only adds observability/debugging capability
- Low risk - stderr capture failures are caught and ignored
- Will help diagnose the 33% failure rate in sync scope decisions