### PR TITLE
fix(agent): authenticate worktree checkout, consistent logging, agent labels

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -32,5 +32,7 @@ level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
-datefmt = %H:%M:%S
+# Kept in sync with baloo.logging_config.LOG_FORMAT / LOG_DATEFMT so Alembic
+# output (CLI and in-app migrations) matches the rest of the application.
+format = %(asctime)s %(levelname)-5s [%(name)s] %(message)s
+datefmt = %Y-%m-%d %H:%M:%S UTC

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -41,6 +41,10 @@ class PIAgentOptions:
     # Useful for single-turn JSON-in/JSON-out tasks where all context
     # is already embedded in the prompt.
     no_tools: bool = False
+    # Human-readable label for logs. Distinguishes the several agents that
+    # instantiate PIAgentBase directly (scope decider, thread agent, ...) —
+    # without it they all log under the generic class name "PIAgentBase".
+    name: str | None = None
 
 
 @dataclass
@@ -374,7 +378,9 @@ class PIAgentBase:
 
     def __init__(self, options: PIAgentOptions):
         self.options = options
-        self.agent_name = self.__class__.__name__
+        # Prefer an explicit label so directly-instantiated agents are
+        # distinguishable in logs; fall back to the subclass name.
+        self.agent_name = options.name or self.__class__.__name__
 
     # -----------------------------------------------------------------
     # Low-level RPC helpers
@@ -856,12 +862,22 @@ Serialized payload:
                     )
                 turn_tools = []
                 if turn_count >= self.options.max_turns:
-                    logger.warning(
-                        "%s: max turns (%d) reached, aborting",
-                        self.agent_name,
-                        self.options.max_turns,
-                    )
                     result.max_turns_reached = True
+                    if last_assistant_text:
+                        # The model produced a final response before exhausting
+                        # its budget — expected for single-turn deciders, and a
+                        # clean (if capped) finish for longer agents. Not an error.
+                        logger.info(
+                            "%s: reached turn cap (%d) with a response — finalizing",
+                            self.agent_name,
+                            self.options.max_turns,
+                        )
+                    else:
+                        logger.warning(
+                            "%s: max turns (%d) reached with no response, aborting",
+                            self.agent_name,
+                            self.options.max_turns,
+                        )
                     assert proc.stdin is not None
                     proc.stdin.write(self._make_command("abort").encode("utf-8"))
                     await proc.stdin.drain()

--- a/baloo/agent/repo_provision.py
+++ b/baloo/agent/repo_provision.py
@@ -149,10 +149,20 @@ def build_fetch_cmd(
 
 
 def build_worktree_add_cmd(
-    cache_dir_path: str | os.PathLike, wt_dir: str | os.PathLike, head_sha: str
+    token: str | None,
+    cache_dir_path: str | os.PathLike,
+    wt_dir: str | os.PathLike,
+    head_sha: str,
 ) -> list[str]:
+    # The bare cache is blobless (clone + fetch use --filter=blob:none), so
+    # checking out the worktree triggers a lazy promisor fetch of the missing
+    # file blobs from origin. Inject the auth header (never the URL) so that
+    # fetch authenticates; without it git prompts for a username and aborts
+    # with "could not read Username for 'https://github.com'". The -c override
+    # propagates to the internal fetch via GIT_CONFIG_PARAMETERS.
     return [
         "git",
+        *_auth_args(token),
         "-C",
         str(cache_dir_path),
         "worktree",
@@ -320,7 +330,7 @@ async def provision_repo(
                 raise RuntimeError(f"fetch failed (rc={rc}): {out[-500:]}")
             # Clear stale worktree admin metadata left by crashed reviews.
             await _run_git(build_worktree_prune_cmd(cdir))
-            rc, out = await _run_git(build_worktree_add_cmd(cdir, wt, head_sha))
+            rc, out = await _run_git(build_worktree_add_cmd(token, cdir, wt, head_sha))
             if rc != 0:
                 raise RuntimeError(f"worktree add failed (rc={rc}): {out[-500:]}")
             _active[ckey] = _active.get(ckey, 0) + 1

--- a/baloo/agent/thread_agent.py
+++ b/baloo/agent/thread_agent.py
@@ -117,6 +117,7 @@ class ThreadAgent:
         options.system_prompt = THREAD_AGENT_SYSTEM_PROMPT
         options.no_tools = True
         options.max_turns = 2
+        options.name = "ThreadAgent"
 
         agent = PIAgentBase(options)
         return await agent.run_query(prompt)

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -100,6 +100,12 @@ SETTING_CATEGORIES = {
         "fidelity_plan_path_pattern",
         "fidelity_approval_threshold",
     },
+    "Repo Provisioning": {
+        "repo_cache_enabled",
+        "repo_cache_root",
+        "repo_cache_max_disk_gb",
+        "repo_sandbox_mode",
+    },
 }
 
 

--- a/baloo/db/engine.py
+++ b/baloo/db/engine.py
@@ -111,6 +111,13 @@ def _run_alembic_migrations(database_url: str) -> bool:
             # Advisory lock released automatically when connection closes
     finally:
         sync_engine.dispose()
+        # Alembic's env.py ran fileConfig(alembic.ini), which clobbered the
+        # root logger's handler/format and raised its level to WARN (silently
+        # dropping every baloo.* INFO line). Restore the app's logging config.
+        from baloo.config.settings import get_settings
+        from baloo.logging_config import configure_logging
+
+        configure_logging(get_settings().log_level)
 
     return True
 

--- a/baloo/logging_config.py
+++ b/baloo/logging_config.py
@@ -1,0 +1,67 @@
+"""Centralized logging configuration for the Baloo application.
+
+Every log line — app code, uvicorn, and Alembic — should share one format:
+
+    2026-06-06 15:31:24 UTC INFO  [baloo.agent.pi_runtime] ...
+
+The non-obvious hazard this module guards against: Alembic's ``env.py`` calls
+``logging.config.fileConfig(alembic.ini)`` whenever migrations run. ``fileConfig``
+clears the root logger's handlers and installs Alembic's own (timestamp-less)
+handler *and* raises the root level to WARN — silently dropping every ``baloo.*``
+INFO line for the rest of the process. ``configure_logging`` is therefore called
+both at startup AND again after migrations (see ``baloo.db.engine``) to restore
+the app's handler, format, and level.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+# Shared by the app, uvicorn, and alembic.ini's formatter — keep all three in sync.
+LOG_FORMAT = "%(asctime)s %(levelname)-5s [%(name)s] %(message)s"
+LOG_DATEFMT = "%Y-%m-%d %H:%M:%S UTC"
+
+# Uvicorn log config — override its default formatters so every line gets a
+# timestamp, matching the rest of the application output.
+UVICORN_LOG_CONFIG: dict = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "default": {"format": LOG_FORMAT, "datefmt": LOG_DATEFMT},
+        "access": {"format": LOG_FORMAT, "datefmt": LOG_DATEFMT},
+    },
+    "handlers": {
+        "default": {
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+        },
+        "access": {
+            "formatter": "access",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
+        },
+    },
+    "loggers": {
+        "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
+        "uvicorn.error": {"level": "INFO"},
+        "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
+    },
+}
+
+
+def configure_logging(level: str | int = "INFO") -> None:
+    """(Re)apply the canonical root logging configuration.
+
+    Idempotent and safe to call repeatedly: ``force=True`` replaces any existing
+    root handlers (including ones Alembic's ``fileConfig`` may have installed) so
+    the app's format and level always win.
+    """
+    logging.basicConfig(level=level, format=LOG_FORMAT, datefmt=LOG_DATEFMT, force=True)
+    # Emit all timestamps in UTC (matches the " UTC" suffix in LOG_DATEFMT).
+    logging.Formatter.converter = time.gmtime
+
+    # Suppress verbose logs from third-party libraries.
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -292,6 +292,7 @@ async def _decide_synchronize_review_mode(
     options.max_turns = 1
     options.no_tools = True
     options.thinking_level = "minimal"
+    options.name = "SyncScopeDecider"
     decider = PIAgentBase(options)
 
     changed_files_list = "\n".join(
@@ -1088,6 +1089,25 @@ async def process_pr_review(
                 repo_path = checkout.path if checkout.available else None
                 if repo_path:
                     agent.options.cwd = repo_path
+                    logger.info(
+                        "Agent file tools using provisioned worktree for %s#%s: %s",
+                        repo_full_name,
+                        pr_number,
+                        repo_path,
+                    )
+                else:
+                    # No checkout: the PI subprocess inherits baloo's own cwd
+                    # (/app in the container), so every PR-file read/grep/find
+                    # fails and the review is effectively diff-only. Surface why
+                    # — the master switch being off is otherwise totally silent.
+                    logger.warning(
+                        "No PR checkout for %s#%s (repo_cache_enabled=%s) — agent "
+                        "file tools will run against baloo's own cwd, not the PR; "
+                        "reviewing diff-only",
+                        repo_full_name,
+                        pr_number,
+                        settings.repo_cache_enabled,
+                    )
 
                 if settings.fidelity_enabled:
                     (

--- a/main.py
+++ b/main.py
@@ -1,53 +1,17 @@
 """Main entry point for Baloo application."""
 
 import logging
-import time
 
 import uvicorn
 
 from baloo.config.settings import settings
 from baloo.github.webhook_handler import app
+from baloo.logging_config import UVICORN_LOG_CONFIG, configure_logging
 from baloo.version import BUILD_DATE, COMMIT_SHA, VERSION, get_version_info
 
-# Logging format shared by the app and uvicorn
-LOG_FORMAT = "%(asctime)s %(levelname)-5s [%(name)s] %(message)s"
-LOG_DATEFMT = "%Y-%m-%d %H:%M:%S UTC"
-
-# Configure root logger (covers all non-uvicorn loggers)
-logging.basicConfig(level=settings.log_level, format=LOG_FORMAT, datefmt=LOG_DATEFMT)
-logging.Formatter.converter = time.gmtime
-
-# Uvicorn log config — override its default formatters so every line
-# gets a timestamp, matching the rest of the application output.
-UVICORN_LOG_CONFIG: dict = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "default": {"format": LOG_FORMAT, "datefmt": LOG_DATEFMT},
-        "access": {"format": LOG_FORMAT, "datefmt": LOG_DATEFMT},
-    },
-    "handlers": {
-        "default": {
-            "formatter": "default",
-            "class": "logging.StreamHandler",
-            "stream": "ext://sys.stderr",
-        },
-        "access": {
-            "formatter": "access",
-            "class": "logging.StreamHandler",
-            "stream": "ext://sys.stdout",
-        },
-    },
-    "loggers": {
-        "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
-        "uvicorn.error": {"level": "INFO"},
-        "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": False},
-    },
-}
-
-# Suppress verbose logs from third-party libraries
-logging.getLogger("httpcore").setLevel(logging.WARNING)
-logging.getLogger("httpx").setLevel(logging.WARNING)
+# Configure root logger (covers all non-uvicorn loggers). Re-applied after DB
+# migrations run — see baloo.logging_config for why.
+configure_logging(settings.log_level)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/agent/test_repo_provision.py
+++ b/tests/agent/test_repo_provision.py
@@ -69,9 +69,11 @@ def test_fetch_cmd_targets_cache_and_sha():
 
 
 def test_worktree_add_cmd_is_detached_at_sha():
-    cmd = rp.build_worktree_add_cmd("/cache/x.git", "/cache/wt", "deadbeef")
+    cmd = rp.build_worktree_add_cmd("TOK123", "/cache/x.git", "/cache/wt", "deadbeef")
     assert cmd == [
         "git",
+        "-c",
+        f"http.extraHeader={rp.auth_header('TOK123')}",
         "-C",
         "/cache/x.git",
         "worktree",
@@ -80,6 +82,21 @@ def test_worktree_add_cmd_is_detached_at_sha():
         "/cache/wt",
         "deadbeef",
     ]
+
+
+def test_worktree_add_cmd_injects_token_for_lazy_blob_fetch():
+    # The bare repo is blobless; `worktree add` checks out the head SHA, which
+    # triggers a lazy promisor fetch of the missing file blobs. That fetch must
+    # carry the auth header or it fails with "could not read Username".
+    cmd = rp.build_worktree_add_cmd("TOK123", "/cache/x.git", "/cache/wt", "deadbeef")
+    assert "TOK123@" not in " ".join(cmd)
+    assert any(a.startswith("http.extraHeader=AUTHORIZATION: basic ") for a in cmd)
+
+
+def test_worktree_add_cmd_omits_auth_when_token_empty():
+    cmd = rp.build_worktree_add_cmd("", "/cache/x.git", "/cache/wt", "deadbeef")
+    assert "-c" not in cmd
+    assert not any("http.extraHeader" in a for a in cmd)
 
 
 def test_worktree_remove_and_prune_cmds():

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -75,6 +75,7 @@ class TestPIAgentOptions:
         assert opts.thinking_level == "medium"
         assert opts.max_turns == 20
         assert opts.cwd is None
+        assert opts.name is None
 
     def test_custom_values(self):
         opts = PIAgentOptions(
@@ -87,6 +88,14 @@ class TestPIAgentOptions:
         assert opts.model == "claude-opus-4-6"
         assert opts.max_turns == 30
         assert opts.cwd == "/tmp/repo"
+
+    def test_agent_name_defaults_to_class_name(self):
+        agent = PIAgentBase(PIAgentOptions())
+        assert agent.agent_name == "PIAgentBase"
+
+    def test_agent_name_prefers_options_name(self):
+        agent = PIAgentBase(PIAgentOptions(name="SyncScopeDecider"))
+        assert agent.agent_name == "SyncScopeDecider"
 
 
 class TestPIAgentBase:
@@ -450,6 +459,86 @@ class TestPIAgentBaseRunQuery:
             write_calls = proc.stdin.write.call_args_list
             abort_sent = any(b'"abort"' in call[0][0] for call in write_calls)
             assert abort_sent
+
+    async def _run_single_turn(self, *, with_text: bool):
+        """Drive a max_turns=1 agent, optionally producing assistant text."""
+        agent = PIAgentBase(PIAgentOptions(max_turns=1, name="SyncScopeDecider"))
+
+        message_content = [{"type": "text", "text": '{"mode": "scoped"}'}] if with_text else []
+        events = [
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
+            json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
+            json.dumps({"type": "turn_start"}).encode() + b"\n",
+            json.dumps(
+                {
+                    "type": "message_end",
+                    "message": {
+                        "role": "assistant",
+                        "content": message_content,
+                        "model": "test",
+                        "usage": {"input": 10, "output": 5, "cost": {"total": 0.001}},
+                    },
+                }
+            ).encode()
+            + b"\n",
+            json.dumps({"type": "turn_end"}).encode() + b"\n",
+            json.dumps({"type": "agent_end"}).encode() + b"\n",
+        ]
+
+        with patch("baloo.agent.pi_runtime.asyncio.create_subprocess_exec") as mock_exec:
+            proc = AsyncMock()
+            proc.returncode = None
+            proc.stdin = AsyncMock()
+            proc.stdin.write = MagicMock()
+            proc.stdin.drain = AsyncMock()
+            proc.stdout = AsyncMock(spec=asyncio.StreamReader)
+
+            event_iter = iter(events)
+
+            async def fake_readline():
+                try:
+                    return next(event_iter)
+                except StopIteration:
+                    return b""
+
+            proc.stdout.readline = fake_readline
+            proc.stderr = AsyncMock()
+            proc.kill = MagicMock()
+            proc.wait = AsyncMock()
+            mock_exec.return_value = proc
+
+            await agent.run_query("Decide scope")
+
+    @pytest.mark.asyncio
+    async def test_max_turns_with_response_logs_info_not_warning(self, caplog):
+        """A single-turn decider that answered should not warn — reaching the
+        cap is its expected, successful exit."""
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="baloo.agent.pi_runtime"):
+            await self._run_single_turn(with_text=True)
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not any("max turns" in r.getMessage() for r in warnings)
+        assert any(
+            "reached turn cap" in r.getMessage() and "SyncScopeDecider" in r.getMessage()
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_max_turns_without_response_warns(self, caplog):
+        """Hitting the cap with no output is a genuine problem — warn."""
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="baloo.agent.pi_runtime"):
+            await self._run_single_turn(with_text=False)
+
+        assert any(
+            r.levelno >= logging.WARNING and "max turns" in r.getMessage() for r in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_json_retry_on_invalid_response(self):

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -93,3 +93,25 @@ def test_dashboard_settings_renders_sanitized_values(monkeypatch) -> None:
     assert "sk-ant-test-secret" not in response.text
     assert "webhook-secret" not in response.text
     assert "dashboard-secret" not in response.text
+
+
+def test_every_setting_is_categorized() -> None:
+    """No setting should fall into the catch-all 'Other' bucket — each new
+    field must be assigned a category so it surfaces under a real heading."""
+    from baloo.dashboard.router import _settings_rows
+
+    uncategorized = sorted(r["name"] for r in _settings_rows() if r["category"] == "Other")
+    assert uncategorized == [], f"settings missing a category: {uncategorized}"
+
+
+def test_repo_provisioning_settings_are_grouped() -> None:
+    from baloo.dashboard.router import _settings_rows
+
+    by_name = {r["name"]: r["category"] for r in _settings_rows()}
+    for name in (
+        "repo_cache_enabled",
+        "repo_cache_root",
+        "repo_cache_max_disk_gb",
+        "repo_sandbox_mode",
+    ):
+        assert by_name[name] == "Repo Provisioning"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,77 @@
+"""Tests for centralized logging configuration.
+
+The critical regression these guard: Alembic's ``fileConfig`` (run on every
+in-app migration) clobbers the root logger — stripping timestamps and raising
+the level to WARN, which silently drops every ``baloo.*`` INFO line.
+``configure_logging`` must be able to undo that.
+"""
+
+from __future__ import annotations
+
+import logging
+from logging.config import fileConfig
+
+import pytest
+
+from baloo.logging_config import (
+    LOG_DATEFMT,
+    LOG_FORMAT,
+    UVICORN_LOG_CONFIG,
+    configure_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_logging():
+    """Leave global logging state as we found it."""
+    root = logging.getLogger()
+    saved = (root.level, list(root.handlers), logging.Formatter.converter)
+    try:
+        yield
+    finally:
+        root.setLevel(saved[0])
+        root.handlers[:] = saved[1]
+        logging.Formatter.converter = saved[2]
+
+
+def test_configure_logging_sets_format_and_level():
+    configure_logging("INFO")
+    root = logging.getLogger()
+    assert root.level == logging.INFO
+    assert root.handlers, "expected a root handler"
+    assert root.handlers[0].formatter._fmt == LOG_FORMAT
+
+
+def test_configure_logging_restores_after_alembic_fileconfig():
+    """fileConfig strips the timestamp and raises root to WARN; re-applying
+    configure_logging must restore both so baloo INFO lines survive."""
+    configure_logging("INFO")
+    fileConfig("alembic.ini", disable_existing_loggers=False)
+
+    # Sanity: alembic really did raise the root level to WARN (alembic.ini's
+    # [logger_root] level) — otherwise this test would be vacuous. This is the
+    # hazard that silently drops baloo.* INFO lines.
+    assert logging.getLogger().level == logging.WARNING
+
+    configure_logging("INFO")
+
+    root = logging.getLogger()
+    assert root.level == logging.INFO
+    assert root.handlers[0].formatter._fmt == LOG_FORMAT
+    assert logging.getLogger("baloo.agent.repo_provision").isEnabledFor(logging.INFO)
+
+
+def test_alembic_ini_format_matches_app_format():
+    """Standalone `alembic` CLI output should match the app's format."""
+    import configparser
+
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.read("alembic.ini")
+    assert parser.get("formatter_generic", "format") == LOG_FORMAT
+    assert parser.get("formatter_generic", "datefmt") == LOG_DATEFMT
+
+
+def test_uvicorn_log_config_uses_shared_format():
+    for name in ("default", "access"):
+        assert UVICORN_LOG_CONFIG["formatters"][name]["format"] == LOG_FORMAT
+        assert UVICORN_LOG_CONFIG["formatters"][name]["datefmt"] == LOG_DATEFMT


### PR DESCRIPTION
## Summary

Fixes surfaced by prod review runs operating against `/app` (baloo's own container) instead of the PR checkout.

### 1. Worktree checkout auth (the actual `/app` blocker)
After enabling `REPO_CACHE_ENABLED`, `git worktree add` failed with `could not read Username for 'https://github.com'`. The bare cache is blobless (`--filter=blob:none`), so checking out the head SHA triggers a lazy promisor fetch of the file blobs — but `build_worktree_add_cmd` was the only network-capable builder not injecting the auth header. It now takes a `token` like clone/fetch; the `-c http.extraHeader` override propagates to the lazy fetch. (`contents:read` perms are sufficient — it was never a permissions problem.)

### 2. Consistent logging + recovered INFO lines
Alembic's `fileConfig` (run on every startup migration) clears the root handler and raises root level to `WARN` — stripping timestamps from subsequent lines **and silently dropping every `baloo.*` INFO log** (including the per-turn `pi_runtime` lines that carry the agent name + model). Centralized config in `baloo/logging_config.py`, re-asserted after migrations in `_run_alembic_migrations`, and aligned `alembic.ini`'s formatter so CLI output matches too.

### 3. Agent identification + quieter max-turns
- `PIAgentOptions.name` — directly-instantiated agents now log as `SyncScopeDecider` / `ThreadAgent` instead of the generic `PIAgentBase`.
- Max-turns logs at `INFO` when the agent produced output (the normal exit for single-turn deciders), `WARNING` only on genuine no-output exhaustion.

### 4. Observability + console
- Orchestrator logs per review whether file tools use the provisioned worktree or fall back to baloo's own cwd (the master-switch-off path was previously silent).
- Dashboard settings page: new "Repo Provisioning" category; regression test that no setting falls into the catch-all "Other" bucket.

## Testing
- `uv run pytest` — 717 passing
- `ruff` + `black` clean
- New tests: `tests/test_logging_config.py` (alembic clobber/restore), worktree-add auth in `tests/agent/test_repo_provision.py`, max-turns log level + agent name in `tests/agent/test_runtime.py`, settings categorization in `tests/dashboard/test_router.py`

## Deploy note
Keep `REPO_CACHE_ENABLED=true`. Post-deploy, reviews should log `Agent file tools using provisioned worktree …` instead of guessing paths under `/app`.