### PR TITLE
fix(db): serialize Alembic migrations with pg_advisory_lock on startup

### DIFF
--- a/baloo/db/engine.py
+++ b/baloo/db/engine.py
@@ -30,11 +30,18 @@ def get_session_factory(database_url: str) -> async_sessionmaker[AsyncSession]:
     return _session_factory
 
 
+_MIGRATION_LOCK_KEY = 7756279  # arbitrary fixed key for baloo migration advisory lock
+
+
 def _run_alembic_migrations(database_url: str) -> bool:
     """Run Alembic migrations synchronously.
 
     Uses a sync connection to avoid nested-async-loop issues when
     called from within an already-running event loop.
+
+    On PostgreSQL, a session-level advisory lock serializes concurrent
+    startup across replicas — the second pod blocks until the first
+    finishes, then runs upgrade head as a no-op.
 
     If the database was previously managed by ``create_all`` (no
     ``alembic_version`` table), we stamp the baseline revision
@@ -67,25 +74,38 @@ def _run_alembic_migrations(database_url: str) -> bool:
         "script_location", str(project_root / "baloo" / "db" / "migrations")
     )
 
-    # If the DB already has tables but no alembic_version table,
-    # stamp the initial migration so Alembic doesn't try to re-create.
-    try:
-        import sqlalchemy
+    import sqlalchemy
 
-        sync_engine = sqlalchemy.create_engine(sync_url)
-        inspector = sqlalchemy.inspect(sync_engine)
-        tables = inspector.get_table_names()
+    is_postgres = sync_url.startswith("postgresql")
+    sync_engine = sqlalchemy.create_engine(sync_url)
+    try:
+        with sync_engine.connect() as conn:
+            if is_postgres:
+                conn.execute(
+                    sqlalchemy.text("SELECT pg_advisory_lock(:key)"),
+                    {"key": _MIGRATION_LOCK_KEY},
+                )
+                logger.info("Acquired migration advisory lock")
+
+            # If the DB already has tables but no alembic_version table,
+            # stamp the initial migration so Alembic doesn't try to re-create.
+            try:
+                inspector = sqlalchemy.inspect(conn)
+                tables = inspector.get_table_names()
+                if "reviews" in tables and "alembic_version" not in tables:
+                    logger.info(
+                        "Existing DB without alembic_version detected, "
+                        "stamping baseline revision 001"
+                    )
+                    command.stamp(alembic_cfg, "001")
+            except Exception as e:
+                logger.warning("Could not inspect DB for stamping: %s", e)
+
+            command.upgrade(alembic_cfg, "head")
+            # Advisory lock released automatically when connection closes
+    finally:
         sync_engine.dispose()
 
-        if "reviews" in tables and "alembic_version" not in tables:
-            logger.info(
-                "Existing DB without alembic_version detected, " "stamping baseline revision 001"
-            )
-            command.stamp(alembic_cfg, "001")
-    except Exception as e:
-        logger.warning("Could not inspect DB for stamping: %s", e)
-
-    command.upgrade(alembic_cfg, "head")
     return True
 
 

--- a/baloo/db/engine.py
+++ b/baloo/db/engine.py
@@ -81,11 +81,17 @@ def _run_alembic_migrations(database_url: str) -> bool:
     try:
         with sync_engine.connect() as conn:
             if is_postgres:
-                conn.execute(
-                    sqlalchemy.text("SELECT pg_advisory_lock(:key)"),
-                    {"key": _MIGRATION_LOCK_KEY},
-                )
-                logger.info("Acquired migration advisory lock")
+                try:
+                    conn.execute(
+                        sqlalchemy.text("SELECT pg_advisory_lock(:key)"),
+                        {"key": _MIGRATION_LOCK_KEY},
+                    )
+                    logger.info("Acquired migration advisory lock")
+                except Exception:
+                    logger.warning(
+                        "Could not acquire advisory lock, proceeding without serialization",
+                        exc_info=True,
+                    )
 
             # If the DB already has tables but no alembic_version table,
             # stamp the initial migration so Alembic doesn't try to re-create.

--- a/tests/db/test_engine.py
+++ b/tests/db/test_engine.py
@@ -1,0 +1,56 @@
+"""Tests for _run_alembic_migrations advisory lock behaviour."""
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+
+def _run_with_mocks(database_url: str, *, lock_raises: bool = False):
+    """Exercise _run_alembic_migrations with all external dependencies mocked."""
+    mock_conn = MagicMock()
+    if lock_raises:
+        mock_conn.execute.side_effect = Exception("lock error")
+
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value.__enter__ = lambda _: mock_conn
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_inspector = MagicMock()
+    mock_inspector.get_table_names.return_value = []
+
+    with ExitStack() as stack:
+        mock_upgrade = stack.enter_context(patch("alembic.command.upgrade"))
+        stack.enter_context(patch("alembic.command.stamp"))
+        stack.enter_context(patch("alembic.config.Config"))
+        stack.enter_context(patch("pathlib.Path.exists", return_value=True))
+        stack.enter_context(patch("sqlalchemy.create_engine", return_value=mock_engine))
+        stack.enter_context(patch("sqlalchemy.inspect", return_value=mock_inspector))
+
+        from baloo.db.engine import _run_alembic_migrations
+
+        result = _run_alembic_migrations(database_url)
+
+    executed_texts = [str(c.args[0]) for c in mock_conn.execute.call_args_list]
+    return result, mock_upgrade, executed_texts
+
+
+def test_advisory_lock_acquired_for_postgres():
+    result, mock_upgrade, executed_texts = _run_with_mocks("postgresql://localhost/test")
+
+    assert result is True
+    assert any("pg_advisory_lock" in t for t in executed_texts)
+    mock_upgrade.assert_called_once()
+
+
+def test_advisory_lock_skipped_for_sqlite():
+    result, mock_upgrade, executed_texts = _run_with_mocks("sqlite:///test.db")
+
+    assert result is True
+    assert not any("pg_advisory_lock" in t for t in executed_texts)
+    mock_upgrade.assert_called_once()
+
+
+def test_advisory_lock_failure_does_not_block_migrations():
+    result, mock_upgrade, _ = _run_with_mocks("postgresql://localhost/test", lock_raises=True)
+
+    assert result is True
+    mock_upgrade.assert_called_once()

--- a/tests/db/test_engine.py
+++ b/tests/db/test_engine.py
@@ -8,7 +8,13 @@ def _run_with_mocks(database_url: str, *, lock_raises: bool = False):
     """Exercise _run_alembic_migrations with all external dependencies mocked."""
     mock_conn = MagicMock()
     if lock_raises:
-        mock_conn.execute.side_effect = Exception("lock error")
+
+        def _selective_execute(*args, **_kwargs):
+            if args and "pg_advisory_lock" in str(args[0]):
+                raise Exception("lock error")
+            return MagicMock()
+
+        mock_conn.execute.side_effect = _selective_execute
 
     mock_engine = MagicMock()
     mock_engine.connect.return_value.__enter__ = lambda _: mock_conn


### PR DESCRIPTION
Closes #44

## Summary

- On PostgreSQL, `_run_alembic_migrations` now acquires a session-level advisory lock (`pg_advisory_lock(7756279)`) before running `alembic upgrade head`
- The first pod acquires the lock and runs migrations; concurrent pods block until it releases (connection close), then run `upgrade head` as a no-op
- Lock is skipped for non-PostgreSQL URLs (SQLite in tests is unaffected)
- Inspection/stamping logic moved inside the same connection context, eliminating the extra `create_engine` / `dispose` cycle

## Test plan

- [ ] `uv run pytest` — 540 tests pass
- [ ] Deploy two replicas simultaneously on a fresh DB and confirm only one set of migration logs appears