### PR TITLE
fix: pin scorecard action to release commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@f2ea147fec3c2f0d459703eba7405b5e9bcd8c8f # v2.4.2
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           results_file: scorecard.sarif


### PR DESCRIPTION
## Summary
- pin OpenSSF Scorecard v2.4.2 to the release commit instead of the annotated tag object SHA

## Testing
- git diff --check
- verified via GitHub API that tag object f2ea147fec3c2f0d459703eba7405b5e9bcd8c8f dereferences to commit 05b42c624433fc40578a4040d5cf5e36ddca8cde
- attempted manual workflow dispatch on the PR branch in runs 27014911959 and 27015057081; both confirmed the action uses the corrected ref, but OpenSSF Scorecard refuses non-default branches with: "Only the default branch main is supported"

## Notes
- Full end-to-end Scorecard publish verification can only run on the repository default branch. The failing main run rejected the annotated tag object SHA; this PR changes the action ref to the actual commit behind v2.4.2.