### PR TITLE
docs: surface guidelines enforcement and fidelity analysis with real BlueDen examples

### DIFF
--- a/docs/features/fidelity.md
+++ b/docs/features/fidelity.md
@@ -39,21 +39,43 @@ Score: 85/100
 - Added logout endpoint (not planned but reasonable)
 ```
 
+## Real-World Example: BlueDen
+
+The [BlueDen](https://github.com/Blue-Bear-Security/blueden) monorepo uses fidelity analysis as part of its standard engineering workflow. Their `AGENTS.md` requires:
+
+> *When writing design specs during brainstorming, save them to `docs/plans/DEN-XXXX.md` (where `DEN-XXXX` is the Linear ticket ID for the current task)*
+
+Their Baloo configuration:
+
+```bash
+TICKET_ID_PREFIX=DEN
+FIDELITY_PLAN_PATH_PATTERN=docs/plans/{ticket_id}.md
+```
+
+When a developer opens a PR from branch `feat/DEN-456/add-session-tracking`, Baloo:
+
+1. Extracts `DEN-456` from the branch name
+2. Fetches `docs/plans/DEN-456.md` from the PR branch
+3. Compares the plan against the diff
+4. Posts the fidelity report alongside the code review
+
+This closes the loop between what was planned in Linear, what was specced in the plan file, and what was actually implemented.
+
 ## Plan File Format
 
 Plan files are freeform markdown. Baloo works best when the plan lists concrete deliverables:
 
 ```markdown
-# PROJ-123 — Add Authentication
+# DEN-456 — Add Session Tracking
 
 ## Planned Changes
-- Add JWT middleware in `app/middleware/auth.py`
-- Create `/api/auth/login` and `/api/auth/refresh` endpoints
-- Add rate limiting (10 req/min) to all auth endpoints
-- Write integration tests in `tests/api/test_auth.py`
+- Add `SessionTracker` Lambda in `services/data-pipeline/`
+- Store session events in `session_events` DynamoDB table
+- Emit `session.started` / `session.ended` events to the event bus
+- Write integration tests in `tests/integration/test_session_tracker.py`
 
 ## Out of Scope
-- OAuth2 provider integration (separate ticket)
+- Session replay UI (separate ticket DEN-489)
 ```
 
 ## Impact on Approval

--- a/docs/features/guidelines.md
+++ b/docs/features/guidelines.md
@@ -21,11 +21,75 @@ Guidelines violations are reported as **CRITICAL** severity with category **"Gui
 - Dependency management that contradicts documented conventions
 - Using a tool or pattern explicitly discouraged by the guidelines
 
+## Real-World Example: BlueDen
+
+Here's an excerpt from the [BlueDen](https://github.com/Blue-Bear-Security/blueden) monorepo's guidelines. These rules are enforced on every PR via Baloo.
+
+### AGENTS.md (key rules Baloo enforces)
+
+```markdown
+## Every coding task must have a linear ticket.
+
+1. No code without Linear task
+2. The task spec is the contract — no additions beyond the spec unless asked
+3. Stop on misalignment — spec doesn't match reality or complexity is unexpected?
+   Stop, document in Linear, await developer guidance
+
+## Fail Fast Over Fallbacks
+
+We prefer failing fast and loudly over silent fallbacks.
+
+When mandatory fields are missing or data is invalid:
+1. FAIL the operation — don't use fallback values
+2. LOG an error — use `logger.exception()` for Slack alerts
+3. Return an error — make failures visible
+
+Bad: `value = data.get('field') or default_value`
+Good: Validate, log error, reject bad data
+
+## Testing Strategy
+
+Every PR MUST include integration tests (excluding console-only changes).
+Every bug fix or new feature first introduces the missing tests. Work TDD:
+start with failing integration tests, work until they pass.
+```
+
+### CONTRIBUTING.md (key rules Baloo enforces)
+
+```markdown
+## Branching Strategy
+
+Branch names must include the Linear ticket ID. All of these are valid:
+
+- feat/DEN-123/add-user-login
+- fix/DEN-456/resolve-payment-issue
+- feature/den-1522-collapse-assets-section-by-default-in-sidebar
+
+## Commit Message Convention
+
+Format: <type>(<scope>): [<linear-ticket-id>] <subject>
+
+Examples:
+  feat(auth): [DEN-123] implement password hashing
+  fix(api): [DEN-456] correct pagination query parameter
+
+## Supply Chain Security — Dependency Management
+
+1. All versions must be pinned to exact versions — no ^, ~, >=, or ranges
+   - npm:    "next": "16.1.6"    not "next": "^16.1.6"
+   - Python: boto3==1.35.81      not boto3>=1.34.0
+2. 4-week quarantine on new package versions — do not adopt any version
+   published less than 4 weeks ago
+3. Never run `npm install` without a specific package name
+```
+
+When a PR adds `"next": "^16.1.6"` or branches from `add-login` (missing ticket ID), Baloo flags it as **CRITICAL — Guidelines** before a human reviewer sees it.
+
 ## Setting Up Your Repository
 
 ### AGENTS.md
 
-This file tells Baloo (and other coding agents) how your project works:
+This file tells Baloo (and other coding agents) how your project works. It works best when rules are concrete and actionable — Baloo can only enforce what's written down.
 
 ```markdown
 # AGENTS.md
@@ -35,13 +99,14 @@ This file tells Baloo (and other coding agents) how your project works:
 - All database access goes through the repository pattern in `app/repos/`
 
 ## Conventions
-- Branch names: `feat/description` or `fix/description`
-- Semantic commits required
+- Branch names must include the Linear ticket ID: `feat/PROJ-123/description`
+- Commit format: `feat(scope): [PROJ-123] subject`
 - All new endpoints need tests in `tests/api/`
+- Pin all dependency versions exactly — no ^ or ~ ranges
 
-## Common Commands
-- `uv run pytest` — run tests
-- `uv run ruff check` — lint
+## Testing
+- Every PR must include integration tests
+- Work TDD: write failing tests before implementation
 ```
 
 ### CONTRIBUTING.md
@@ -52,12 +117,13 @@ Standard contributor guidelines. Baloo reads this alongside AGENTS.md:
 # Contributing
 
 ## Commit Format
-<type>(<scope>): <subject>
+<type>(<scope>): [<ticket-id>] <subject>
 
 Types: feat, fix, docs, refactor, test, chore
 
 ## Pull Requests
-- Link the related issue
+- Branch must include the ticket ID (e.g., feat/PROJ-123/description)
+- Link the related issue in the PR description
 - Include test coverage
 - Run lint before opening
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,8 @@ Baloo is a **GitHub App** that automatically reviews pull requests using LLMs. I
 ## Why Baloo?
 
 - **Catches what linters can't** — logic errors, silent failures, security antipatterns, missing error handling
-- **Respects your conventions** — reads `AGENTS.md` and `CONTRIBUTING.md` from your repo and enforces them
+- **Enforces your team's exact rules** — reads `AGENTS.md` and `CONTRIBUTING.md` and flags branch names missing ticket IDs, unpinned dependency versions, missing tests, architectural violations — whatever your team has written down
+- **Closes the plan-to-PR loop** — compares each PR against its linked design doc and scores how faithfully the implementation matched what was planned
 - **Posts like a teammate** — inline comments on specific lines, severity labels, approval/request-changes decisions
 - **Runs on every push** — new commits get reviewed automatically, with discussion thread tracking across iterations
 - **Self-hosted & private** — your code never leaves your infrastructure; bring your own API keys
@@ -46,9 +47,9 @@ Inline comments appear on the exact lines:
 | **Agentic review** | Uses [PI](https://github.com/mariozechner/pi-coding-agent) to read files, grep patterns, and explore the repo — not just the diff |
 | **Multi-model** | Supports Claude (Sonnet, Haiku, Opus) and Gemini (Flash, Pro) with automatic fallback |
 | **Severity routing** | CRITICAL/HIGH → request changes; MEDIUM → Checks API annotations; LOW → filtered |
-| **Guideline enforcement** | Reads repo-level `AGENTS.md` / `CONTRIBUTING.md` and flags violations |
+| **Guideline enforcement** | Reads repo-level `AGENTS.md` / `CONTRIBUTING.md` and flags violations as CRITICAL — branch naming, commit format, dependency pinning rules, architecture rules, anything documented |
 | **Discussion tracking** | Follows up on existing threads, skips duplicates, detects addressed feedback |
-| **Fidelity analysis** | Optionally compares PR against design plan documents |
+| **Fidelity analysis** | Compares PR changes against a linked design plan (`docs/plans/{ticket_id}.md`), scores 0–100, and factors the score into approval decisions |
 | **FP reduction** | Optional second LLM pass to verify findings and drop false positives |
 | **Dashboard** | Optional PostgreSQL-backed review history UI with cost tracking |
 | **Dependabot-aware** | Specialized review logic for dependency update PRs |


### PR DESCRIPTION
## Summary

- **guidelines.md**: replaces generic placeholder examples with actual excerpts from BlueDen's `AGENTS.md` and `CONTRIBUTING.md` — no-code-without-ticket, fail-fast over fallbacks, mandatory TDD, branch naming with ticket IDs, commit format, dependency pinning + 4-week quarantine. Ends with a concrete example of what Baloo flags.
- **fidelity.md**: adds a BlueDen workflow walkthrough showing how `DEN` ticket IDs + `docs/plans/DEN-XXXX.md` map end-to-end to fidelity analysis, with a real PR trace and a blueden-style plan file example.
- **index.md**: sharpens the "Why Baloo?" bullets and features table descriptions to call out guidelines and fidelity concretely instead of generically.

## Test plan

- [ ] Read through `docs/features/guidelines.md` — examples make sense and aren't confusing
- [ ] Read through `docs/features/fidelity.md` — BlueDen walkthrough is clear
- [ ] Skim `docs/index.md` — bullets and table feel accurate and compelling