### PR TITLE
fix: pin codeql-action/upload-sarif to a real release SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard SARIF
-        uses: github/codeql-action/upload-sarif@a6fd1787519fd23e68309fad43738e41a6ff2a9d # v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: scorecard.sarif


### PR DESCRIPTION
## Problem

The OpenSSF Scorecard workflow fails on `main` ([run](https://github.com/Blue-Bear-Security/baloo-bear/actions/runs/27016024540/job/79731115321)). The Scorecard webapp rejects the results with:

```
imposter commit: a6fd1787519fd23e68309fad43738e41a6ff2a9d does not belong to github/codeql-action/upload-sarif
```

The SHA pinned in #92 does not exist in `github/codeql-action` (`gh api` returns 422 "No commit found"). Because `publish_results: true` triggers workflow verification, the bogus pin fails the whole job.

## Fix

Repin `github/codeql-action/upload-sarif` to **v4.36.2** (`8aad20d150bbac5944a9f9d289da16a4b0d87c1e`), the real SHA for that release tag.