### PR TITLE
feat(agent): flag in-memory data-access anti-pattern as CRITICAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- Review rule: flag the unbounded in-memory data-access anti-pattern (filtering/sorting/pagination/aggregation done in app code, and the bulk-fetch that feeds it — `size: 10000`, `scan`/`scroll`/`search_after`, fetch-then-process) as **CRITICAL**. Reviewers recommend pushing the work into the query/datastore.
+
 ### Changed
 
 - Reworked public documentation for open source use

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -15,7 +15,7 @@ Your response will be parsed as JSON automatically.  Return an object with:
 """
 
 REVIEW_SEVERITY_GUIDELINES = """## Severity Guidelines
-- **CRITICAL**: Reserve for confirmed exploitable vulnerabilities or certain catastrophic data loss only
+- **CRITICAL**: Reserve for confirmed exploitable vulnerabilities, certain catastrophic data loss, or the unbounded in-memory data-access anti-pattern (see Data-access rule)
 - **HIGH**: Security concerns, serious bugs, silent failure patterns, or clear guidelines violations
 - **MEDIUM**: Quality, maintainability, or performance issues
 - **LOW**: Style or minor polish improvements
@@ -64,6 +64,14 @@ Flag only issues **introduced or made worse by this PR's changes**. Pre-existing
   Treat as HIGH unless tied to security, data corruption, or guaranteed wrong financial/identity outcomes.
 - **Performance (MEDIUM)**: Algorithm efficiency, N+1 queries, blocking ops
 - **Quality (MEDIUM/LOW)**: DRY, complexity, naming, tests
+
+## Data-access (CRITICAL): filtering, sorting, pagination, and aggregation MUST run in the query/datastore — NEVER in application memory
+Flag as **CRITICAL** any change that pulls a large or unbounded result set and then sorts/filters/paginates/aggregates it in code. The datastore (OpenSearch, SQL, etc.) must do that work in the query. This is a scalability/latency/cost landmine and overrides the usual "performance = MEDIUM" rule. Concrete signals (non-exhaustive):
+- An OpenSearch `size` set to a large/"fetch-all" literal (e.g. `size: 10000`), or any query written to return "all" documents/rows for in-code processing.
+- `helpers.scan`, `search_after`/`scroll` loops, or `while` loops issuing repeated queries to walk a whole result set.
+- Fetching rows/buckets then processing in app code: `.all()`/`fetchall()`/`hits` followed by Python/JS `sorted(...)`, comprehension/`.filter()` filtering, manual slicing for pagination (`results[offset:offset+limit]`), or summing/counting in a loop.
+- Per-item fan-out (`ThreadPoolExecutor` / `asyncio.gather` / `Promise.all` over ids) issuing one query per id instead of one aggregation or `IN`/`terms` query.
+Compliant alternative to recommend: push it into the query — `WHERE`/`ORDER BY`/`LIMIT`/`OFFSET` (SQL), or `size:0` + filter + aggregations in OpenSearch (`composite` + `after_key` for paging, `cardinality` for totals). Sorting must use indexed fields, not in-memory comparisons.
 
 ## Project Guidelines Compliance (HIGH)
 You MUST read `AGENTS.md` and `CONTRIBUTING.md` at the repo root before checking for violations.

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,11 +4,22 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 from baloo.agent.prompts import (
+    REVIEW_SYSTEM_PROMPT,
     _is_dependabot_pr,
     _is_security_patch,
     _is_simple_pr,
     build_pr_review_prompt,
 )
+
+
+def test_system_prompt_flags_in_memory_data_access_as_critical():
+    """The reviewer must treat in-memory filter/sort/aggregate + bulk-fetch as CRITICAL."""
+    assert "## Data-access (CRITICAL)" in REVIEW_SYSTEM_PROMPT
+    assert "NEVER in application memory" in REVIEW_SYSTEM_PROMPT
+    # Names the concrete fetch-all signal the rule exists to catch.
+    assert "size: 10000" in REVIEW_SYSTEM_PROMPT
+    # CRITICAL severity is explicitly extended to this anti-pattern.
+    assert "data-access" in REVIEW_SYSTEM_PROMPT.split("## Severity Guidelines")[1]
 
 
 def test_prompt_includes_discussion_digest():


### PR DESCRIPTION
## What

Adds an explicit **CRITICAL** "Data-access" rule to Baloo's review system prompt (`baloo/agent/prompts.py`):

> Filtering, sorting, pagination, and aggregation MUST run in the query/datastore — **never in application memory**. The bulk-fetch that feeds in-memory processing is the same anti-pattern.

Concrete signals the reviewer now flags as CRITICAL:
- OpenSearch `size` set to a fetch-all literal (e.g. `size: 10000`)
- `helpers.scan`, `search_after`/`scroll` loops, `while`-loops walking a full result set
- Fetching rows/buckets then sorting/filtering/slicing/reducing in app code
- Per-id fan-out (`ThreadPoolExecutor`/`asyncio.gather`/`Promise.all`) instead of one aggregation/`IN` query

Recommends pushing the work into the query (`WHERE`/`ORDER BY`/`LIMIT` in SQL; `size:0` + filter + aggregations, `composite`+`after_key`, `cardinality` in OpenSearch; sort on indexed fields).

## Why

This anti-pattern keeps shipping (e.g. a BFF endpoint that pulls up to 10k OpenSearch buckets and sorts/paginates in Python — the slowest lambda in the fleet). It doesn't scale and is a latency/cost landmine. Making Baloo flag it CRITICAL stops it at review.

## Notes

- Framed generically (universal scalability anti-pattern), so it applies to every repo Baloo reviews.
- Extends the CRITICAL severity carve-out (previously: exploitable vulns / catastrophic data loss only).
- Adds a regression unit test; `pytest tests/test_prompts.py` → 30 passed.