### PR TITLE
Add PR total cost tracking

### DIFF
--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -24,7 +24,14 @@ def _log_cost(metadata_json: str | None) -> float:
         return 0.0
     if not isinstance(metadata, dict):
         return 0.0
-    return float(metadata.get("cost") or metadata.get("cost_usd") or 0.0)
+    for key in ("cost", "cost_usd"):
+        value = metadata.get(key)
+        if value is not None:
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return 0.0
+    return 0.0
 
 
 async def _attach_pr_total_costs(

--- a/baloo/dashboard/queries.py
+++ b/baloo/dashboard/queries.py
@@ -2,15 +2,82 @@
 
 from __future__ import annotations
 
+import json
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import selectinload
 
 from baloo.config.settings import get_settings
 from baloo.db.engine import get_session_factory
 from baloo.db.models import Finding, FindingOutcome, Review, ReviewLog
 from baloo.db.tenant import apply_tenant_filter
+
+
+def _log_cost(metadata_json: str | None) -> float:
+    if not metadata_json:
+        return 0.0
+    try:
+        metadata = json.loads(metadata_json)
+    except (TypeError, ValueError):
+        return 0.0
+    if not isinstance(metadata, dict):
+        return 0.0
+    return float(metadata.get("cost") or metadata.get("cost_usd") or 0.0)
+
+
+async def _attach_pr_total_costs(
+    session, reviews: list[Review], installation_id: str | None
+) -> None:
+    if not reviews:
+        return
+
+    keys = {(r.repo_full_name, r.pr_number) for r in reviews}
+    pr_filter = or_(
+        *(
+            and_(Review.repo_full_name == repo_full_name, Review.pr_number == pr_number)
+            for repo_full_name, pr_number in keys
+        )
+    )
+    rows = (
+        await session.execute(
+            apply_tenant_filter(
+                select(Review.id, Review.repo_full_name, Review.pr_number, Review.cost_usd).where(
+                    pr_filter
+                ),
+                Review,
+                installation_id,
+            )
+        )
+    ).all()
+
+    review_ids = [review_id for review_id, *_ in rows]
+    logged_costs: dict[int, float] = defaultdict(float)
+    if review_ids:
+        log_rows = (
+            await session.execute(
+                apply_tenant_filter(
+                    select(ReviewLog.review_id, ReviewLog.metadata_json).where(
+                        ReviewLog.review_id.in_(review_ids),
+                        ReviewLog.event_type == "agent_completed",
+                    ),
+                    ReviewLog,
+                    installation_id,
+                )
+            )
+        ).all()
+        for review_id, metadata_json in log_rows:
+            logged_costs[review_id] += _log_cost(metadata_json)
+
+    totals: dict[tuple[str, int], float] = defaultdict(float)
+    for review_id, repo_full_name, pr_number, cost_usd in rows:
+        totals[(repo_full_name, pr_number)] += (
+            cost_usd if cost_usd is not None else logged_costs[review_id]
+        )
+
+    for review in reviews:
+        review.pr_total_cost_usd = totals[(review.repo_full_name, review.pr_number)]
 
 
 class DashboardService:
@@ -195,6 +262,7 @@ class DashboardService:
             q = q.offset((page - 1) * per_page).limit(per_page)
 
             reviews = (await session.execute(q)).scalars().all()
+            await _attach_pr_total_costs(session, reviews, installation_id)
 
             # Distinct repos for filter dropdown
             repos_stmt = apply_tenant_filter(
@@ -228,7 +296,10 @@ class DashboardService:
                 installation_id,
             )
             result = await session.execute(stmt)
-            return result.scalars().first()
+            review = result.scalars().first()
+            if review:
+                await _attach_pr_total_costs(session, [review], installation_id)
+            return review
 
     @staticmethod
     async def get_review_logs(review_id: int) -> list[ReviewLog]:

--- a/baloo/dashboard/templates/partials/reviews_table.html
+++ b/baloo/dashboard/templates/partials/reviews_table.html
@@ -7,6 +7,7 @@
       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Duration</th>
       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Cost</th>
+      <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">PR Total</th>
       <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Started</th>
     </tr>
   </thead>
@@ -37,11 +38,12 @@
       </td>
       <td class="px-4 py-3 text-sm text-gray-500">{{ "%.1fs"|format(r.duration_seconds) if r.duration_seconds else "-" }}</td>
       <td class="px-4 py-3 text-sm text-gray-500">{{ "$%.4f"|format(r.cost_usd) if r.cost_usd else "-" }}</td>
+      <td class="px-4 py-3 text-sm text-gray-500">{{ "$%.4f"|format(r.pr_total_cost_usd) if r.pr_total_cost_usd else "-" }}</td>
       <td class="px-4 py-3 text-sm text-gray-500"><time datetime="{{ r.started_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}" class="local-time">{{ r.started_at.strftime("%Y-%m-%d %H:%M") }} UTC</time></td>
     </tr>
     {% endfor %}
     {% if not reviews %}
-    <tr><td colspan="7" class="px-4 py-8 text-center text-gray-400">No reviews match the filters</td></tr>
+    <tr><td colspan="8" class="px-4 py-8 text-center text-gray-400">No reviews match the filters</td></tr>
     {% endif %}
   </tbody>
 </table>

--- a/baloo/dashboard/templates/review_detail.html
+++ b/baloo/dashboard/templates/review_detail.html
@@ -66,6 +66,10 @@
     <p class="text-sm font-semibold">{{ "$%.4f"|format(review.cost_usd) if review.cost_usd else "-" }}</p>
   </div>
   <div class="bg-white rounded-lg shadow p-4">
+    <p class="text-xs text-gray-500 uppercase">PR Total Cost</p>
+    <p class="text-sm font-semibold">{{ "$%.4f"|format(review.pr_total_cost_usd) if review.pr_total_cost_usd else "-" }}</p>
+  </div>
+  <div class="bg-white rounded-lg shadow p-4">
     <p class="text-xs text-gray-500 uppercase">Files Examined</p>
     <p class="text-sm font-semibold">{{ review.files_examined if review.files_examined is not none else "-" }}</p>
   </div>

--- a/tests/dashboard/test_queries.py
+++ b/tests/dashboard/test_queries.py
@@ -165,3 +165,15 @@ async def test_pr_total_cost_includes_active_and_cancelled_logged_costs(dashboar
     assert {r.review_status for r in pr_reviews} == {"approved", "in_progress", "cancelled"}
     assert all(r.pr_total_cost_usd == pytest.approx(0.15) for r in pr_reviews)
     assert detail.pr_total_cost_usd == pytest.approx(0.15)
+
+
+def test_log_cost_zero_and_invalid_values():
+    """cost=0 must not fall through to cost_usd; bad values must not raise."""
+    from baloo.dashboard.queries import _log_cost
+
+    assert _log_cost(json.dumps({"cost": 0, "cost_usd": 0.5})) == 0.0
+    assert _log_cost(json.dumps({"cost_usd": 0.25})) == 0.25
+    assert _log_cost(json.dumps({"cost": "not-a-number"})) == 0.0
+    assert _log_cost(json.dumps({"cost": None, "cost_usd": 0.1})) == 0.1
+    assert _log_cost(None) == 0.0
+    assert _log_cost("not json") == 0.0

--- a/tests/dashboard/test_queries.py
+++ b/tests/dashboard/test_queries.py
@@ -1,5 +1,6 @@
 """Cross-tenant isolation tests for DashboardService."""
 
+import json
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -7,7 +8,7 @@ import pytest
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from baloo.db.engine import reset_engine
-from baloo.db.models import Base, Review
+from baloo.db.models import Base, Review, ReviewLog
 
 
 @pytest.fixture
@@ -87,3 +88,80 @@ async def test_list_reviews_only_returns_own_tenant(dashboard_db):
 
     assert result["total"] == 2
     assert all(r.installation_id == "tenant_a" for r in result["reviews"])
+
+
+@pytest.mark.asyncio
+async def test_pr_total_cost_includes_active_and_cancelled_logged_costs(dashboard_db):
+    """PR total cost includes every action for the same repo/PR."""
+    now = datetime.now(timezone.utc)
+    async with dashboard_db() as session:
+        async with session.begin():
+            completed = Review(
+                repo_full_name="owner/repo",
+                pr_number=7,
+                review_status="approved",
+                trigger_reason="test",
+                started_at=now,
+                cost_usd=0.10,
+                installation_id="tenant_a",
+            )
+            active = Review(
+                repo_full_name="owner/repo",
+                pr_number=7,
+                review_status="in_progress",
+                trigger_reason="test",
+                started_at=now,
+                installation_id="tenant_a",
+            )
+            cancelled = Review(
+                repo_full_name="owner/repo",
+                pr_number=7,
+                review_status="cancelled",
+                trigger_reason="test",
+                started_at=now,
+                installation_id="tenant_a",
+            )
+            other_pr = Review(
+                repo_full_name="owner/repo",
+                pr_number=8,
+                review_status="approved",
+                trigger_reason="test",
+                started_at=now,
+                cost_usd=0.99,
+                installation_id="tenant_a",
+            )
+            session.add_all([completed, active, cancelled, other_pr])
+            await session.flush()
+            session.add_all(
+                [
+                    ReviewLog(
+                        review_id=active.id,
+                        event_type="agent_completed",
+                        message="agent done",
+                        metadata_json=json.dumps({"cost": 0.02}),
+                        installation_id="tenant_a",
+                    ),
+                    ReviewLog(
+                        review_id=cancelled.id,
+                        event_type="agent_completed",
+                        message="agent done",
+                        metadata_json=json.dumps({"cost": 0.03}),
+                        installation_id="tenant_a",
+                    ),
+                ]
+            )
+
+    with patch("baloo.dashboard.queries.get_settings") as mock_settings:
+        mock_settings.return_value.database_url = "sqlite+aiosqlite://"
+        mock_settings.return_value.installation_id = "tenant_a"
+
+        from baloo.dashboard.queries import DashboardService
+
+        result = await DashboardService.list_reviews()
+        detail = await DashboardService.get_review_detail(completed.id)
+
+    pr_reviews = [r for r in result["reviews"] if r.pr_number == 7]
+    assert pr_reviews
+    assert {r.review_status for r in pr_reviews} == {"approved", "in_progress", "cancelled"}
+    assert all(r.pr_total_cost_usd == pytest.approx(0.15) for r in pr_reviews)
+    assert detail.pr_total_cost_usd == pytest.approx(0.15)


### PR DESCRIPTION
## Summary
- Add dashboard PR-total cost aggregation across all review attempts for the same repo/PR.
- Include active and cancelled attempts by falling back to recorded agent completion log cost when a review row has no finalized cost.
- Show the PR total on the review list and review detail pages.

## Impact
This makes it possible to track total spend per PR over time without adding schema or changing the review runtime.

## Validation
- uv run pytest tests/dashboard
- uv run ruff check baloo/dashboard/queries.py tests/dashboard/test_queries.py
- uv run black --check baloo/dashboard/queries.py tests/dashboard/test_queries.py