### PR TITLE
[codex] Fix PR review cost accounting

### DIFF
--- a/baloo/processor/fp_verifier.py
+++ b/baloo/processor/fp_verifier.py
@@ -48,6 +48,11 @@ class FPStats:
     kept: int = 0
     rejected: int = 0
     errors: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    thinking_tokens: int = 0
     total_cost_usd: float = 0.0
     duration_seconds: float = 0.0
 
@@ -163,6 +168,11 @@ class FPVerifier:
             cost = verdict_data.get("cost_usd", 0.0)
             model_used = verdict_data.get("model", self.model)
 
+            stats.input_tokens += verdict_data.get("input_tokens", 0)
+            stats.output_tokens += verdict_data.get("output_tokens", 0)
+            stats.cache_read_tokens += verdict_data.get("cache_read_tokens", 0)
+            stats.cache_write_tokens += verdict_data.get("cache_write_tokens", 0)
+            stats.thinking_tokens += verdict_data.get("thinking_tokens", 0)
             stats.total_cost_usd += cost
 
             if verdict == "fp":
@@ -252,6 +262,13 @@ class FPVerifier:
 
             cost = metadata.get("cost_usd", 0.0)
             model_used = metadata.get("model", self.model)
+            usage_metadata = {
+                "input_tokens": metadata.get("input_tokens", 0),
+                "output_tokens": metadata.get("output_tokens", 0),
+                "cache_read_tokens": metadata.get("cache_read_tokens", 0),
+                "cache_write_tokens": metadata.get("cache_write_tokens", 0),
+                "thinking_tokens": metadata.get("thinking_tokens", 0),
+            }
 
             if structured and isinstance(structured, dict):
                 verdict = structured.get("verdict", "real")
@@ -264,6 +281,7 @@ class FPVerifier:
                     "reason": reason,
                     "cost_usd": cost,
                     "model": model_used,
+                    **usage_metadata,
                 }
 
             # Could not parse response — fail-open.  Distinguish the
@@ -285,6 +303,7 @@ class FPVerifier:
                 "reason": reason,
                 "cost_usd": cost,
                 "model": model_used,
+                **usage_metadata,
             }
 
         except Exception as exc:

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -79,6 +79,12 @@ thread_agent_semaphore = None
 # Map of (repo_full_name, pr_number) -> asyncio.Task
 active_reviews: dict[tuple[str, int], asyncio.Task] = {}
 
+_REVIEW_SIDE_AGENT_METADATA_KEYS = (
+    "fp_verification",
+    "thread_reverification",
+    "sync_scope_decider",
+)
+
 
 def get_review_semaphore() -> asyncio.Semaphore:
     """Get or create the review semaphore with the configured limit."""
@@ -222,9 +228,6 @@ def _total_review_cost_usd(
     documentation_metadata: dict | None = None,
 ) -> float:
     """Aggregate all model-call cost components associated with a review."""
-    fp_metadata = review_metadata.get("fp_verification") or {}
-    if not isinstance(fp_metadata, dict):
-        fp_metadata = {}
     if documentation_metadata is None:
         documentation_metadata = {}
 
@@ -232,8 +235,59 @@ def _total_review_cost_usd(
         (review_metadata.get("cost_usd") or 0.0)
         + (fidelity_metadata.get("cost_usd") or 0.0)
         + (documentation_metadata.get("cost_usd") or 0.0)
-        + (fp_metadata.get("cost_usd") or 0.0)
+        + sum(
+            (metadata.get("cost_usd") or 0.0)
+            for metadata in _review_side_agent_metadata(review_metadata)
+        )
     )
+
+
+def _total_review_tokens(
+    token_key: str,
+    review_metadata: dict,
+    fidelity_metadata: dict,
+    documentation_metadata: dict | None = None,
+) -> int:
+    """Aggregate token counters for all model calls associated with a review."""
+    if documentation_metadata is None:
+        documentation_metadata = {}
+
+    return int(
+        (review_metadata.get(token_key) or 0)
+        + (fidelity_metadata.get(token_key) or 0)
+        + (documentation_metadata.get(token_key) or 0)
+        + sum(
+            (metadata.get(token_key) or 0)
+            for metadata in _review_side_agent_metadata(review_metadata)
+        )
+    )
+
+
+def _review_side_agent_metadata(review_metadata: dict) -> list[dict]:
+    """Return nested per-review side-agent metadata blocks."""
+    nested = []
+    for key in _REVIEW_SIDE_AGENT_METADATA_KEYS:
+        metadata = review_metadata.get(key) or {}
+        if isinstance(metadata, dict):
+            nested.append(metadata)
+    return nested
+
+
+def _fp_stats_metadata(stats) -> dict:
+    """Normalize FP verifier stats into the same metadata shape as PI agents."""
+    return {
+        "input_tokens": stats.input_tokens,
+        "output_tokens": stats.output_tokens,
+        "cache_read_tokens": stats.cache_read_tokens,
+        "cache_write_tokens": stats.cache_write_tokens,
+        "thinking_tokens": stats.thinking_tokens,
+        "cost_usd": stats.total_cost_usd,
+        "duration_seconds": stats.duration_seconds,
+        "total": stats.total_verified,
+        "kept": stats.kept,
+        "rejected": stats.rejected,
+        "errors": stats.errors,
+    }
 
 
 def _threads_from_issue_comments(
@@ -301,6 +355,7 @@ async def _decide_synchronize_review_mode(
     pr_context: PRContext,
     changed_files_changed: list,
     scoped_diff: str,
+    usage_metadata: dict | None = None,
 ) -> tuple[str, str]:
     """Ask PI whether synchronize should use scoped or full PR context."""
     options = get_agent_options()
@@ -332,7 +387,9 @@ Full PR diff (truncated):
 {pr_context.diff[:12000]}
 """
     try:
-        structured, _ = await decider.run_query(prompt)
+        structured, metadata = await decider.run_query(prompt)
+        if usage_metadata is not None:
+            usage_metadata.update(metadata)
         if isinstance(structured, dict):
             mode = str(structured.get("mode", "")).strip().lower()
             reason = str(structured.get("reason", "")).strip()
@@ -345,6 +402,8 @@ Full PR diff (truncated):
                 pr_context.pr_number,
             )
     except Exception as exc:
+        if usage_metadata is not None:
+            usage_metadata.update(getattr(exc, "metadata", {}) or {})
         logger.warning("Scope decider failed, defaulting full_pr: %s", exc)
 
     return "full_pr", "Scope decision unavailable; defaulting to full PR"
@@ -421,6 +480,7 @@ async def _reverify_awaiting_threads(
     pr_context: PRContext,
     api_client,
     db_review_id: int | None = None,
+    usage_metadata: dict | None = None,
 ) -> int:
     """Re-verify awaiting Baloo threads against the new diff.
 
@@ -446,6 +506,8 @@ async def _reverify_awaiting_threads(
 
     verifier = FPVerifier()
     fp_result = await verifier.verify(comments, pr_context)
+    if usage_metadata is not None:
+        usage_metadata.update(_fp_stats_metadata(fp_result.stats))
 
     # fp_result.rejected = findings the verifier says are no longer present
     rejected_paths_lines = {(r.comment.path, r.comment.line) for r in fp_result.rejected}
@@ -1140,6 +1202,7 @@ async def process_pr_review(
 
             changed_files_scope: set[str] | None = None
             changed_line_scope: dict[str, set[int]] = {}
+            sync_scope_metadata: dict = {}
             review_mode = "full_pr"
             review_mode_reason = "Non-synchronize trigger"
             review_context = pr_context
@@ -1159,6 +1222,7 @@ async def process_pr_review(
                         pr_context=pr_context,
                         changed_files_changed=changed_files_changed,
                         scoped_diff=scoped_diff,
+                        usage_metadata=sync_scope_metadata,
                     )
                     logger.info(
                         "Synchronize review mode for %s#%s: %s (%s)",
@@ -1376,14 +1440,7 @@ async def process_pr_review(
                 nonlocal agent_metadata
                 merged_metadata = {
                     **review_result.metadata,
-                    "fp_verification": {
-                        "total": fp_result.stats.total_verified,
-                        "kept": fp_result.stats.kept,
-                        "rejected": fp_result.stats.rejected,
-                        "errors": fp_result.stats.errors,
-                        "cost_usd": fp_result.stats.total_cost_usd,
-                        "duration_seconds": fp_result.stats.duration_seconds,
-                    },
+                    "fp_verification": _fp_stats_metadata(fp_result.stats),
                 }
                 agent_metadata = merged_metadata
                 logger.info(
@@ -1394,12 +1451,24 @@ async def process_pr_review(
                 )
                 return fp_result.verified
 
+            thread_reverification_metadata: dict = {}
             verified_new_findings, auto_resolved_count = await asyncio.gather(
                 _fp_verify_new_findings(new_findings_comments),
                 _reverify_awaiting_threads(
-                    awaiting_not_refiled, pr_context, github_client, db_review_id=db_review_id
+                    awaiting_not_refiled,
+                    pr_context,
+                    github_client,
+                    db_review_id=db_review_id,
+                    usage_metadata=thread_reverification_metadata,
                 ),
             )
+            side_agent_metadata = {}
+            if sync_scope_metadata:
+                side_agent_metadata["sync_scope_decider"] = sync_scope_metadata
+            if thread_reverification_metadata:
+                side_agent_metadata["thread_reverification"] = thread_reverification_metadata
+            if side_agent_metadata:
+                agent_metadata = {**agent_metadata, **side_agent_metadata}
 
             fresh_comments = verified_new_findings
             decision_comments = fresh_comments + [comment for _, comment in follow_up_comments]
@@ -1684,15 +1753,17 @@ async def process_pr_review(
                 )
 
                 # Aggregate costs and tokens
-                total_input_tokens = (
-                    (review_metadata.get("input_tokens") or 0)
-                    + (fidelity_metadata.get("input_tokens") or 0)
-                    + (documentation_metadata.get("input_tokens") or 0)
+                total_input_tokens = _total_review_tokens(
+                    "input_tokens",
+                    review_metadata,
+                    fidelity_metadata,
+                    documentation_metadata,
                 )
-                total_output_tokens = (
-                    (review_metadata.get("output_tokens") or 0)
-                    + (fidelity_metadata.get("output_tokens") or 0)
-                    + (documentation_metadata.get("output_tokens") or 0)
+                total_output_tokens = _total_review_tokens(
+                    "output_tokens",
+                    review_metadata,
+                    fidelity_metadata,
+                    documentation_metadata,
                 )
                 total_cost_usd = _total_review_cost_usd(
                     review_metadata,

--- a/tests/github/test_reverify_threads.py
+++ b/tests/github/test_reverify_threads.py
@@ -126,6 +126,53 @@ async def test_reverify_fp_verdict_triggers_reply_and_resolve():
 
 
 @pytest.mark.asyncio
+async def test_reverify_records_verifier_usage_metadata():
+    """Awaiting-thread re-verification should expose usage for review cost totals."""
+    from baloo.review.orchestrator import _reverify_awaiting_threads
+
+    thread = _make_awaiting_thread(root_comment_id=42, node_id="PRT_x")
+    pr_context = _make_pr_context(awaiting_threads=[thread])
+    usage = {}
+    fp_result = FPVerificationResult(
+        verified=[],
+        rejected=[],
+        stats=FPStats(
+            total_verified=1,
+            kept=1,
+            input_tokens=25,
+            output_tokens=7,
+            cache_read_tokens=3,
+            cache_write_tokens=2,
+            thinking_tokens=5,
+            total_cost_usd=0.006,
+            duration_seconds=1.2,
+        ),
+    )
+
+    mock_api = AsyncMock()
+
+    with patch("baloo.review.orchestrator.FPVerifier") as mock_verifier_cls:
+        mock_instance = AsyncMock()
+        mock_instance.verify = AsyncMock(return_value=fp_result)
+        mock_verifier_cls.return_value = mock_instance
+
+        await _reverify_awaiting_threads(
+            awaiting_threads=[thread],
+            pr_context=pr_context,
+            api_client=mock_api,
+            usage_metadata=usage,
+        )
+
+    assert usage["input_tokens"] == 25
+    assert usage["output_tokens"] == 7
+    assert usage["cache_read_tokens"] == 3
+    assert usage["cache_write_tokens"] == 2
+    assert usage["thinking_tokens"] == 5
+    assert usage["cost_usd"] == 0.006
+    assert usage["total"] == 1
+
+
+@pytest.mark.asyncio
 async def test_reverify_real_verdict_no_action():
     """real verdict → thread untouched."""
     from baloo.review.orchestrator import _reverify_awaiting_threads

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -27,6 +27,7 @@ from baloo.github.models import (
 from baloo.review.orchestrator import (
     _decide_synchronize_review_mode,
     _total_review_cost_usd,
+    _total_review_tokens,
     process_pr_review,
 )
 
@@ -66,17 +67,36 @@ def _baloo_thread(
     )
 
 
-def test_total_review_cost_includes_fp_verification_cost():
-    """Persisted review cost should include main, fidelity, and FP verifier calls."""
+def test_total_review_cost_includes_side_agent_costs():
+    """Persisted review cost should include main and PR-time side-agent calls."""
     total = _total_review_cost_usd(
         {
             "cost_usd": 0.10,
             "fp_verification": {"cost_usd": 0.03},
+            "thread_reverification": {"cost_usd": 0.04},
+            "sync_scope_decider": {"cost_usd": 0.005},
         },
         {"cost_usd": 0.02},
+        {"cost_usd": 0.01},
     )
 
-    assert total == pytest.approx(0.15)
+    assert total == pytest.approx(0.205)
+
+
+def test_total_review_tokens_include_side_agent_tokens():
+    total = _total_review_tokens(
+        "input_tokens",
+        {
+            "input_tokens": 100,
+            "fp_verification": {"input_tokens": 10},
+            "thread_reverification": {"input_tokens": 20},
+            "sync_scope_decider": {"input_tokens": 5},
+        },
+        {"input_tokens": 30},
+        {"input_tokens": 40},
+    )
+
+    assert total == 205
 
 
 @pytest.mark.asyncio

--- a/tests/processor/test_fp_verifier.py
+++ b/tests/processor/test_fp_verifier.py
@@ -273,6 +273,39 @@ class TestFPVerifier:
         assert result.stats.kept == 1
 
     @pytest.mark.asyncio
+    async def test_usage_tokens_are_aggregated(self):
+        verifier = FPVerifier()
+        comment = _make_comment()
+        pr_ctx = _make_pr_context()
+
+        with patch.object(
+            verifier,
+            "_verify_single",
+            new_callable=AsyncMock,
+            return_value=(
+                comment,
+                {
+                    "verdict": "real",
+                    "reason": "SQL injection is real",
+                    "cost_usd": 0.001,
+                    "model": "haiku",
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_tokens": 7,
+                    "cache_write_tokens": 3,
+                    "thinking_tokens": 5,
+                },
+            ),
+        ):
+            result = await verifier.verify([comment], pr_ctx)
+
+        assert result.stats.input_tokens == 100
+        assert result.stats.output_tokens == 20
+        assert result.stats.cache_read_tokens == 7
+        assert result.stats.cache_write_tokens == 3
+        assert result.stats.thinking_tokens == 5
+
+    @pytest.mark.asyncio
     async def test_fp_finding_is_rejected(self):
         verifier = FPVerifier()
         comment = _make_comment()

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -254,6 +254,29 @@ class TestDecideSynchronizeReviewMode:
         assert reason == "small diff"
 
     @pytest.mark.asyncio
+    async def test_records_scope_decider_usage_metadata(self):
+        from baloo.review.orchestrator import _decide_synchronize_review_mode
+
+        usage = {}
+        with patch(
+            "baloo.review.orchestrator.PIAgentBase.run_query",
+            new=AsyncMock(
+                return_value=(
+                    {"mode": "scoped", "reason": "small diff"},
+                    {"input_tokens": 12, "output_tokens": 3, "cost_usd": 0.004},
+                )
+            ),
+        ):
+            await _decide_synchronize_review_mode(
+                pr_context=_make_pr_context(),
+                changed_files_changed=[],
+                scoped_diff="+ small change",
+                usage_metadata=usage,
+            )
+
+        assert usage == {"input_tokens": 12, "output_tokens": 3, "cost_usd": 0.004}
+
+    @pytest.mark.asyncio
     async def test_returns_full_pr_when_llm_says_full_pr(self):
         from baloo.review.orchestrator import _decide_synchronize_review_mode
 


### PR DESCRIPTION
## Summary

- aggregate PR-time side-agent costs for sync scope decisions and awaiting-thread reverification
- include FP verifier token usage in persisted PR review token totals
- add regression coverage for review cost and token aggregation

## Why

The persisted review cost counted the main reviewer plus fidelity, documentation drift, and new-finding FP verification, but it missed other LLM calls that can run inside a PR review. This made dashboard cost reporting undercount reviews with synchronize scope decisions or awaiting-thread reverification.

## Validation

- uv run ruff check baloo/processor/fp_verifier.py baloo/review/orchestrator.py tests/github/test_webhook_handler.py tests/review/test_orchestrator.py tests/github/test_reverify_threads.py tests/processor/test_fp_verifier.py
- uv run pytest
