### PR TITLE
feat: add GeneralFinding type for observations without a file/line anchor

### DIFF
--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -8,7 +8,7 @@ from baloo.agent.pi_runtime import PIAgentBase
 from baloo.agent.prompts import (
     build_pr_review_prompt,
 )
-from baloo.agent.schemas import findings_to_comments
+from baloo.agent.schemas import parse_review_output
 from baloo.github.models import PRContext, ReviewResult
 from baloo.processor.decision_engine import DecisionEngine
 from baloo.processor.formatter import CommentFormatter
@@ -80,10 +80,11 @@ class BalooAgent(PIAgentBase):
                 review_query, review_logger=review_logger
             )
 
-            # Convert structured output to review comments
+            # Convert structured output to review comments and general findings
             comments = []
+            general_findings = []
             if structured_data is not None:
-                comments = findings_to_comments(structured_data)
+                comments, general_findings = parse_review_output(structured_data)
             else:
                 logger.warning(
                     "No structured output received from agent "
@@ -100,14 +101,19 @@ class BalooAgent(PIAgentBase):
                     metadata["error_category"] = metadata.get("error_category", "no_output")
 
             # Generate summary using shared formatter
-            summary = CommentFormatter.format_summary(comments, metadata)
+            summary = CommentFormatter.format_summary(
+                comments, metadata, general_findings=general_findings
+            )
 
             # Make approval decision using centralized engine
-            approve, request_changes = DecisionEngine.make_decision(comments)
+            approve, request_changes = DecisionEngine.make_decision(
+                comments, general_findings=general_findings
+            )
 
             return ReviewResult(
                 summary=summary,
                 comments=comments,
+                general_findings=general_findings,
                 approve=approve,
                 request_changes=request_changes,
                 metadata=metadata,

--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -10,6 +10,9 @@ REVIEW_JSON_RESPONSE_SCHEMA = """## Output Schema
 Your response will be parsed as JSON automatically.  Return an object with:
 - "findings": list of objects with keys: file, line, severity (CRITICAL|HIGH|MEDIUM|LOW),
   category (Security|Bugs|Silent Failures|Guidelines|Performance|Quality), title, description, impact, recommendation, code_example
+- "general_findings": list of objects for observations that have no single file/line anchor
+  (e.g. missing tests, missing documentation, architectural gaps). Keys: severity, category, title, description, recommendation.
+  Use this instead of citing a file that is NOT changed in this PR.
 - "summary": object with keys: total_issues, critical, high, medium, low,
   files_examined, patterns_searched (list), positive_observations (list)
 """

--- a/baloo/agent/schemas.py
+++ b/baloo/agent/schemas.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
-from baloo.github.models import FindingCategory, ReviewComment, ReviewSeverity
+from baloo.github.models import FindingCategory, GeneralFinding, ReviewComment, ReviewSeverity
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +95,21 @@ class ReviewSummary(BaseModel):
     positive_observations: Any = Field(default_factory=list)
 
 
+class GeneralReviewFinding(BaseModel):
+    """A finding with no specific file/line location (e.g. missing tests, doc gaps).
+
+    Tolerant of agent returning unexpected types for fields.
+    """
+
+    model_config = {"extra": "ignore", "coerce_numbers_to_str": True}
+
+    severity: str = "MEDIUM"
+    category: str = "Quality"
+    title: str = "Observation"
+    description: str = ""
+    recommendation: str | None = None
+
+
 class ReviewOutput(BaseModel):
     """Top-level structured output from the review agent.
 
@@ -104,6 +119,7 @@ class ReviewOutput(BaseModel):
     """
 
     findings: list[ReviewFinding] = Field(default_factory=list)
+    general_findings: list[GeneralReviewFinding] = Field(default_factory=list)
     summary: ReviewSummary = Field(default_factory=ReviewSummary)
 
     @classmethod
@@ -193,15 +209,16 @@ def review_output_schema() -> dict:
     return {"type": "json_schema", "schema": ReviewOutput.model_json_schema()}
 
 
-def findings_to_comments(data: dict) -> list[ReviewComment]:
-    """
-    Convert a raw structured output dict into ReviewComment objects.
+def parse_review_output(
+    data: dict,
+) -> tuple[list[ReviewComment], list[GeneralFinding]]:
+    """Convert a raw structured output dict into inline comments and general findings.
 
     Args:
         data: Dict matching the ReviewOutput schema.
 
     Returns:
-        List of ReviewComment objects.
+        Tuple of (inline ReviewComment list, general GeneralFinding list).
     """
     output = ReviewOutput.model_validate(data)
 
@@ -256,4 +273,24 @@ def findings_to_comments(data: dict) -> list[ReviewComment]:
             )
         )
 
+    general: list[GeneralFinding] = []
+    for gf in output.general_findings:
+        enforced_severity = enforce_severity(gf)  # type: ignore[arg-type]
+        body_parts = [f"**{gf.title}**", "", gf.description]
+        if gf.recommendation:
+            body_parts.extend(["", "**Recommendation:**", gf.recommendation])
+        general.append(
+            GeneralFinding(
+                body="\n".join(body_parts),
+                severity=_normalize_severity(enforced_severity),
+                category=_normalize_category(gf.category),
+            )
+        )
+
+    return comments, general
+
+
+# ponytail: backwards-compat alias; prefer parse_review_output
+def findings_to_comments(data: dict) -> list[ReviewComment]:
+    comments, _ = parse_review_output(data)
     return comments

--- a/baloo/agent/schemas.py
+++ b/baloo/agent/schemas.py
@@ -173,7 +173,7 @@ def _lang_for_file(filename: str) -> str:
     return _EXT_TO_LANG.get(ext, "text")
 
 
-def enforce_severity(finding: ReviewFinding) -> str:
+def enforce_severity(finding: ReviewFinding | GeneralReviewFinding) -> str:
     """Derive severity from category using deterministic rules.
 
     Security/Bugs/Silent Failures/Guidelines → floor of HIGH (CRITICAL passes through).
@@ -275,7 +275,7 @@ def parse_review_output(
 
     general: list[GeneralFinding] = []
     for gf in output.general_findings:
-        enforced_severity = enforce_severity(gf)  # type: ignore[arg-type]
+        enforced_severity = enforce_severity(gf)
         body_parts = [f"**{gf.title}**", "", gf.description]
         if gf.recommendation:
             body_parts.extend(["", "**Recommendation:**", gf.recommendation])

--- a/baloo/github/models.py
+++ b/baloo/github/models.py
@@ -233,11 +233,20 @@ class ReviewComment(BaseModel):
     category: FindingCategory = FindingCategory.QUALITY
 
 
+class GeneralFinding(BaseModel):
+    """A review finding with no specific file/line (e.g. missing tests, architectural gaps)."""
+
+    body: str
+    severity: ReviewSeverity = ReviewSeverity.MEDIUM
+    category: FindingCategory = FindingCategory.QUALITY
+
+
 class ReviewResult(BaseModel):
     """Result of a code review."""
 
     summary: str
     comments: list[ReviewComment]
+    general_findings: list[GeneralFinding] = Field(default_factory=list)
     approve: bool = False
     request_changes: bool = False
     metadata: dict = Field(default_factory=dict)

--- a/baloo/processor/decision_engine.py
+++ b/baloo/processor/decision_engine.py
@@ -2,7 +2,7 @@
 
 from baloo.config.settings import get_settings
 from baloo.fidelity.models import FidelityResult
-from baloo.github.models import ReviewComment
+from baloo.github.models import GeneralFinding, ReviewComment
 from baloo.processor.severity_router import ReviewSeverity, count_by_severity
 
 
@@ -13,6 +13,7 @@ class DecisionEngine:
     def make_decision(
         comments: list[ReviewComment],
         fidelity_result: FidelityResult | None = None,
+        general_findings: list[GeneralFinding] | None = None,
     ) -> tuple[bool, bool]:
         """
         Determine review decision based on findings and fidelity score.
@@ -20,14 +21,18 @@ class DecisionEngine:
         Args:
             comments: List of review comments
             fidelity_result: Optional fidelity analysis result
+            general_findings: Optional list of general (non-inline) findings
 
         Returns:
             Tuple of (approve, request_changes)
         """
         settings = get_settings()
 
-        # Count by severity using shared utility
+        # Count by severity using shared utility; also fold in general findings
         counts = count_by_severity(comments)
+        for gf in general_findings or []:
+            sev = gf.severity.value if hasattr(gf.severity, "value") else gf.severity
+            counts[sev] = counts.get(sev, 0) + 1
         critical_count = counts.get(ReviewSeverity.CRITICAL.value, 0)
         high_count = counts.get(ReviewSeverity.HIGH.value, 0)
 

--- a/baloo/processor/formatter.py
+++ b/baloo/processor/formatter.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from baloo.github.models import ReviewComment
+from baloo.github.models import GeneralFinding, ReviewComment
 
 
 class CommentFormatter:
@@ -16,7 +16,11 @@ class CommentFormatter:
     }
 
     @staticmethod
-    def format_summary(comments: list[ReviewComment], metadata: dict[str, Any] = None) -> str:
+    def format_summary(
+        comments: list[ReviewComment],
+        metadata: dict[str, Any] | None = None,
+        general_findings: list[GeneralFinding] | None = None,
+    ) -> str:
         """
         Format a review summary markdown.
 
@@ -27,20 +31,22 @@ class CommentFormatter:
         Returns:
             Formatted Markdown summary
         """
+        general_findings = general_findings or []
         severity_counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
-        for comment in comments:
-            sev = comment.severity.value if hasattr(comment.severity, "value") else comment.severity
+        for finding in list(comments) + list(general_findings):
+            sev = finding.severity.value if hasattr(finding.severity, "value") else finding.severity
             severity_counts[sev] = severity_counts.get(sev, 0) + 1
 
         critical = severity_counts["CRITICAL"]
         high = severity_counts["HIGH"]
         medium = severity_counts["MEDIUM"]
         low = severity_counts["LOW"]
+        total = len(comments) + len(general_findings)
 
         summary_parts = []
         summary_parts.append("## 🐻 Baloo Review Summary\n")
 
-        if not comments:
+        if not comments and not general_findings:
             summary_parts.append("✅ **No issues found!** Code looks good.")
         else:
             stats = []
@@ -54,7 +60,7 @@ class CommentFormatter:
                 stats.append(f"🔵 **{low}** Low")
 
             summary_parts.append(" | ".join(stats))
-            summary_parts.append(f"\n**Total**: {len(comments)} issue(s) found")
+            summary_parts.append(f"\n**Total**: {total} issue(s) found")
 
             if critical > 0 or high > 0:
                 summary_parts.append("\n⚠️ **Please address CRITICAL/HIGH issues before merging**")
@@ -62,6 +68,13 @@ class CommentFormatter:
                 summary_parts.append(
                     "\n✅ **No blocking issues - safe to merge** (consider addressing MEDIUM/LOW items)"
                 )
+
+        if general_findings:
+            summary_parts.append("\n---\n\n**💬 General Observations**\n")
+            for gf in general_findings:
+                sev = gf.severity.value if hasattr(gf.severity, "value") else gf.severity
+                emoji = CommentFormatter.SEVERITY_EMOJIS.get(sev, "")
+                summary_parts.append(f"{emoji} {gf.body}\n")
 
         if metadata:
             summary_parts.append(CommentFormatter.format_metadata_section(metadata))

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -1530,6 +1530,7 @@ async def process_pr_review(
             review_result = ReviewResult(
                 summary=summary_text,
                 comments=fresh_comments,
+                general_findings=general_findings,
                 approve=approve,
                 request_changes=request_changes,
                 metadata=agent_metadata,
@@ -1620,9 +1621,11 @@ async def process_pr_review(
                         )
                         await github_client.post_comment(repo_full_name, pr_number, comment_body)
 
-            has_new_feedback = bool(routed["review"] or follow_up_comments or routed["checks"])
+            has_new_feedback = bool(
+                routed["review"] or follow_up_comments or routed["checks"] or general_findings
+            )
 
-            if request_changes and (routed["review"] or follow_up_comments):
+            if request_changes and (routed["review"] or follow_up_comments or general_findings):
                 logger.info("Posting request-changes review with new or follow-up findings")
                 posted_result = await github_client.post_review(
                     repo_full_name,

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -1475,9 +1475,12 @@ async def process_pr_review(
 
             fresh_comments = verified_new_findings
             decision_comments = fresh_comments + [comment for _, comment in follow_up_comments]
+            general_findings = review_result.general_findings
 
             approve, request_changes = DecisionEngine.make_decision(
-                decision_comments, fidelity_result=fidelity_result
+                decision_comments,
+                fidelity_result=fidelity_result,
+                general_findings=general_findings,
             )
             awaiting_threads = pr_context.awaiting_response_threads - auto_resolved_count
 
@@ -1486,7 +1489,9 @@ async def process_pr_review(
 
             decision_summary = DecisionEngine.get_decision_summary(approve, request_changes)
 
-            summary_text = CommentFormatter.format_summary(decision_comments, agent_metadata)
+            summary_text = CommentFormatter.format_summary(
+                decision_comments, agent_metadata, general_findings=general_findings
+            )
             summary_text = f"{summary_text}\n\n{decision_summary}"
 
             if skipped_responded:

--- a/docs/features/review-agent.md
+++ b/docs/features/review-agent.md
@@ -8,7 +8,7 @@ Baloo uses [PI](https://github.com/mariozechner/pi-coding-agent) as its agentic 
 2. **Context assembly** — Baloo fetches the PR diff, file list, metadata, and any prior discussion threads
 3. **Agent spawns** — A PI process starts in RPC mode with **read-only tools**: `read`, `grep`, `find`, `ls`
 4. **Agentic review** — The agent reads changed files in full, greps for security patterns, explores project structure, checks for tests and configs
-5. **Structured output** — The agent returns a JSON object with findings (file, line, severity, category, description, recommendation)
+5. **Structured output** — The agent returns a JSON object with findings (file, line, severity, category, description, recommendation), plus a `general_findings` list for observations with no file/line anchor (e.g. missing tests, architectural gaps). General findings appear as a "General Observations" section in the PR summary rather than as inline comments
 6. **Post-processing** — Findings go through FP verification (optional), severity filtering, duplicate detection, and severity routing before being posted
 
 ## Why Agentic?

--- a/docs/features/severity-routing.md
+++ b/docs/features/severity-routing.md
@@ -11,6 +11,8 @@ Baloo routes findings to different GitHub surfaces based on severity, so develop
 | **MEDIUM** | GitHub Checks API annotation | ❌ No |
 | **LOW** | Filtered out (not posted) | ❌ No |
 
+General findings (no file/line anchor, e.g. missing tests) are not posted inline or to the Checks API — they appear under a "💬 General Observations" section in the review summary. CRITICAL/HIGH general findings still count toward the "Request Changes" decision.
+
 ## How It Looks
 
 ### CRITICAL / HIGH → Review Comments
@@ -47,7 +49,7 @@ The agent assigns severity based on these guidelines:
 ## Approval Decision Logic
 
 ```
-CRITICAL or HIGH found  →  Request Changes
+CRITICAL or HIGH found (inline or general)  →  Request Changes
 No blocking issues + high fidelity score  →  Approve
 No blocking issues + auto-approve enabled  →  Approve
 Otherwise  →  Comment only (no approval or rejection)

--- a/scripts/dry_run_pr.py
+++ b/scripts/dry_run_pr.py
@@ -91,6 +91,9 @@ async def async_main(argv: list[str] | None = None) -> int:
     parser.add_argument("--head", default="HEAD", help="Head ref for the diff")
     parser.add_argument("--model", help="Optional Baloo model override")
     parser.add_argument(
+        "--output-json", metavar="PATH", help="Write ReviewResult JSON to this file"
+    )
+    parser.add_argument(
         "--reproduce-bug",
         action="store_true",
         help="Do NOT set the agent cwd (reproduces the production behavior where "
@@ -135,12 +138,25 @@ async def async_main(argv: list[str] | None = None) -> int:
     print("\n=== Review summary ===")
     print(result.summary)
     if result.comments:
-        print("\n=== Findings ===")
+        print("\n=== Inline findings ===")
         for c in result.comments:
             sev = c.severity.value if hasattr(c.severity, "value") else c.severity
             print(f"[{sev}] {c.path}:{c.line}")
+    if result.general_findings:
+        print("\n=== General findings ===")
+        for gf in result.general_findings:
+            sev = gf.severity.value if hasattr(gf.severity, "value") else gf.severity
+            print(f"[{sev}] {gf.body[:120]}")
 
     _print_outcome_summary(collector)
+
+    if args.output_json:
+        import json
+
+        out_path = Path(args.output_json)
+        out_path.write_text(json.dumps(result.model_dump(mode="json"), indent=2))
+        print(f"\n[output] wrote result to {out_path}", file=sys.stderr)
+
     return 0
 
 

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -1,0 +1,201 @@
+"""Baloo regression harness.
+
+Runs known PR scenarios through the full review pipeline and checks assertions.
+
+Usage:
+    uv run python -m scripts.regression
+
+Requirements:
+    ANTHROPIC_API_KEY or OPENROUTER_API_KEY must be set.
+
+Override the model for all scenarios:
+    BALOO_REGRESSION_MODEL=claude-haiku-4-5-20251001 uv run python -m scripts.regression
+
+Run a single scenario by name:
+    uv run python -m scripts.regression --scenario missing-tests-surfaces-finding
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _run_scenario(scenario: dict, base_env: dict[str, str]) -> dict:
+    """Run one scenario via dry_run_pr and return the parsed ReviewResult JSON."""
+    env = os.environ.copy()
+    env.update(base_env)
+
+    model_override = os.environ.get("BALOO_REGRESSION_MODEL") or scenario.get("model")
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        out_path = f.name
+
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "scripts.dry_run_pr",
+        "--repo",
+        str(REPO_ROOT),
+        "--base",
+        scenario["base"],
+        "--head",
+        scenario["head"],
+        "--output-json",
+        out_path,
+    ]
+    if model_override:
+        cmd += ["--model", model_override]
+
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    if proc.returncode != 0:
+        return {"_error": proc.stderr[-2000:]}
+
+    try:
+        return json.loads(Path(out_path).read_text())
+    except Exception as exc:
+        return {"_error": f"Could not parse output JSON: {exc}\nstderr: {proc.stderr[-500:]}"}
+    finally:
+        Path(out_path).unlink(missing_ok=True)
+
+
+def _check_assertions(result: dict, assertions: list[dict]) -> list[str]:
+    """Return a list of failure messages (empty = all passed)."""
+    inline = result.get("comments", [])
+    general = result.get("general_findings", [])
+    all_findings = inline + general
+
+    failures = []
+    for a in assertions:
+        t = a["type"]
+
+        if t == "no_blocking_findings":
+            if result.get("request_changes"):
+                findings_desc = ", ".join(
+                    f"[{f.get('severity', '?')}] {f.get('path', 'general')}" for f in all_findings
+                )
+                failures.append(
+                    f"request_changes=True but expected no blocking findings. "
+                    f"Findings: {findings_desc or '(none listed)'}"
+                )
+
+        elif t == "has_findings":
+            if not all_findings:
+                failures.append("Expected ≥1 finding but got 0")
+
+        elif t == "request_changes":
+            if not result.get("request_changes"):
+                failures.append("Expected request_changes=True")
+
+        elif t == "approve":
+            if not result.get("approve"):
+                failures.append("Expected approve=True")
+
+        elif t == "summary_contains":
+            text = a["text"]
+            if text.lower() not in result.get("summary", "").lower():
+                failures.append(f"Expected summary to contain '{text}'")
+
+        elif t == "finding_count_gte":
+            count = len(all_findings)
+            if count < a["value"]:
+                failures.append(f"Expected ≥{a['value']} findings, got {count}")
+
+        elif t == "general_findings_gte":
+            count = len(general)
+            if count < a["value"]:
+                failures.append(f"Expected ≥{a['value']} general findings, got {count}")
+
+        elif t == "has_severity":
+            want = a["severity"].upper()
+            if not any(f.get("severity") == want for f in all_findings):
+                failures.append(f"Expected ≥1 {want} finding")
+
+    return failures
+
+
+def _print_result_stats(result: dict) -> None:
+    inline = result.get("comments", [])
+    general = result.get("general_findings", [])
+    print(
+        f"  inline={len(inline)} general={len(general)} "
+        f"request_changes={result.get('request_changes')} approve={result.get('approve')}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--scenario", help="Run only this scenario (by name)")
+    parser.add_argument(
+        "--verbose", "-v", action="store_true", help="Print full review summary on failure"
+    )
+    args = parser.parse_args(argv)
+
+    # Import here so the file is easy to edit without restarting
+    from scripts.regression_scenarios import BASE_ENV, SCENARIOS  # noqa: PLC0415
+
+    scenarios = SCENARIOS
+    if args.scenario:
+        scenarios = [s for s in scenarios if s["name"] == args.scenario]
+        if not scenarios:
+            print(
+                f"Unknown scenario '{args.scenario}'. Available: {[s['name'] for s in SCENARIOS]}"
+            )
+            return 1
+
+    passed = failed = 0
+    for scenario in scenarios:
+        name = scenario["name"]
+        model = os.environ.get("BALOO_REGRESSION_MODEL") or scenario.get("model", "?")
+        print(f"\n{'─'*60}")
+        print(f"  {name}")
+        print(f"  {scenario.get('description', '')}")
+        print(f"  diff: {scenario['base']}..{scenario['head']}  model: {model}")
+        print("  running...", flush=True)
+
+        result = _run_scenario(scenario, BASE_ENV)
+
+        if "_error" in result:
+            print(f"  FAIL (runner error):\n    {result['_error'][:400]}")
+            failed += 1
+            continue
+
+        _print_result_stats(result)
+        failures = _check_assertions(result, scenario.get("assertions", []))
+
+        if failures:
+            print("  FAIL:")
+            for f in failures:
+                print(f"    ✗ {f}")
+            if args.verbose:
+                print("\n  --- summary ---")
+                print(result.get("summary", "(none)"))
+            failed += 1
+        else:
+            print("  PASS ✓")
+            passed += 1
+
+    print(f"\n{'='*60}")
+    print(f"  {passed} passed  {failed} failed  ({passed + failed} total)")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -29,8 +29,9 @@ REPO_ROOT = Path(__file__).parent.parent
 
 def _run_scenario(scenario: dict, base_env: dict[str, str]) -> dict:
     """Run one scenario via dry_run_pr and return the parsed ReviewResult JSON."""
-    env = os.environ.copy()
-    env.update(base_env)
+    # BASE_ENV provides defaults; ambient env wins (see regression_scenarios.py).
+    env = dict(base_env)
+    env.update(os.environ)
 
     model_override = os.environ.get("BALOO_REGRESSION_MODEL") or scenario.get("model")
 

--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -55,21 +55,22 @@ def _run_scenario(scenario: dict, base_env: dict[str, str]) -> dict:
     if model_override:
         cmd += ["--model", model_override]
 
-    proc = subprocess.run(
-        cmd,
-        cwd=str(REPO_ROOT),
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-    if proc.returncode != 0:
-        return {"_error": proc.stderr[-2000:]}
-
     try:
-        return json.loads(Path(out_path).read_text())
-    except Exception as exc:
-        return {"_error": f"Could not parse output JSON: {exc}\nstderr: {proc.stderr[-500:]}"}
+        proc = subprocess.run(
+            cmd,
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+        if proc.returncode != 0:
+            return {"_error": proc.stderr[-2000:]}
+
+        try:
+            return json.loads(Path(out_path).read_text())
+        except Exception as exc:
+            return {"_error": f"Could not parse output JSON: {exc}\nstderr: {proc.stderr[-500:]}"}
     finally:
         Path(out_path).unlink(missing_ok=True)
 
@@ -125,6 +126,9 @@ def _check_assertions(result: dict, assertions: list[dict]) -> list[str]:
             want = a["severity"].upper()
             if not any(f.get("severity") == want for f in all_findings):
                 failures.append(f"Expected ≥1 {want} finding")
+
+        else:
+            failures.append(f"Unknown assertion type: '{t}'")
 
     return failures
 

--- a/scripts/regression_scenarios.py
+++ b/scripts/regression_scenarios.py
@@ -1,0 +1,75 @@
+"""Known PR scenarios for Baloo regression testing.
+
+Each scenario tests a real diff from the baloo-bear repo itself.  Assertions
+are intentionally loose (LLM is non-deterministic) — they check observable
+behavior, not exact output.
+
+Add new scenarios here whenever a bug is fixed or a new feature ships.
+"""
+
+from __future__ import annotations
+
+# Env vars applied to every scenario run (mirrors prod minus expensive passes).
+# Override any of these via ambient env before running.
+BASE_ENV: dict[str, str] = {
+    "FP_VERIFICATION_ENABLED": "false",  # skip for speed
+    "DOCUMENTATION_DRIFT_ENABLED": "false",  # skip for speed
+    "FIDELITY_ENABLED": "false",  # skip for speed
+    "THREAD_AGENT_ENABLED": "false",
+    "REPO_CACHE_ENABLED": "false",
+    "REVIEW_AUTO_APPROVE": "true",
+    "REVIEW_MIN_SEVERITY": "MEDIUM",
+    "REVIEW_USE_CHECKS_API": "false",
+    "PI_THINKING_LEVEL": "low",
+}
+
+# Default models — override per scenario or via BALOO_REGRESSION_MODEL env var.
+# Use haiku for cheap/fast scenarios, sonnet for those requiring deeper reasoning.
+_FAST_MODEL = "claude-haiku-4-5-20251001"
+_MAIN_MODEL = "claude-sonnet-4-6"
+
+SCENARIOS: list[dict] = [
+    {
+        "name": "docs-fix-no-blocking",
+        "description": (
+            "A one-line docs typo fix should not produce blocking findings. "
+            "Regression for false-positive noise on trivial changes."
+        ),
+        # Diff: 300332e (readme support link) → e577e11 (fix docs typo)
+        "base": "300332e",
+        "head": "e577e11",
+        "model": _FAST_MODEL,
+        "assertions": [
+            {"type": "no_blocking_findings"},
+        ],
+    },
+    {
+        "name": "missing-tests-surfaces-finding",
+        "description": (
+            "PR adding a Pydantic model_validator with no tests should surface ≥1 finding. "
+            "Validates general_findings path: the test file is not in the diff so the finding "
+            "must appear as a general observation rather than being silently dropped."
+        ),
+        # Diff: cfe5191 (semantic PR docs merge) → 9bad2fa (validator fix, no tests added)
+        "base": "cfe5191",
+        "head": "9bad2fa",
+        "model": _MAIN_MODEL,
+        "assertions": [
+            {"type": "has_findings"},
+        ],
+    },
+    {
+        "name": "dep-bump-no-blocking",
+        "description": (
+            "A pure dependency version bump should not produce blocking findings. "
+            "Regression for false positives on automated Dependabot-style PRs."
+        ),
+        # Diff: single pytest dev-dep bump commit
+        "base": "b9a3198^",
+        "head": "b9a3198",
+        "model": _FAST_MODEL,
+        "assertions": [
+            {"type": "no_blocking_findings"},
+        ],
+    },
+]

--- a/tests/agent/test_schemas.py
+++ b/tests/agent/test_schemas.py
@@ -7,6 +7,7 @@ from baloo.agent.schemas import (
     _normalize_category,
     enforce_severity,
     findings_to_comments,
+    parse_review_output,
     review_output_schema,
 )
 from baloo.fidelity.models import (
@@ -641,3 +642,64 @@ class TestLangForFile:
         }
         comments = findings_to_comments(data)
         assert "```typescript" in comments[0].body
+
+
+class TestParseReviewOutput:
+    """Tests for parse_review_output returning both inline and general findings."""
+
+    def test_returns_inline_and_general(self):
+        data = {
+            "findings": [
+                {
+                    "file": "a.py",
+                    "line": 10,
+                    "severity": "HIGH",
+                    "category": "Bugs",
+                    "title": "Null check missing",
+                    "description": "Value may be None.",
+                }
+            ],
+            "general_findings": [
+                {
+                    "severity": "HIGH",
+                    "category": "Guidelines",
+                    "title": "No tests for new validator",
+                    "description": "The PR adds a model_validator but no tests.",
+                    "recommendation": "Add tests to tests/documentation/test_models.py.",
+                }
+            ],
+        }
+        comments, general = parse_review_output(data)
+        assert len(comments) == 1
+        assert comments[0].path == "a.py"
+        assert len(general) == 1
+        assert general[0].severity == "HIGH"
+        assert "No tests for new validator" in general[0].body
+        assert "Add tests" in general[0].body
+
+    def test_empty_general_findings(self):
+        data = {"findings": [], "general_findings": []}
+        comments, general = parse_review_output(data)
+        assert comments == []
+        assert general == []
+
+    def test_general_finding_severity_enforced(self):
+        data = {
+            "general_findings": [
+                {
+                    "severity": "LOW",
+                    "category": "Guidelines",
+                    "title": "Missing docs",
+                    "description": "No docs updated.",
+                }
+            ]
+        }
+        _, general = parse_review_output(data)
+        # Guidelines floor is HIGH; LOW should be escalated
+        assert general[0].severity == "HIGH"
+
+    def test_missing_general_findings_key(self):
+        """Output without general_findings key should work fine."""
+        data = {"findings": []}
+        comments, general = parse_review_output(data)
+        assert general == []

--- a/tests/processor/test_decision_engine.py
+++ b/tests/processor/test_decision_engine.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch
 
 from baloo.fidelity.models import FidelityResult
-from baloo.github.models import ReviewComment
+from baloo.github.models import GeneralFinding, ReviewComment
 from baloo.processor.decision_engine import DecisionEngine
 
 
@@ -230,3 +230,25 @@ class TestGetDecisionSummary:
         summary = DecisionEngine.get_decision_summary(approve=False, request_changes=False)
         assert "Comments Only" in summary
         assert "💬" in summary
+
+
+class TestMakeDecisionWithGeneralFindings:
+    def test_high_general_finding_blocks(self):
+        gf = GeneralFinding(body="Missing tests", severity="HIGH", category="Guidelines")
+        approve, request_changes = DecisionEngine.make_decision([], general_findings=[gf])
+        assert request_changes is True
+        assert approve is False
+
+    def test_medium_general_finding_does_not_block(self):
+        gf = GeneralFinding(body="Minor observation", severity="MEDIUM", category="Quality")
+        with patch("baloo.processor.decision_engine.get_settings") as mock_settings:
+            mock_settings.return_value.review_auto_approve = False
+            mock_settings.return_value.fidelity_approval_threshold = 80
+            approve, request_changes = DecisionEngine.make_decision([], general_findings=[gf])
+        assert request_changes is False
+
+    def test_inline_clean_general_high_still_blocks(self):
+        """No inline issues but a HIGH general finding should still request changes."""
+        gf = GeneralFinding(body="No tests added", severity="HIGH", category="Guidelines")
+        approve, request_changes = DecisionEngine.make_decision([], general_findings=[gf])
+        assert request_changes is True

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -1114,3 +1114,49 @@ class TestDocumentationDriftOrchestration:
             )
 
         assert documentation.await_args.args[2] is pr_context
+
+
+class TestGeneralFindingsPosting:
+    """A review whose only findings are general (no file/line) must still be visible."""
+
+    @pytest.mark.asyncio
+    async def test_general_findings_only_review_posts_request_changes(self):
+        from baloo.github.models import GeneralFinding
+
+        gf = GeneralFinding(
+            body="No tests cover the new validator",
+            severity=ReviewSeverity.HIGH,
+            category=FindingCategory.GUIDELINES,
+        )
+        agent = MagicMock()
+        agent.review_pr = AsyncMock(
+            return_value=ReviewResult(
+                summary="## Summary",
+                comments=[],
+                general_findings=[gf],
+                approve=False,
+                request_changes=True,
+                metadata={},
+            )
+        )
+        gc = _make_github_client()
+
+        await _run_review(gc, agent)
+
+        posted_blocking = [
+            call
+            for call in gc.post_review.call_args_list
+            if (
+                call.args[2] if len(call.args) >= 3 else call.kwargs.get("review_result")
+            ).request_changes
+        ]
+        assert posted_blocking, (
+            "A general-findings-only review must post a request_changes review, "
+            "not silently block the PR"
+        )
+        result_arg = (
+            posted_blocking[0].args[2]
+            if len(posted_blocking[0].args) >= 3
+            else posted_blocking[0].kwargs.get("review_result")
+        )
+        assert result_arg.comments == []


### PR DESCRIPTION
## Summary

Findings like "missing tests" or "update the docs" can't be placed as inline review comments because they reference files not in the PR diff. Previously these were silently dropped (the symptom from PR #145).

This PR adds a `GeneralFinding` type for observations that have no specific file/line anchor:

- Agent emits `general_findings` (alongside `findings`) when a finding can't be anchored to a changed line
- General findings appear in the **review summary body** under a "General Observations" section — visible to everyone reading the review
- CRITICAL/HIGH general findings still **block the PR** (request changes)
- Same `enforce_severity` rules apply (Guidelines floor at HIGH, etc.)
- Output schema updated so the agent knows when to use `general_findings` vs `findings`

## What the agent should now do

Instead of citing `tests/foo.py:31` (a file not in the diff), the agent emits:
```json
"general_findings": [{
  "severity": "HIGH",
  "category": "Guidelines",
  "title": "No tests for new model_validator",
  "description": "...",
  "recommendation": "Add tests to tests/documentation/test_models.py."
}]
```

## Test plan

- [ ] `uv run pytest tests/` passes (783 tests)
- [ ] `parse_review_output` returns correct `(comments, general_findings)` tuple
- [ ] HIGH general finding triggers `request_changes` with no inline findings
- [ ] General findings appear in `format_summary` output