### PR TITLE
feat: add read-only dashboard settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,5 @@ temp/
 
 # AI agent plans/specs (internal workflow scaffolding)
 docs/superpowers/
+.antigravitycli/
+.claude/

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse
@@ -26,6 +26,21 @@ SENSITIVE_SETTINGS = {
     "dashboard_password",
     "github_private_key",
     "github_webhook_secret",
+}
+
+SENSITIVE_DATABASE_QUERY_KEYS = {
+    "api_key",
+    "apikey",
+    "auth_source",
+    "authsource",
+    "client_secret",
+    "pass",
+    "password",
+    "pwd",
+    "secret",
+    "ssl_password",
+    "sslpassword",
+    "token",
 }
 
 SETTING_CATEGORIES = {
@@ -88,6 +103,18 @@ SETTING_CATEGORIES = {
 }
 
 
+def _sanitize_database_query(query: str) -> str:
+    if not query:
+        return ""
+
+    params = parse_qsl(query, keep_blank_values=True)
+    sanitized = [
+        (key, "[REDACTED]" if key.lower() in SENSITIVE_DATABASE_QUERY_KEYS else value)
+        for key, value in params
+    ]
+    return urlencode(sanitized, doseq=True)
+
+
 def _sanitize_database_url(value: str) -> str:
     """Remove database credentials while preserving the useful connection target."""
     if not value:
@@ -98,8 +125,12 @@ def _sanitize_database_url(value: str) -> str:
     except ValueError:
         return "Configured (credentials redacted)"
 
+    query = _sanitize_database_query(parsed.query)
+
     if not parsed.username and not parsed.password:
-        return value
+        if query == parsed.query:
+            return value
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
 
     host = parsed.hostname or ""
     if ":" in host and not host.startswith("["):
@@ -110,7 +141,7 @@ def _sanitize_database_url(value: str) -> str:
         port = None
     if port is not None:
         host = f"{host}:{port}"
-    return urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+    return urlunsplit((parsed.scheme, host, parsed.path, query, parsed.fragment))
 
 
 def _format_setting_value(name: str, value: Any) -> str:

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from baloo.config.settings import Settings, get_settings
 from baloo.dashboard.auth import verify_credentials
 from baloo.dashboard.queries import DashboardService
 
@@ -17,6 +20,135 @@ router = APIRouter(
 )
 
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+SENSITIVE_SETTINGS = {
+    "anthropic_api_key",
+    "dashboard_password",
+    "github_private_key",
+    "github_webhook_secret",
+}
+
+SETTING_CATEGORIES = {
+    "GitHub": {
+        "github_app_id",
+        "github_private_key",
+        "github_webhook_secret",
+        "webhook_pre_verified",
+    },
+    "Anthropic": {"anthropic_api_key"},
+    "Application": {
+        "app_environment",
+        "app_host",
+        "app_port",
+        "log_level",
+        "max_concurrent_reviews",
+        "review_stale_timeout_minutes",
+    },
+    "Agent": {
+        "agent_provider",
+        "agent_model",
+        "agent_fallback_model",
+        "agent_max_tokens",
+        "agent_temperature",
+        "pi_binary_path",
+        "pi_thinking_level",
+    },
+    "Review": {
+        "ticket_id_prefix",
+        "review_auto_approve",
+        "review_min_severity",
+        "review_use_checks_api",
+    },
+    "Database": {"database_url", "database_enabled", "installation_id"},
+    "Dashboard": {
+        "dashboard_enabled",
+        "dashboard_username",
+        "dashboard_password",
+        "log_retention_days",
+    },
+    "False-Positive Verification": {
+        "fp_verification_enabled",
+        "fp_verification_model",
+        "fp_verification_max_concurrent",
+        "fp_audit_log_path",
+    },
+    "Thread Agent": {
+        "thread_agent_enabled",
+        "thread_agent_model",
+        "thread_agent_max_replies",
+        "thread_agent_max_concurrent",
+    },
+    "Feedback Signals": {"feedback_signals_enabled", "feedback_signals_ttl_days"},
+    "AST Tools": {"ast_tools_enabled"},
+    "Fidelity Report": {
+        "fidelity_enabled",
+        "fidelity_plan_path_pattern",
+        "fidelity_approval_threshold",
+    },
+}
+
+
+def _sanitize_database_url(value: str) -> str:
+    """Remove database credentials while preserving the useful connection target."""
+    if not value:
+        return "(empty)"
+
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "Configured (credentials redacted)"
+
+    if not parsed.username and not parsed.password:
+        return value
+
+    host = parsed.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        host = f"{host}:{port}"
+    return urlunsplit((parsed.scheme, host, parsed.path, parsed.query, parsed.fragment))
+
+
+def _format_setting_value(name: str, value: Any) -> str:
+    if name in SENSITIVE_SETTINGS:
+        return "Configured (redacted)" if value else "Not configured"
+    if name == "database_url":
+        return _sanitize_database_url(str(value or ""))
+    if value is None:
+        return "None"
+    if value == "":
+        return "(empty)"
+    return str(value)
+
+
+def _setting_category(name: str) -> str:
+    for category, names in SETTING_CATEGORIES.items():
+        if name in names:
+            return category
+    return "Other"
+
+
+def _settings_rows() -> list[dict[str, str]]:
+    settings = get_settings()
+    rows = []
+    for name, field in Settings.model_fields.items():
+        value = getattr(settings, name)
+        default = field.default
+        rows.append(
+            {
+                "category": _setting_category(name),
+                "env_var": name.upper(),
+                "name": name,
+                "value": _format_setting_value(name, value),
+                "default": _format_setting_value(name, default),
+                "description": field.description or "",
+            }
+        )
+    return rows
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -104,4 +236,13 @@ async def outcomes(
         request=request,
         name="outcomes.html",
         context={"days": days, "repo": repo, **data},
+    )
+
+
+@router.get("/settings", response_class=HTMLResponse)
+async def settings_page(request: Request):
+    return templates.TemplateResponse(
+        request=request,
+        name="settings.html",
+        context={"settings_rows": _settings_rows()},
     )

--- a/baloo/dashboard/templates/base.html
+++ b/baloo/dashboard/templates/base.html
@@ -34,6 +34,11 @@
                     {% if active_page == 'outcomes' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{% endif %}">
             Outcomes
           </a>
+          <a href="/dashboard/settings"
+             class="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium
+                    {% if active_page == 'settings' %}border-indigo-500 text-gray-900{% else %}border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300{% endif %}">
+            Settings
+          </a>
         </div>
       </div>
     </div>

--- a/baloo/dashboard/templates/settings.html
+++ b/baloo/dashboard/templates/settings.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% set active_page = "settings" %}
+
+{% block title %}Settings - Baloo Dashboard{% endblock %}
+
+{% block content %}
+<div class="flex items-start justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-bold text-gray-900">Settings</h1>
+    <p class="mt-1 text-sm text-gray-500">Effective runtime configuration loaded for this Baloo instance.</p>
+  </div>
+</div>
+
+{% set ns = namespace(category="") %}
+{% for row in settings_rows %}
+  {% if row.category != ns.category %}
+    {% if not loop.first %}
+      </tbody>
+      </table>
+      </div>
+      </div>
+    {% endif %}
+    {% set ns.category = row.category %}
+    <div class="bg-white rounded-lg shadow overflow-hidden mb-8">
+      <div class="px-5 py-4 border-b border-gray-200">
+        <h2 class="text-lg font-semibold text-gray-900">{{ row.category }}</h2>
+      </div>
+      <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Variable</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Value</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Default</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Description</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+  {% endif %}
+          <tr class="hover:bg-gray-50">
+            <td class="px-4 py-3 text-sm font-mono text-gray-900 whitespace-nowrap">{{ row.env_var }}</td>
+            <td class="px-4 py-3 text-sm font-mono text-gray-700 max-w-md break-all">{{ row.value }}</td>
+            <td class="px-4 py-3 text-sm font-mono text-gray-500 max-w-sm break-all">{{ row.default }}</td>
+            <td class="px-4 py-3 text-sm text-gray-600 min-w-64">{{ row.description }}</td>
+          </tr>
+{% endfor %}
+{% if settings_rows %}
+        </tbody>
+      </table>
+      </div>
+    </div>
+{% else %}
+<div class="bg-white rounded-lg shadow p-8 text-center text-gray-400">No settings available</div>
+{% endif %}
+{% endblock %}

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -62,7 +62,8 @@ def test_dashboard_settings_renders_sanitized_values(monkeypatch) -> None:
 
     monkeypatch.setenv(
         "DATABASE_URL",
-        "postgresql+asyncpg://dbuser:dbpass@db.example.com:5432/baloo",
+        "postgresql+asyncpg://dbuser:dbpass@db.example.com:5432/baloo"
+        "?sslmode=require&password=query-secret&sslpassword=ssl-secret",
     )
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-secret")
     monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "webhook-secret")
@@ -79,10 +80,16 @@ def test_dashboard_settings_renders_sanitized_values(monkeypatch) -> None:
     assert "APP_ENVIRONMENT" in response.text
     assert "production" in response.text
     assert "DATABASE_URL" in response.text
-    assert "postgresql+asyncpg://db.example.com:5432/baloo" in response.text
+    assert (
+        "postgresql+asyncpg://db.example.com:5432/baloo"
+        "?sslmode=require&amp;password=%5BREDACTED%5D&amp;sslpassword=%5BREDACTED%5D"
+        in response.text
+    )
     assert "Configured (redacted)" in response.text
     assert "dbuser" not in response.text
     assert "dbpass" not in response.text
+    assert "query-secret" not in response.text
+    assert "ssl-secret" not in response.text
     assert "sk-ant-test-secret" not in response.text
     assert "webhook-secret" not in response.text
     assert "dashboard-secret" not in response.text

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -55,3 +55,34 @@ def test_dashboard_overview_renders() -> None:
     assert response.status_code == 200
     assert "Overview" in response.text
     assert "example-org/example-repo" in response.text
+
+
+def test_dashboard_settings_renders_sanitized_values(monkeypatch) -> None:
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+asyncpg://dbuser:dbpass@db.example.com:5432/baloo",
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-secret")
+    monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", "webhook-secret")
+    monkeypatch.setenv("DASHBOARD_PASSWORD", "dashboard-secret")
+    monkeypatch.setenv("APP_ENVIRONMENT", "production")
+    reset_settings()
+
+    app = _build_app()
+    client = TestClient(app)
+    response = client.get("/dashboard/settings")
+
+    assert response.status_code == 200
+    assert "Settings" in response.text
+    assert "APP_ENVIRONMENT" in response.text
+    assert "production" in response.text
+    assert "DATABASE_URL" in response.text
+    assert "postgresql+asyncpg://db.example.com:5432/baloo" in response.text
+    assert "Configured (redacted)" in response.text
+    assert "dbuser" not in response.text
+    assert "dbpass" not in response.text
+    assert "sk-ant-test-secret" not in response.text
+    assert "webhook-secret" not in response.text
+    assert "dashboard-secret" not in response.text


### PR DESCRIPTION
## Summary
- add a read-only dashboard settings page backed by the Pydantic Settings model
- redact configured secrets and sanitize DATABASE_URL credentials
- add the Settings nav link and ignore local AI tooling directories

## Validation
- uv run pytest
- uv run ruff check baloo tests