### PR TITLE
docs: strengthen guidelines and fidelity feature pages

### DIFF
--- a/docs/features/fidelity.md
+++ b/docs/features/fidelity.md
@@ -56,6 +56,17 @@ Plan files are freeform markdown. Baloo works best when the plan lists concrete 
 - OAuth2 provider integration (separate ticket)
 ```
 
+## Workflow Integration
+
+Fidelity works best when your team commits to writing plan files before coding. A common pattern:
+
+1. Create a ticket in your issue tracker (e.g., `PROJ-123`)
+2. Write `docs/plans/PROJ-123.md` with the planned deliverables
+3. Open the PR from a branch that includes the ticket ID (e.g., `feat/PROJ-123/add-auth`)
+4. Baloo automatically finds the plan, scores the PR, and posts the report
+
+This closes the loop between what was planned and what was actually shipped.
+
 ## Impact on Approval
 
 Fidelity score affects the approval decision:

--- a/docs/features/guidelines.md
+++ b/docs/features/guidelines.md
@@ -15,17 +15,18 @@ The contents are injected into the review agent's prompt. The agent then flags a
 
 Guidelines violations are reported as **CRITICAL** severity with category **"Guidelines"**. Examples:
 
-- Branch name doesn't follow the naming convention (e.g., `fix/thing` when repo requires `fix(scope): thing`)
+- Branch name missing required ticket ID (e.g., `fix/thing` when the repo requires `fix/PROJ-123/thing`)
 - Commit messages missing required ticket references
+- Dependency versions not pinned exactly (e.g., `^1.2.3` when exact pinning is required)
 - Code that violates architectural decisions stated in AGENTS.md
-- Dependency management that contradicts documented conventions
 - Using a tool or pattern explicitly discouraged by the guidelines
+- Missing integration tests when AGENTS.md mandates TDD
 
 ## Setting Up Your Repository
 
 ### AGENTS.md
 
-This file tells Baloo (and other coding agents) how your project works:
+This file tells Baloo (and other coding agents) how your project works. Rules should be concrete and actionable — Baloo can only enforce what's written down.
 
 ```markdown
 # AGENTS.md
@@ -35,9 +36,14 @@ This file tells Baloo (and other coding agents) how your project works:
 - All database access goes through the repository pattern in `app/repos/`
 
 ## Conventions
-- Branch names: `feat/description` or `fix/description`
-- Semantic commits required
-- All new endpoints need tests in `tests/api/`
+- Every PR must be tied to a ticket; branch name must include the ticket ID
+- Branch format: `feat/PROJ-123/short-description` or `fix/PROJ-456/short-description`
+- Commit format: `feat(scope): [PROJ-123] subject`
+- Pin all dependency versions exactly — no ^ or ~ ranges
+
+## Testing
+- Every PR must include integration tests
+- Work TDD: write failing tests before implementation
 
 ## Common Commands
 - `uv run pytest` — run tests
@@ -51,13 +57,25 @@ Standard contributor guidelines. Baloo reads this alongside AGENTS.md:
 ```markdown
 # Contributing
 
-## Commit Format
-<type>(<scope>): <subject>
+## Branching Strategy
 
-Types: feat, fix, docs, refactor, test, chore
+All branch names must include the ticket ID. Examples:
+- feat/PROJ-123/add-auth
+- fix/PROJ-456/fix-pagination
+
+## Commit Format
+<type>(<scope>): [<ticket-id>] <subject>
+
+Examples:
+  feat(auth): [PROJ-123] implement password hashing
+  fix(api): [PROJ-456] correct pagination query parameter
+
+## Dependency Management
+- All versions must be pinned exactly — no ^, ~, or >= ranges
+- Verify new packages before adding them
 
 ## Pull Requests
-- Link the related issue
+- Link the related ticket in the PR description
 - Include test coverage
 - Run lint before opening
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,8 @@ Baloo is a **GitHub App** that automatically reviews pull requests using LLMs. I
 ## Why Baloo?
 
 - **Catches what linters can't** — logic errors, silent failures, security antipatterns, missing error handling
-- **Respects your conventions** — reads `AGENTS.md` and `CONTRIBUTING.md` from your repo and enforces them
+- **Enforces your team's exact rules** — reads `AGENTS.md` and `CONTRIBUTING.md` and flags branch names missing ticket IDs, unpinned dependency versions, missing tests, architectural violations — whatever your team has written down
+- **Closes the plan-to-PR loop** — compares each PR against its linked design doc and scores how faithfully the implementation matched what was planned
 - **Posts like a teammate** — inline comments on specific lines, severity labels, approval/request-changes decisions
 - **Runs on every push** — new commits get reviewed automatically, with discussion thread tracking across iterations
 - **Self-hosted & private** — your code never leaves your infrastructure; bring your own API keys
@@ -46,9 +47,9 @@ Inline comments appear on the exact lines:
 | **Agentic review** | Uses [PI](https://github.com/mariozechner/pi-coding-agent) to read files, grep patterns, and explore the repo — not just the diff |
 | **Multi-model** | Supports Claude (Sonnet, Haiku, Opus) and Gemini (Flash, Pro) with automatic fallback |
 | **Severity routing** | CRITICAL/HIGH → request changes; MEDIUM → Checks API annotations; LOW → filtered |
-| **Guideline enforcement** | Reads repo-level `AGENTS.md` / `CONTRIBUTING.md` and flags violations |
+| **Guideline enforcement** | Reads repo-level `AGENTS.md` / `CONTRIBUTING.md` and flags violations as CRITICAL — branch naming, commit format, dependency pinning rules, architecture rules, anything documented |
 | **Discussion tracking** | Follows up on existing threads, skips duplicates, detects addressed feedback |
-| **Fidelity analysis** | Optionally compares PR against design plan documents |
+| **Fidelity analysis** | Compares PR changes against a linked design plan (`docs/plans/{ticket_id}.md`), scores 0–100, and factors the score into approval decisions |
 | **FP reduction** | Optional second LLM pass to verify findings and drop false positives |
 | **Dashboard** | Optional PostgreSQL-backed review history UI with cost tracking |
 | **Dependabot-aware** | Specialized review logic for dependency update PRs |


### PR DESCRIPTION
## Summary

- **guidelines.md**: expands "What Gets Flagged" with concrete examples (missing ticket IDs, unpinned deps, missing tests), and replaces the minimal placeholder examples with richer AGENTS.md / CONTRIBUTING.md templates covering ticket-linked branches, commit format, exact dependency pinning, and TDD requirements
- **fidelity.md**: adds a "Workflow Integration" section explaining the plan-before-coding pattern end-to-end
- **index.md**: sharpens "Why Baloo?" bullets and features table to call out guidelines enforcement and fidelity more concretely

## Test plan

- [ ] Read through `docs/features/guidelines.md` — examples are clear and actionable
- [ ] Read through `docs/features/fidelity.md` — workflow section makes the feature's value obvious
- [ ] Skim `docs/index.md` — bullets and table feel accurate