### PR TITLE
[codex] Improve docs drift report UX

### DIFF
--- a/baloo/documentation/models.py
+++ b/baloo/documentation/models.py
@@ -31,6 +31,7 @@ class DocumentationWorkItem(BaseModel):
     changed_files: list[str]
     matches: list[DocumentationWorkItemMatch]
     unmapped_files: list[str]
+    ignored_unmapped_files: list[str] = Field(default_factory=list)
     has_relevant_impl_changes: bool
     has_docs_to_review: bool
     has_docs_already_changed: bool
@@ -47,6 +48,7 @@ class DocumentationDriftFinding(BaseModel):
 
 
 class DocumentationDriftResult(BaseModel):
+    action_required: Literal["none", "update_docs", "catalog_hygiene"] | None = None
     summary: str = ""
     required_updates: list[DocumentationDriftFinding] = Field(default_factory=list)
     optional_updates: list[DocumentationDriftFinding] = Field(default_factory=list)

--- a/baloo/documentation/prompts.py
+++ b/baloo/documentation/prompts.py
@@ -9,13 +9,16 @@ from baloo.github.models import PRContext
 
 DOCUMENTATION_DRIFT_SYSTEM_PROMPT = """You are Baloo's documentation drift reviewer.
 
-You run during pull request review. Your job is to decide whether implementation
-changes make existing documentation stale, and whether documentation already
-changed in the same PR is sufficient.
+You run during pull request review. Your audience is the PR author. Your job is
+to decide whether implementation changes make existing documentation stale, and
+whether documentation already changed in the same PR is sufficient.
 
 Use only read-only tools such as read, grep, find, and ls in the checked-out
 repository. Do not edit files. Do not create branches. Do not open pull
 requests. Return JSON only.
+
+Only report things the PR author can act on in this PR. Be concise and avoid
+listing every inspected document.
 """
 
 
@@ -55,10 +58,19 @@ Instructions:
 - Evaluate every docs_to_review path.
 - Inspect every docs_already_changed path and decide whether they are sufficient for this PR.
 - Do not recommend docs that are already sufficiently updated in this PR.
-- Report unmapped_files as catalog gaps separately from documentation update findings.
+- Treat unmapped_files as catalog hygiene, not as documentation updates.
+- Do not report ignored_unmapped_files as catalog gaps.
+- Do not include an "Already Covered" section or summarize every inspected doc.
+- If no author action is needed, the summary must start with "Action required: none."
+- If docs must change before merge, the summary must start with "Action required: update docs."
 - Do not edit files.
 - Do not create branches.
 - Return JSON only. Do not wrap it in markdown.
+
+Use these action_required values:
+- "update_docs": required_updates is non-empty; the author should update docs in this PR.
+- "none": no author action is needed.
+- "catalog_hygiene": there are catalog gaps but no required docs updates.
 
 Use these verdicts for findings:
 - "required": documentation is stale or missing and should be updated in this PR.
@@ -67,6 +79,7 @@ Use these verdicts for findings:
 
 Return this JSON shape:
 {{
+  "action_required": "none",
   "summary": "short summary",
   "required_updates": [
     {{

--- a/baloo/documentation/report.py
+++ b/baloo/documentation/report.py
@@ -67,7 +67,7 @@ def has_actionable_documentation_drift(result: DocumentationDriftResult) -> bool
 
 def has_reportable_documentation_drift(result: DocumentationDriftResult) -> bool:
     """Return True when a documentation drift result is useful enough to show."""
-    return bool(result.required_updates or result.catalog_gaps)
+    return bool(result.required_updates or result.optional_updates or result.catalog_gaps)
 
 
 def _format_action_required(result: DocumentationDriftResult) -> str:

--- a/baloo/documentation/report.py
+++ b/baloo/documentation/report.py
@@ -16,15 +16,21 @@ def format_documentation_drift_report(result: DocumentationDriftResult) -> str:
         "",
     ]
 
-    if not has_actionable_documentation_drift(result) and not result.optional_updates:
+    if not has_reportable_documentation_drift(result):
+        lines.append("Action required: none.")
+        lines.append("")
         lines.append("No documentation drift detected in the latest review.")
         return "\n".join(lines).rstrip() + "\n"
+
+    lines.extend([_format_action_required(result), ""])
 
     summary = (
         result.summary
         or "This PR appears to change behavior or workflows that are documented elsewhere."
     )
-    lines.extend([summary, ""])
+    summary = _strip_action_prefix(summary)
+    if summary:
+        lines.extend([summary, ""])
 
     if result.required_updates:
         lines.extend(["### Required Updates", ""])
@@ -36,15 +42,14 @@ def format_documentation_drift_report(result: DocumentationDriftResult) -> str:
         lines.extend(_format_findings(result.optional_updates))
         lines.append("")
 
-    if result.not_needed:
-        lines.extend(["### Already Covered", ""])
-        lines.extend(_format_findings(result.not_needed))
-        lines.append("")
-
     if result.catalog_gaps:
-        lines.extend(["### Catalog Gaps", ""])
+        lines.extend(["### Catalog Hygiene", ""])
         for gap in result.catalog_gaps:
-            lines.append(f"- `{gap}` is not mapped in the documentation drift catalog.")
+            lines.append(
+                f"- `{gap}` is not mapped. Add a catalog rule if this area "
+                "should be checked for documentation drift, or mark it read-only if it should "
+                "never request docs."
+            )
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"
@@ -58,6 +63,31 @@ def has_documentation_drift_comment(body: str) -> bool:
 def has_actionable_documentation_drift(result: DocumentationDriftResult) -> bool:
     """Return True when a result should create or keep a PR comment."""
     return bool(result.required_updates or result.catalog_gaps)
+
+
+def has_reportable_documentation_drift(result: DocumentationDriftResult) -> bool:
+    """Return True when a documentation drift result is useful enough to show."""
+    return bool(result.required_updates or result.catalog_gaps)
+
+
+def _format_action_required(result: DocumentationDriftResult) -> str:
+    if result.required_updates:
+        return "Action required: update docs."
+    return "Action required: none."
+
+
+def _strip_action_prefix(summary: str) -> str:
+    stripped = summary.strip()
+    lowered = stripped.lower()
+    for prefix in (
+        "action required: none.",
+        "action required: none",
+        "action required: update docs.",
+        "action required: update docs",
+    ):
+        if lowered.startswith(prefix):
+            return stripped[len(prefix) :].lstrip(" \n:-")
+    return stripped
 
 
 def _format_findings(findings: list[DocumentationDriftFinding]) -> list[str]:

--- a/baloo/documentation/work_items.py
+++ b/baloo/documentation/work_items.py
@@ -12,6 +12,24 @@ from baloo.documentation.models import (
 from baloo.github.models import PRContext
 
 _DOC_EXTENSIONS = (".md", ".mdx", ".rst", ".csv")
+_IGNORED_UNMAPPED_BASENAMES = {
+    "next-env.d.ts",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "uv.lock",
+    "poetry.lock",
+}
+_IGNORED_UNMAPPED_SEGMENTS = {
+    "__generated__",
+    "__snapshots__",
+    "__tests__",
+    "dist",
+    "build",
+    "coverage",
+    "node_modules",
+    "tests",
+}
 
 
 def is_documentation_path(path: str) -> bool:
@@ -24,6 +42,41 @@ def rule_matches_path(path: str, patterns: list[str]) -> bool:
     """Match GitHub-style globs where * is one segment and ** is recursive."""
     normalized_path = path.strip("/")
     return any(_glob_to_regex(pattern).fullmatch(normalized_path) for pattern in patterns)
+
+
+def is_ignored_unmapped_path(path: str) -> bool:
+    """Return True for paths that should not create documentation catalog gaps."""
+    normalized = path.strip("/")
+    lowered = normalized.lower()
+    basename = lowered.rsplit("/", 1)[-1]
+    segments = set(lowered.split("/"))
+
+    if basename in _IGNORED_UNMAPPED_BASENAMES:
+        return True
+    if segments & _IGNORED_UNMAPPED_SEGMENTS:
+        return True
+    if basename.startswith("test_"):
+        return True
+    if any(
+        basename.endswith(suffix)
+        for suffix in (
+            "_test.py",
+            ".test.js",
+            ".test.jsx",
+            ".test.ts",
+            ".test.tsx",
+            ".spec.js",
+            ".spec.jsx",
+            ".spec.ts",
+            ".spec.tsx",
+            ".snap",
+            ".d.ts",
+        )
+    ):
+        return True
+    if "/generated/" in lowered or lowered.startswith("generated/"):
+        return True
+    return False
 
 
 def build_documentation_work_item(
@@ -64,7 +117,9 @@ def build_documentation_work_item(
             )
         )
 
-    unmapped_files = [path for path in implementation_files if path not in matched_impl_files]
+    raw_unmapped_files = [path for path in implementation_files if path not in matched_impl_files]
+    ignored_unmapped_files = [path for path in raw_unmapped_files if is_ignored_unmapped_path(path)]
+    unmapped_files = [path for path in raw_unmapped_files if path not in ignored_unmapped_files]
     has_relevant_impl_changes = bool(matched_impl_files)
     has_docs_to_review = any(match.docs_to_review for match in matches)
     has_docs_already_changed = any(match.docs_already_changed for match in matches)
@@ -78,6 +133,7 @@ def build_documentation_work_item(
         changed_files=changed_files,
         matches=matches,
         unmapped_files=unmapped_files,
+        ignored_unmapped_files=ignored_unmapped_files,
         has_relevant_impl_changes=has_relevant_impl_changes,
         has_docs_to_review=has_docs_to_review,
         has_docs_already_changed=has_docs_already_changed,

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -951,17 +951,20 @@ async def _post_or_update_documentation_drift_report(
     pr_number: int,
     issue_comments: list[DiscussionComment],
     result: DocumentationDriftResult,
-) -> None:
+) -> str:
     """Upsert the single PR-level documentation drift report comment."""
     existing = _existing_documentation_drift_comment(issue_comments)
     report_body = format_documentation_drift_report(result)
 
     if existing is not None:
         await github_client.edit_comment(repo_full_name, existing.id, report_body)
-        return
+        return "updated"
 
     if has_actionable_documentation_drift(result):
         await github_client.post_comment(repo_full_name, pr_number, report_body)
+        return "posted"
+
+    return "skipped"
 
 
 async def _process_thread_reply(
@@ -1720,7 +1723,7 @@ async def process_pr_review(
 
             if documentation_result:
                 try:
-                    await _post_or_update_documentation_drift_report(
+                    documentation_report_status = await _post_or_update_documentation_drift_report(
                         github_client,
                         repo_full_name,
                         pr_number,
@@ -1729,7 +1732,8 @@ async def process_pr_review(
                     )
                     if documentation_report_text:
                         logger.info(
-                            "Posted or updated documentation drift report for %s#%s",
+                            "Documentation drift report %s for %s#%s",
+                            documentation_report_status,
                             repo_full_name,
                             pr_number,
                         )

--- a/docs/features/documentation-drift.md
+++ b/docs/features/documentation-drift.md
@@ -147,7 +147,7 @@ Baloo uses the stable sentinel `<!-- baloo:documentation-drift-report -->` to fi
 - If no drift is found and no previous report exists, Baloo stays silent.
 - If no drift is found and a previous report exists, Baloo edits it to say no drift was detected.
 
-Catalog gaps are actionable. If an implementation file changed but did not match any catalog rule, Baloo reports it under `Catalog Gaps` so maintainers can decide whether to add a new rule.
+Catalog gaps are reported as catalog hygiene, not as a required PR-author docs update. If an implementation file changed but did not match any catalog rule, Baloo reports it under `Catalog Hygiene` so maintainers can decide whether to add a new rule. Low-signal generated, test, lockfile, build-output, and framework ambient type files are ignored for catalog-gap reporting.
 
 ## Example Comment
 
@@ -156,7 +156,9 @@ Catalog gaps are actionable. If an implementation file changed but did not match
 
 ## Documentation Drift Review
 
-This PR appears to change behavior or workflows that are documented elsewhere.
+Action required: update docs.
+
+This PR changes review behavior that is documented elsewhere.
 
 ### Required Updates
 
@@ -165,9 +167,9 @@ This PR appears to change behavior or workflows that are documented elsewhere.
   - Rationale: The PR adds a new review-side analysis step.
   - Evidence: `baloo/review/orchestrator.py`
 
-### Catalog Gaps
+### Catalog Hygiene
 
-- `baloo/documentation/analyzer.py` is not mapped in the documentation drift catalog.
+- `baloo/documentation/analyzer.py` is not mapped. Add a catalog rule if this area should be checked for documentation drift, or mark it read-only if it should never request docs.
 ```
 
 If a previous drift comment exists and the latest review finds no drift, Baloo edits that same comment to a short no-drift message. If no previous drift comment exists and no drift is found, Baloo posts nothing.
@@ -188,10 +190,10 @@ Check these first:
 
 - `DOCUMENTATION_DRIFT_ENABLED=true` is set in the running Baloo service.
 - The reviewed PR head contains the catalog file.
-- The changed files match at least one catalog rule, or there are unmapped implementation files that should be reported as catalog gaps.
+- The changed files match at least one catalog rule, or there are meaningful unmapped implementation files that should be reported as catalog hygiene.
 - The PR only changed docs. Docs-only PRs skip analysis unless implementation files changed too.
 
-### The report says there is a catalog gap
+### The report says there is catalog hygiene
 
 Add or update a rule in `.baloo/documentation-catalog.json` so the changed implementation path maps to the docs that describe it. If the path should never request documentation updates, add a `read_only: true` rule.
 

--- a/tests/documentation/test_prompts.py
+++ b/tests/documentation/test_prompts.py
@@ -73,6 +73,7 @@ def test_prompt_includes_changed_files_and_matched_docs():
     assert "baloo/review/orchestrator.py" in prompt
     assert "README.md" in prompt
     assert "docs_to_review" in prompt
+    assert "ignored_unmapped_files" in prompt
 
 
 def test_prompt_includes_docs_already_changed():
@@ -85,6 +86,20 @@ def test_prompt_includes_docs_already_changed():
     assert "docs_already_changed" in prompt
     assert "docs/features/review-agent.md" in prompt
     assert "decide whether they are sufficient" in prompt
+
+
+def test_prompt_requires_author_focused_action_summary():
+    prompt = build_documentation_drift_prompt(
+        pr_context=_pr_context(),
+        work_item=_work_item(),
+        catalog_path=".baloo/documentation-catalog.json",
+    )
+
+    assert "Use these action_required values" in prompt
+    assert 'Do not include an "Already Covered" section' in prompt
+    assert "Treat unmapped_files as catalog hygiene" in prompt
+    assert "Action required: none" in prompt
+    assert "Action required: update docs" in prompt
 
 
 def test_prompt_forbids_file_edits():

--- a/tests/documentation/test_report.py
+++ b/tests/documentation/test_report.py
@@ -52,7 +52,55 @@ def test_required_updates_render_before_optional_updates():
 def test_empty_result_renders_no_drift_message():
     body = format_documentation_drift_report(DocumentationDriftResult())
 
+    assert "Action required: none." in body
     assert "No documentation drift detected in the latest review." in body
+
+
+def test_report_suppresses_already_covered_section():
+    body = format_documentation_drift_report(
+        DocumentationDriftResult(
+            catalog_gaps=["baloo/documentation/analyzer.py"],
+            not_needed=[
+                DocumentationDriftFinding(
+                    doc_path="README.md",
+                    verdict="not_needed",
+                    rationale="Already generic enough.",
+                )
+            ],
+        )
+    )
+
+    assert "### Already Covered" not in body
+    assert "README.md" not in body
+
+
+def test_catalog_gaps_render_as_catalog_hygiene():
+    body = format_documentation_drift_report(
+        DocumentationDriftResult(catalog_gaps=["baloo/documentation/analyzer.py"])
+    )
+
+    assert "Action required: none." in body
+    assert "### Catalog Hygiene" in body
+    assert "Add a catalog rule" in body
+    assert "### Catalog Gaps" not in body
+
+
+def test_required_updates_render_action_required():
+    body = format_documentation_drift_report(
+        DocumentationDriftResult(
+            summary="Action required: update docs. API response changed.",
+            required_updates=[
+                DocumentationDriftFinding(
+                    doc_path="docs/api.md",
+                    verdict="required",
+                    rationale="Response shape changed.",
+                )
+            ],
+        )
+    )
+
+    assert body.count("Action required: update docs.") == 1
+    assert "API response changed." in body
 
 
 def test_has_actionable_documentation_drift_for_required_updates_or_gaps():

--- a/tests/documentation/test_report.py
+++ b/tests/documentation/test_report.py
@@ -85,6 +85,25 @@ def test_catalog_gaps_render_as_catalog_hygiene():
     assert "### Catalog Gaps" not in body
 
 
+def test_optional_only_updates_are_rendered():
+    body = format_documentation_drift_report(
+        DocumentationDriftResult(
+            optional_updates=[
+                DocumentationDriftFinding(
+                    doc_path="docs/api.md",
+                    verdict="optional",
+                    rationale="Could mention the optional helper.",
+                )
+            ],
+        )
+    )
+
+    assert "Action required: none." in body
+    assert "### Optional Updates" in body
+    assert "docs/api.md" in body
+    assert "No documentation drift detected" not in body
+
+
 def test_required_updates_render_action_required():
     body = format_documentation_drift_report(
         DocumentationDriftResult(

--- a/tests/documentation/test_work_items.py
+++ b/tests/documentation/test_work_items.py
@@ -4,6 +4,7 @@ from baloo.documentation.models import DocumentationCatalog, DocumentationCatalo
 from baloo.documentation.work_items import (
     build_documentation_work_item,
     is_documentation_path,
+    is_ignored_unmapped_path,
     rule_matches_path,
 )
 from baloo.github.models import (
@@ -110,6 +111,35 @@ def test_unmapped_implementation_files_are_surfaced():
     assert item.unmapped_files == ["baloo/documentation/analyzer.py"]
     assert item.has_catalog_gaps is True
     assert item.needs_analysis is True
+
+
+def test_low_signal_unmapped_files_are_ignored():
+    item = build_documentation_work_item(
+        pr_context=_pr_context(
+            [
+                "bluebear-backend/src/shared/tests/test_managed_agents.py",
+                "console/next-env.d.ts",
+                "src/generated/client.ts",
+            ]
+        ),
+        catalog=_catalog(),
+    )
+
+    assert item.unmapped_files == []
+    assert item.ignored_unmapped_files == [
+        "bluebear-backend/src/shared/tests/test_managed_agents.py",
+        "console/next-env.d.ts",
+        "src/generated/client.ts",
+    ]
+    assert item.has_catalog_gaps is False
+    assert item.needs_analysis is False
+
+
+def test_is_ignored_unmapped_path():
+    assert is_ignored_unmapped_path("src/tests/test_widget.py")
+    assert is_ignored_unmapped_path("console/next-env.d.ts")
+    assert is_ignored_unmapped_path("src/generated/client.ts")
+    assert not is_ignored_unmapped_path("src/shared/managed_agents.py")
 
 
 def test_read_only_rules_do_not_create_docs_to_review():

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -852,8 +852,9 @@ class TestDocumentationDriftOrchestration:
             ]
         )
 
-        await _post_or_update_documentation_drift_report(gc, "org/repo", 1, [], result)
+        status = await _post_or_update_documentation_drift_report(gc, "org/repo", 1, [], result)
 
+        assert status == "posted"
         gc.post_comment.assert_awaited_once()
         assert "Documentation Drift Review" in gc.post_comment.call_args.args[2]
 
@@ -882,8 +883,11 @@ class TestDocumentationDriftOrchestration:
             ]
         )
 
-        await _post_or_update_documentation_drift_report(gc, "org/repo", 1, [existing], result)
+        status = await _post_or_update_documentation_drift_report(
+            gc, "org/repo", 1, [existing], result
+        )
 
+        assert status == "updated"
         gc.edit_comment.assert_awaited_once()
         assert gc.edit_comment.call_args.args[:2] == ("org/repo", 99)
         gc.post_comment.assert_not_called()
@@ -904,7 +908,7 @@ class TestDocumentationDriftOrchestration:
             is_baloo=True,
         )
 
-        await _post_or_update_documentation_drift_report(
+        status = await _post_or_update_documentation_drift_report(
             gc,
             "org/repo",
             1,
@@ -912,6 +916,7 @@ class TestDocumentationDriftOrchestration:
             DocumentationDriftResult(),
         )
 
+        assert status == "updated"
         gc.edit_comment.assert_awaited_once()
         assert "No documentation drift detected" in gc.edit_comment.call_args.args[2]
         gc.post_comment.assert_not_called()
@@ -922,7 +927,7 @@ class TestDocumentationDriftOrchestration:
 
         gc = _make_github_client()
 
-        await _post_or_update_documentation_drift_report(
+        status = await _post_or_update_documentation_drift_report(
             gc,
             "org/repo",
             1,
@@ -930,6 +935,7 @@ class TestDocumentationDriftOrchestration:
             DocumentationDriftResult(),
         )
 
+        assert status == "skipped"
         gc.edit_comment.assert_not_called()
         gc.post_comment.assert_not_called()
 


### PR DESCRIPTION
## Summary

- make documentation drift reports lead with a clear action-required line
- suppress verbose Already Covered sections in PR comments
- treat unmapped implementation files as catalog hygiene and ignore generated/test/lock/build-output paths
- return and log the real documentation drift report upsert outcome

## Why

Documentation drift comments were too long and mixed PR-author doc work with catalog-maintainer hygiene. In cases like PRs with only generic docs inspected, test files, or framework-generated files, the report did not clearly tell the author what to do.

## Impact

PR authors now see concise reports such as "Action required: none" or "Action required: update docs". Meaningful unmapped source files still surface as catalog hygiene, while low-signal generated/test files are filtered out.

## Validation

- uv run ruff check baloo/documentation/models.py baloo/documentation/work_items.py baloo/documentation/prompts.py baloo/documentation/report.py baloo/review/orchestrator.py tests/documentation/test_report.py tests/documentation/test_work_items.py tests/documentation/test_prompts.py tests/review/test_orchestrator.py
- uv run pytest tests/documentation/test_report.py tests/documentation/test_work_items.py tests/documentation/test_prompts.py tests/documentation/test_models.py tests/review/test_orchestrator.py
- uv run pytest
