### PR TITLE
Add @baloo review comment command

### DIFF
--- a/baloo/github/api_client.py
+++ b/baloo/github/api_client.py
@@ -530,6 +530,18 @@ class GitHubAPIClient:
         )
         response.raise_for_status()
 
+    async def add_reaction(
+        self, repo_full_name: str, comment_id: int, content: str = "eyes"
+    ) -> None:
+        """Add a reaction to an issue/PR conversation comment (acknowledges a command)."""
+        url = f"{self.base_url}/repos/{repo_full_name}/issues/comments/{comment_id}/reactions"
+        response = await self._http.post(
+            url,
+            headers=self._get_headers(),
+            json={"content": content},
+        )
+        response.raise_for_status()
+
     async def reply_to_review_comment(
         self,
         repo_full_name: str,

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -46,6 +46,59 @@ def _mark_delivery_seen(delivery_id: str | None, ttl_seconds: int) -> bool:
     return False
 
 
+_REVIEW_COMMAND = "@baloo review"
+# Only people with write access to the repo may spend review budget via a comment command.
+# GitHub stamps every comment with the author's association, so this needs no extra API call.
+_REVIEW_COMMAND_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
+
+def _is_review_command(body: str) -> bool:
+    """True when a comment's first line is the `@baloo review` command (case-insensitive)."""
+    if not body:
+        return False
+    lines = body.strip().splitlines()
+    if not lines:
+        return False
+    tokens = lines[0].strip().lower().split()
+    return tokens[:2] == ["@baloo", "review"]
+
+
+async def _run_review_command(
+    repo_full_name: str,
+    pr_number: int,
+    installation_id: int,
+    comment_id: int | None,
+    delivery_id: str | None,
+) -> None:
+    """Acknowledge a `@baloo review` command with a reaction, then run a full review.
+
+    Passes head_sha="" so the review skips DB-level dedup and always re-runs — an explicit
+    command means "review the current head now", even if it was reviewed before.
+    """
+    if comment_id is not None:
+        try:
+            async with GitHubAPIClient(installation_id) as gh_client:
+                await gh_client.add_reaction(repo_full_name, comment_id, "eyes")
+        except Exception:
+            logger.warning(
+                "Failed to react to @baloo review command on %s#%s",
+                repo_full_name,
+                pr_number,
+                exc_info=True,
+            )
+
+    await process_pr_review(
+        repo_full_name,
+        pr_number,
+        installation_id,
+        trigger_reason="issue_comment:@baloo review",
+        notify_progress=True,
+        synchronize_base_sha=None,
+        head_sha="",
+        delivery_id=delivery_id,
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application lifespan: initialize and tear down database."""
@@ -337,7 +390,61 @@ async def handle_webhook(
 
         return {"status": "queued", "event": event, "action": "thread_reply"}
 
-    elif event in ("issue_comment", "pull_request_review"):
+    elif event == "issue_comment":
+        action = payload.get("action")
+
+        # Only new comments carry commands (not edits or deletions)
+        if action != "created":
+            return {"status": "ignored", "event": event, "reason": f"action={action}"}
+
+        issue = payload.get("issue", {})
+        # issue_comment fires for both issues and PRs; only PRs carry a pull_request object
+        if "pull_request" not in issue:
+            return {"status": "ignored", "event": event, "reason": "not a pull request"}
+
+        comment_data = payload.get("comment", {})
+        if not _is_review_command(comment_data.get("body", "")):
+            return {"status": "ignored", "event": event, "reason": "not a review command"}
+
+        association = comment_data.get("author_association", "")
+        if association not in _REVIEW_COMMAND_ASSOCIATIONS:
+            logger.info(
+                "Ignoring @baloo review on %s#%s from @%s — association %s not authorized",
+                _repo_full_name or "",
+                issue.get("number", 0),
+                (comment_data.get("user") or {}).get("login", ""),
+                association,
+            )
+            return {"status": "ignored", "event": event, "reason": "commenter not authorized"}
+
+        repo_full_name = _repo_full_name or ""
+        pr_number = issue.get("number", 0)
+        comment_id = comment_data.get("id")
+
+        # Cancel any redundant in-flight review, then force a fresh full review of the current
+        # head — deliberately bypassing the merge/sync-commit skip that synchronize applies.
+        cancel_existing_review(repo_full_name, pr_number)
+        task = asyncio.create_task(
+            _run_review_command(
+                repo_full_name,
+                pr_number,
+                _installation_id,
+                comment_id,
+                delivery_id,
+            )
+        )
+        active_reviews[(repo_full_name, pr_number)] = task
+        background_tasks.add_task(lambda: None)
+
+        logger.info(
+            "Queued @baloo review command for %s#%s (comment=%s)",
+            repo_full_name,
+            pr_number,
+            comment_id,
+        )
+        return {"status": "queued", "event": event, "action": "review_command"}
+
+    elif event == "pull_request_review":
         logger.debug("Ignoring %s event — reviews trigger only on new code", event)
         return {"status": "ignored", "event": event, "reason": "comment events disabled"}
 

--- a/tests/github/test_review_command_webhook.py
+++ b/tests/github/test_review_command_webhook.py
@@ -1,0 +1,188 @@
+"""Tests for the `@baloo review` issue-comment command."""
+
+from __future__ import annotations
+
+import itertools
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from baloo.github.webhook_handler import _is_review_command, _run_review_command, app
+
+# Unique per post — the handler dedups repeated X-GitHub-Delivery ids process-wide.
+_delivery_ids = (f"delivery-{n}" for n in itertools.count())
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _make_issue_comment_payload(
+    *,
+    action: str = "created",
+    body: str = "@baloo review",
+    author_association: str = "MEMBER",
+    author: str = "maintainer",
+    is_pull_request: bool = True,
+    comment_id: int = 555,
+    pr_number: int = 7,
+    repo: str = "org/repo",
+    installation_id: int = 1,
+) -> dict:
+    issue: dict = {
+        "number": pr_number,
+        "title": "Test PR",
+        "html_url": f"https://github.com/{repo}/pull/{pr_number}",
+    }
+    if is_pull_request:
+        issue["pull_request"] = {"url": f"https://api.github.com/repos/{repo}/pulls/{pr_number}"}
+
+    return {
+        "action": action,
+        "issue": issue,
+        "comment": {
+            "id": comment_id,
+            "body": body,
+            "author_association": author_association,
+            "user": {"login": author, "id": 1, "avatar_url": "", "html_url": ""},
+            "html_url": f"https://github.com/{repo}/pull/{pr_number}#issuecomment-{comment_id}",
+        },
+        "repository": {
+            "id": 1,
+            "name": "repo",
+            "full_name": repo,
+            "owner": {"login": "org", "id": 1, "avatar_url": "", "html_url": ""},
+            "html_url": f"https://github.com/{repo}",
+            "default_branch": "main",
+        },
+        "installation": {"id": installation_id},
+        "sender": {"login": author, "id": 1, "avatar_url": "", "html_url": ""},
+    }
+
+
+def _post(client, payload: dict, delivery: str | None = None):
+    body = json.dumps(payload).encode()
+    delivery_id = delivery if delivery is not None else next(_delivery_ids)
+    with (
+        patch("baloo.github.webhook_handler.verify_webhook_signature", return_value=True),
+        patch(
+            "baloo.github.webhook_handler._validate_webhook_security",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        return client.post(
+            "/webhook",
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-GitHub-Event": "issue_comment",
+                "X-Hub-Signature-256": "sha256=fake",
+                "X-GitHub-Delivery": delivery_id,
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ("@baloo review", True),
+        ("@BALOO Review", True),
+        ("  @baloo review  ", True),
+        ("@baloo review please re-run", True),
+        ("@baloo review\nthanks", True),
+        ("@baloo reviewer", False),
+        ("please @baloo review", False),
+        ("looks good to me", False),
+        ("", False),
+        ("   ", False),
+    ],
+)
+def test_is_review_command(body: str, expected: bool):
+    assert _is_review_command(body) is expected
+
+
+def test_review_command_queued_for_authorized_member(client):
+    payload = _make_issue_comment_payload(author_association="MEMBER")
+
+    with (
+        patch("baloo.github.webhook_handler._run_review_command", new=AsyncMock()) as mock_run,
+        patch("baloo.github.webhook_handler.cancel_existing_review") as mock_cancel,
+    ):
+        resp = _post(client, payload, delivery="delivery-queued")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "queued"
+    assert data["action"] == "review_command"
+    mock_cancel.assert_called_once_with("org/repo", 7)
+    mock_run.assert_called_once_with("org/repo", 7, 1, 555, "delivery-queued")
+
+
+def test_review_command_ignored_on_plain_issue(client):
+    payload = _make_issue_comment_payload(is_pull_request=False)
+
+    resp = _post(client, payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ignored"
+    assert data["reason"] == "not a pull request"
+
+
+def test_review_command_ignored_for_unauthorized_commenter(client):
+    payload = _make_issue_comment_payload(author_association="CONTRIBUTOR")
+
+    with patch("baloo.github.webhook_handler._run_review_command", new=AsyncMock()) as mock_run:
+        resp = _post(client, payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ignored"
+    assert data["reason"] == "commenter not authorized"
+    mock_run.assert_not_called()
+
+
+def test_non_command_comment_ignored(client):
+    payload = _make_issue_comment_payload(body="looks good, merging")
+
+    resp = _post(client, payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ignored"
+    assert data["reason"] == "not a review command"
+
+
+def test_review_command_ignored_on_edit(client):
+    payload = _make_issue_comment_payload(action="edited")
+
+    resp = _post(client, payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ignored"
+    assert data["reason"] == "action=edited"
+
+
+@pytest.mark.asyncio
+async def test_run_review_command_reacts_then_forces_full_review():
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = None
+
+    with (
+        patch("baloo.github.webhook_handler.GitHubAPIClient", return_value=mock_client),
+        patch("baloo.github.webhook_handler.process_pr_review", new=AsyncMock()) as mock_review,
+    ):
+        await _run_review_command("org/repo", 7, 1, 555, "delivery-123")
+
+    mock_client.add_reaction.assert_awaited_once_with("org/repo", 555, "eyes")
+    mock_review.assert_awaited_once()
+    _, kwargs = mock_review.call_args
+    # head_sha="" forces a fresh review (skips DB-level dedup)
+    assert kwargs["head_sha"] == ""
+    assert kwargs["trigger_reason"] == "issue_comment:@baloo review"
+    assert kwargs["synchronize_base_sha"] is None


### PR DESCRIPTION
## Why

`issue_comment` events are currently **hard-ignored** in `webhook_handler.py`, so there is no way to ask Baloo to re-review a PR without pushing a commit. That leaves PRs stuck in real situations:

- Baloo's last review **races a thread-resolution** — it runs, sees the thread still open ("still waiting on 1 existing thread"), and the thread is resolved seconds later. Baloo never re-reviews, so it never approves.
- The current head is a **merge commit** — `pull_request:synchronize` deliberately skips merge/sync commits (`is_merge_or_sync_commit`), so merging `main` in does not trigger a review.

In both cases there is no re-trigger short of an empty commit. This adds one: `@baloo review`.

## What

Handle `issue_comment` (`action=created`) on a **PR**:

- Trigger only when the comment's **first line** is `@baloo review` (case-insensitive) — starts-with on the first line, so quoting it in prose doesn't fire.
- **Authorization:** only `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` (write access). Read straight from the webhook payload — **no extra API call**. baloo-bear is a public App, so this gates review-budget abuse; outsiders' commands are silently ignored.
- On accept: add a 👀 reaction to the command comment, then queue a **full review of the current head**.
  - `head_sha=""` is passed **deliberately** so the review skips DB-level dedup and always re-runs.
  - The merge/sync-commit skip is **bypassed** — an explicit human command means "review the current head now", even if it's a merge commit.
- Ignored: unauthorized commenters, comments on plain issues (not PRs), non-command bodies, and `edited`/`deleted` actions. `pull_request_review` stays ignored.

Adds `GitHubAPIClient.add_reaction`.

## Tests

`tests/github/test_review_command_webhook.py`:
- command matcher (case, extra tokens, multiline, `@baloo reviewer` and mid-sentence rejected)
- authorized member → queued (`cancel_existing_review` + `_run_review_command` called)
- plain issue → ignored; unauthorized association → ignored; non-command → ignored; `edited` → ignored
- `_run_review_command` reacts then calls `process_pr_review` with `head_sha=""`

`uv run pytest tests/github/test_review_command_webhook.py` → 16 passed. `ruff` + `black` clean. Two unrelated pre-existing failures in `test_webhook_handler.py` (a `MagicMock` reaching `ticket_extractor`) reproduce on clean `main` and are untouched by this change.

## Permissions note

The reaction uses the issue-comment reactions API; the App already writes issue comments (`issues: write`), which covers it.