### PR TITLE
fix: coerce string findings in DocumentationDriftResult validation

### DIFF
--- a/baloo/documentation/models.py
+++ b/baloo/documentation/models.py
@@ -1,8 +1,8 @@
 """Pydantic models for documentation drift analysis."""
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class DocumentationCatalogRule(BaseModel):
@@ -55,3 +55,25 @@ class DocumentationDriftResult(BaseModel):
     not_needed: list[DocumentationDriftFinding] = Field(default_factory=list)
     catalog_gaps: list[str] = Field(default_factory=list)
     metadata: dict = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_finding_lists(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        for field, verdict in (
+            ("required_updates", "required"),
+            ("optional_updates", "optional"),
+            ("not_needed", "not_needed"),
+        ):
+            items = data.get(field, [])
+            if isinstance(items, list):
+                data[field] = [
+                    (
+                        {"doc_path": item, "verdict": verdict, "rationale": ""}
+                        if isinstance(item, str)
+                        else item
+                    )
+                    for item in items
+                ]
+        return data

--- a/tests/documentation/test_models.py
+++ b/tests/documentation/test_models.py
@@ -27,6 +27,38 @@ def test_valid_catalog_rule():
     assert catalog.rules[0].read_only is False
 
 
+def test_coerce_string_findings_not_needed():
+    result = DocumentationDriftResult.model_validate({"not_needed": ["docs/foo.md", "docs/bar.md"]})
+    assert len(result.not_needed) == 2
+    assert result.not_needed[0].doc_path == "docs/foo.md"
+    assert result.not_needed[0].verdict == "not_needed"
+    assert result.not_needed[1].doc_path == "docs/bar.md"
+
+
+def test_coerce_string_findings_required_updates():
+    result = DocumentationDriftResult.model_validate({"required_updates": ["docs/api.md"]})
+    assert result.required_updates[0].verdict == "required"
+    assert result.required_updates[0].doc_path == "docs/api.md"
+
+
+def test_coerce_string_findings_optional_updates():
+    result = DocumentationDriftResult.model_validate({"optional_updates": ["docs/guide.md"]})
+    assert result.optional_updates[0].verdict == "optional"
+
+
+def test_coerce_string_findings_passthrough_dicts():
+    result = DocumentationDriftResult.model_validate(
+        {
+            "not_needed": [
+                {"doc_path": "docs/foo.md", "verdict": "not_needed", "rationale": "unchanged"},
+                "docs/bar.md",
+            ]
+        }
+    )
+    assert result.not_needed[0].rationale == "unchanged"
+    assert result.not_needed[1].rationale == ""
+
+
 def test_default_empty_analysis_result():
     result = DocumentationDriftResult()
 


### PR DESCRIPTION
## Summary

- The documentation drift agent occasionally returns `not_needed`, `required_updates`, or `optional_updates` as lists of bare file-path strings instead of `DocumentationDriftFinding` dicts
- This caused a `ValidationError` and silently dropped the entire analysis result
- Added a `model_validator` on `DocumentationDriftResult` that promotes bare strings to minimal `DocumentationDriftFinding` objects using the field's implicit verdict

## Test plan

- [ ] `uv run pytest tests/` passes (776 tests)
- [ ] Verify with a PR that triggers the documentation drift agent and returns string-only `not_needed` list