### PR TITLE
fix(ci): add explicit permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` to `ci.yml` to scope the `GITHUB_TOKEN` to the minimum required
- Closes CodeQL alert [#1](https://github.com/Blue-Bear-Security/baloo-bear/security/code-scanning/1) (missing workflow permissions)

`deploy.yml` and `docs.yml` already have explicit permissions blocks — no changes needed there.

## Test Plan
- [ ] CI passes on this PR
- [ ] Code scanning alert #1 is resolved after merge