### PR TITLE
fix: include acknowledged findings in hit rate

### DIFF
--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -484,10 +484,11 @@ class DashboardService:
             outcomes = {r[0]: r[1] for r in outcome_rows}
 
             actioned = outcomes.get("actioned", 0)
+            acknowledged = outcomes.get("acknowledged", 0)
             disputed = outcomes.get("disputed", 0)
             ignored = outcomes.get("ignored", 0)
 
-            hit_rate = round(actioned / total * 100, 1) if total else 0.0
+            hit_rate = round((actioned + acknowledged) / total * 100, 1) if total else 0.0
             noise_rate = round((disputed + ignored) / total * 100, 1) if total else 0.0
 
             # --- By severity ---

--- a/tests/dashboard/test_outcomes_page.py
+++ b/tests/dashboard/test_outcomes_page.py
@@ -27,7 +27,7 @@ def test_outcomes_page_renders():
     mock_data = {
         "total": 50,
         "outcomes": {"actioned": 20, "disputed": 5, "acknowledged": 10, "ignored": 15},
-        "hit_rate": 40.0,
+        "hit_rate": 60.0,
         "noise_rate": 40.0,
         "severity_data": {
             "HIGH": {"total": 20, "actioned": 15, "hit_rate": 75.0},
@@ -53,5 +53,5 @@ def test_outcomes_page_renders():
 
     assert response.status_code == 200
     assert "Outcomes" in response.text
-    assert "40.0" in response.text  # hit_rate
+    assert "60.0" in response.text  # hit_rate
     assert "Accuracy Over Time" in response.text


### PR DESCRIPTION
## Summary

- Hit rate was only counting `actioned` findings, leaving `acknowledged` (~10%) unaccounted for in either metric
- `acknowledged` means the developer explicitly agreed the finding was valid (replied positively or resolved the thread) — semantically a hit
- Updated formula: hit rate = `(actioned + acknowledged) / total`, so hit rate + noise rate now sums to 100%

## Test Plan
- [ ] Verify Outcomes page shows hit rate and noise rate summing to 100%
- [ ] Unit tests updated and passing (`588 passed`)