### PR TITLE
Drop husky prepare script in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN pip install --no-cache-dir --require-hashes -r requirements-prod.txt
 
 # Install PI coding agent from package-lock.json (provides the 'pi' CLI)
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+# husky's prepare script needs .husky/ and devDeps, neither present in this layer
+RUN npm pkg delete scripts.prepare && npm ci --omit=dev
 
 # Install AST tools extension dependencies
 COPY extensions/package.json extensions/package-lock.json /app/extensions/


### PR DESCRIPTION
Docker build fails at `npm ci --omit=dev` since #128 added a husky `prepare` script (`node .husky/install.mjs`): the `.husky/` directory isn't copied into the dependency layer, and husky itself is a devDependency omitted from the install.

Fix: `npm pkg delete scripts.prepare` inside the image before `npm ci`. This only strips the git-hooks setup (irrelevant in the container) — dependency lifecycle scripts (koffi, protobufjs, @google/genai) still run normally, unlike `--ignore-scripts`.