### PR TITLE
fix: treat 404 as end-of-pagination in _fetch_paginated_json

### DIFF
--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -866,6 +866,8 @@ class GitHubAPIClient:
             response = await self._http.get(
                 url, headers=headers, params={"per_page": 100, "page": page}
             )
+            if response.status_code == 404:
+                break
             response.raise_for_status()
             data = response.json()
             if not data:

--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -867,6 +867,13 @@ class GitHubAPIClient:
                 url, headers=headers, params={"per_page": 100, "page": page}
             )
             if response.status_code == 404:
+                if page == 1:
+                    response.raise_for_status()
+                logger.debug(
+                    "Received 404 on page %d of %s; treating as end of pagination",
+                    page,
+                    url,
+                )
                 break
             response.raise_for_status()
             data = response.json()

--- a/tests/github/test_api_client.py
+++ b/tests/github/test_api_client.py
@@ -342,6 +342,23 @@ class TestFetchPaginatedJson:
         assert result == []
         mock_http.get.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_stops_on_404_mid_pagination(self):
+        # GitHub can return 404 for out-of-bounds pages (e.g. PR files endpoint)
+        page1 = [{"id": i} for i in range(100)]
+        page2 = [{"id": i} for i in range(100, 200)]
+        client, mock_http = _make_client()
+        mock_http.get.side_effect = [
+            _mock_response(page1),
+            _mock_response(page2),
+            _mock_response(status_code=404),
+        ]
+
+        result = await client._fetch_paginated_json("https://api.github.com/some/endpoint")
+
+        assert len(result) == 200
+        assert mock_http.get.call_count == 3
+
 
 class TestGetChangedScopeBetweenCommits:
     @pytest.mark.asyncio

--- a/tests/github/test_api_client.py
+++ b/tests/github/test_api_client.py
@@ -359,6 +359,15 @@ class TestFetchPaginatedJson:
         assert len(result) == 200
         assert mock_http.get.call_count == 3
 
+    @pytest.mark.asyncio
+    async def test_raises_on_404_first_page(self):
+        # A 404 on page 1 is a genuine error (bad URL, deleted PR) — must not swallow it
+        client, mock_http = _make_client()
+        mock_http.get.return_value = _mock_response(status_code=404)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await client._fetch_paginated_json("https://api.github.com/some/endpoint")
+
 
 class TestGetChangedScopeBetweenCommits:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- GitHub returns 404 (instead of an empty array) for out-of-bounds pages on some endpoints, including PR files for large PRs
- `_fetch_paginated_json` was calling `raise_for_status()` before checking for 404, causing Baloo to crash and post an error comment on any PR with 600+ changed files
- Fix: break out of the pagination loop on 404 instead of raising

## Test Plan

- [ ] New test `test_stops_on_404_mid_pagination` verifies that a 404 mid-pagination returns accumulated results and stops gracefully
- [ ] All 588 existing tests continue to pass