### PR TITLE
fix: remove installation_id from /health response

### DIFF
--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -191,12 +191,7 @@ async def root() -> dict[str, str]:
 @app.get("/health")
 async def health() -> dict[str, str]:
     """Health check endpoint for load balancer probes."""
-    from baloo.config.settings import get_settings
-
-    return {
-        "status": "ok",
-        "installation_id": get_settings().installation_id or "*",
-    }
+    return {"status": "ok"}
 
 
 # ------------------------------------------------------------------

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,10 +141,10 @@ Each broker only sees its own installation's data in the database.
 Each broker exposes `GET /health`:
 
 ```json
-{ "status": "ok", "installation_id": "111" }
+{ "status": "ok" }
 ```
 
-`"*"` means the broker handles all installations. Use this endpoint for load balancer health probes.
+Use this endpoint for load balancer health probes.
 
 ### Webhook Security
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -144,7 +144,7 @@ curl http://localhost:8000/health
 Expected response:
 
 ```json
-{"status":"healthy"}
+{"status":"ok"}
 ```
 
 If you enabled the dashboard, verify both of these:

--- a/tests/github/test_webhook_validation.py
+++ b/tests/github/test_webhook_validation.py
@@ -124,26 +124,13 @@ class TestValidateWebhookSecurity:
 
 
 class TestHealthEndpoint:
-    def test_health_returns_ok_with_wildcard_when_unrestricted(self, monkeypatch):
+    def test_health_returns_ok(self, monkeypatch):
         from fastapi.testclient import TestClient
 
         from baloo.github.webhook_handler import app
 
-        monkeypatch.setenv("INSTALLATION_ID", "")
         client = TestClient(app)
         response = client.get("/health")
 
         assert response.status_code == 200
-        assert response.json() == {"status": "ok", "installation_id": "*"}
-
-    def test_health_returns_installation_id_when_configured(self, monkeypatch):
-        from fastapi.testclient import TestClient
-
-        from baloo.github.webhook_handler import app
-
-        monkeypatch.setenv("INSTALLATION_ID", "111")
-        client = TestClient(app)
-        response = client.get("/health")
-
-        assert response.status_code == 200
-        assert response.json() == {"status": "ok", "installation_id": "111"}
+        assert response.json() == {"status": "ok"}

--- a/tests/github/test_webhook_validation.py
+++ b/tests/github/test_webhook_validation.py
@@ -124,7 +124,7 @@ class TestValidateWebhookSecurity:
 
 
 class TestHealthEndpoint:
-    def test_health_returns_ok(self, monkeypatch):
+    def test_health_returns_ok(self):
         from fastapi.testclient import TestClient
 
         from baloo.github.webhook_handler import app


### PR DESCRIPTION
## Summary

- `installation_id` is confidential and must not be exposed via the public `/health` endpoint
- `/health` now returns only `{"status": "ok"}`
- Removed the two tests that asserted on `installation_id` in the health response, replaced with a single clean test

## Security
This is a patch for v1.2.0 which inadvertently exposed `installation_id` in the health check response.