### PR TITLE
Install libatomic1 for node 26 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     git \
     bubblewrap \
+    libatomic1 \
     && apt-get upgrade -y openssl libssl3 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Docker build fails at `npm ci` with `node: error while loading shared libraries: libatomic.so.1`.

The image copies the `node` binary from `node:26-bookworm-slim` into `python:3.14-slim-bookworm`. Node 26 links against `libatomic.so.1`, which the node image ships but the python-slim base does not. Adding `libatomic1` to the apt install layer fixes the build.