### PR TITLE
fix(db): rename duplicate migration 006 to 007 (prod hotfix)

### DIFF
--- a/baloo/db/migrations/versions/007_add_active_review_lock.py
+++ b/baloo/db/migrations/versions/007_add_active_review_lock.py
@@ -1,7 +1,7 @@
 """Add partial unique index to enforce one active review per PR.
 
-Revision ID: 006
-Revises: 005
+Revision ID: 007
+Revises: 006
 Create Date: 2026-05-19
 """
 
@@ -10,8 +10,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "006"
-down_revision: str = "005"
+revision: str = "007"
+down_revision: str = "006"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary

- PR #50 added `006_add_active_review_lock.py` while `006_add_installation_id.py` already existed in main — both claimed revision `006` with `down_revision=005`
- Alembic fails startup with `MultipleHeads: 006, 006`, crashing prod on every restart
- Fix: rename the lock migration to `007` and set `down_revision=006`

## Test plan

- [ ] `uv run alembic heads` returns a single head (`007`)
- [ ] Deploy to prod and confirm startup succeeds