### PR TITLE
ci: build Docker images only on release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,8 @@
 name: Build and Publish Container Image
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "baloo/**"
-      - "main.py"
-      - "pyproject.toml"
-      - "Dockerfile"
-      - "docker-compose.yml"
-      - ".github/workflows/deploy.yml"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -29,14 +21,14 @@ jobs:
       - name: Extract metadata
         id: meta
         run: |
-          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${REPO_NAME}"
 
-          echo "timestamp=${TIMESTAMP}" >> "${GITHUB_OUTPUT}"
-          echo "short_sha=${SHORT_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "image_tag=${TIMESTAMP}-${SHORT_SHA}" >> "${GITHUB_OUTPUT}"
+          # Extract version from release tag (e.g., v1.0.0 -> 1.0.0)
+          VERSION="${GITHUB_REF#refs/tags/}"
+          VERSION_NO_V="${VERSION#v}"
+
+          echo "version=${VERSION_NO_V}" >> "${GITHUB_OUTPUT}"
           echo "image_name=${IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Docker Buildx
@@ -56,25 +48,23 @@ jobs:
           file: ./Dockerfile
           push: true
           build-args: |
-            BALOO_VERSION=${{ steps.meta.outputs.image_tag }}
+            BALOO_VERSION=${{ steps.meta.outputs.version }}
             BALOO_COMMIT_SHA=${{ github.sha }}
-            BALOO_BUILD_DATE=${{ steps.meta.outputs.timestamp }}
           tags: |
             ${{ steps.meta.outputs.image_name }}:latest
-            ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.image_tag }}
-            ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.short_sha }}
+            ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ steps.meta.outputs.timestamp }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
 
       - name: Publish summary
         run: |
-          echo "Image pushed successfully."
-          echo "Image: ${{ steps.meta.outputs.image_name }}"
-          echo "Tags:"
+          echo "✅ Image pushed successfully for release ${{ steps.meta.outputs.version }}"
+          echo ""
+          echo "**Image:** ${{ steps.meta.outputs.image_name }}"
+          echo "**Tags:**"
           echo "  - latest"
-          echo "  - ${{ steps.meta.outputs.image_tag }}"
-          echo "  - ${{ steps.meta.outputs.short_sha }}"
+          echo "  - ${{ steps.meta.outputs.version }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -24,12 +29,19 @@ jobs:
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${REPO_NAME}"
 
-          # Extract version from release tag (e.g., v1.0.0 -> 1.0.0)
-          VERSION="${GITHUB_REF#refs/tags/}"
-          VERSION_NO_V="${VERSION#v}"
+          # Extract version from release tag or workflow_dispatch input
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION_NO_V="${{ github.event.inputs.version }}"
+            BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+            VERSION_NO_V="${VERSION#v}"
+            BUILD_DATE="${{ github.event.release.created_at }}"
+          fi
 
           echo "version=${VERSION_NO_V}" >> "${GITHUB_OUTPUT}"
           echo "image_name=${IMAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "build_date=${BUILD_DATE}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -50,6 +62,7 @@ jobs:
           build-args: |
             BALOO_VERSION=${{ steps.meta.outputs.version }}
             BALOO_COMMIT_SHA=${{ github.sha }}
+            BALOO_BUILD_DATE=${{ steps.meta.outputs.build_date }}
           tags: |
             ${{ steps.meta.outputs.image_name }}:latest
             ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.version }}
@@ -59,6 +72,7 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.build_date }}
 
       - name: Publish summary
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,18 +25,21 @@ jobs:
 
       - name: Extract metadata
         id: meta
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_CREATED_AT: ${{ github.event.release.created_at }}
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#*/}"
           IMAGE_NAME="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/${REPO_NAME}"
 
           # Extract version from release tag or workflow_dispatch input
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION_NO_V="${{ github.event.inputs.version }}"
+            VERSION_NO_V="${INPUT_VERSION}"
             BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           else
             VERSION="${GITHUB_REF#refs/tags/}"
             VERSION_NO_V="${VERSION#v}"
-            BUILD_DATE="${{ github.event.release.created_at }}"
+            BUILD_DATE="${RELEASE_CREATED_AT}"
           fi
 
           echo "version=${VERSION_NO_V}" >> "${GITHUB_OUTPUT}"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ See [docs/development.md](docs/development.md) for the full contributor guide.
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for planned features including multi-model review with judge, conversational thread replies, and AST-enriched context.
 
+## Support
+
+- **Issues & Bug Reports**: [GitHub Issues](https://github.com/Blue-Bear-Security/baloo-bear/issues)
+- **Feature Requests**: [GitHub Issues](https://github.com/Blue-Bear-Security/baloo-bear/issues)
+- **Questions**: Open a [GitHub Discussion](https://github.com/Blue-Bear-Security/baloo-bear/discussions) or file an issue
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow and conventions, and [AGENTS.md](AGENTS.md) for AI-agent-specific guidance.


### PR DESCRIPTION
## Summary
Change Docker build workflow to trigger on GitHub Releases instead of every push to main.

## Problem
Current workflow builds and publishes Docker images on every push to main, which:
- Creates unnecessary builds for every merge
- Makes it harder to track production versions
- Wastes CI resources
- Uses timestamp-based tags instead of semantic versions

## Solution
**Before:**
- ✅ Trigger: Push to main (with path filters)
- ✅ Tags: `latest`, `{timestamp}-{sha}`, `{sha}`

**After:**
- ✅ Trigger: GitHub Release published
- ✅ Tags: `latest`, `{version}` (from release tag)
- ✅ Version extraction: `v1.0.0` → `1.0.0`

## Changes
1. Changed trigger from `push: main` to `release: published`
2. Extract version from release tag instead of generating timestamp
3. Tag images with semantic version from release
4. Keep `workflow_dispatch` for manual triggering
5. Simplified metadata extraction

## Usage
To publish a new Docker image:
1. Create a GitHub Release with tag like `v1.0.0`
2. Workflow automatically builds and publishes:
   - `ghcr.io/blue-bear-security/baloo-bear:latest`
   - `ghcr.io/blue-bear-security/baloo-bear:1.0.0`

## Benefits
- ✅ Explicit version control via releases
- ✅ Semantic versioning instead of timestamps
- ✅ Reduced CI resource usage
- ✅ Clearer production version tracking
- ✅ Better alignment with release process

## Notes
- No functional changes to the build process itself
- Manual workflow dispatch still available
- First release after merging will publish the initial versioned image