### PR TITLE
fix: scope scorecard workflow permissions to job level

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,15 +8,16 @@ on:
     - cron: "19 5 * * 2"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
-  security-events: write
+permissions: read-all
 
 jobs:
   scorecard:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Summary
- Moves `id-token: write` and `security-events: write` from the global permissions block to the `scorecard` job level
- Sets global permissions to `read-all`

## Why
The Scorecard API rejects results from workflows where write permissions are set globally — it requires them to be scoped to the job.

## Test Plan
- [ ] Workflow runs and publishes results to the Scorecard API
- [ ] Badge at `https://api.scorecard.dev/projects/github.com/Blue-Bear-Security/baloo-bear` resolves