### PR TITLE
docs(readme): add Support section with GitHub issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ See [docs/development.md](docs/development.md) for the full contributor guide.
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for planned features including multi-model review with judge, conversational thread replies, and AST-enriched context.
 
+## Support
+
+- **Issues & Bug Reports**: [GitHub Issues](https://github.com/Blue-Bear-Security/baloo-bear/issues)
+- **Feature Requests**: [GitHub Issues](https://github.com/Blue-Bear-Security/baloo-bear/issues)
+- **Questions**: Open a [GitHub Discussion](https://github.com/Blue-Bear-Security/baloo-bear/discussions) or file an issue
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow and conventions, and [AGENTS.md](AGENTS.md) for AI-agent-specific guidance.


### PR DESCRIPTION
## Summary
Add Support section to README directing users to GitHub Issues for support.

## Changes
- Added new Support section before Contributing
- Direct users to GitHub Issues for bug reports, feature requests, and questions
- Link to GitHub Discussions as alternative for questions

## Motivation
Makes it clear that this project uses GitHub Issues for issue tracking and support, improving discoverability for users who need help or want to report issues.