### PR TITLE
feat(agent): flag a missing PR review-brief section as a HIGH finding (DEN-3316)

### DIFF
--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -77,6 +77,19 @@ Changes that contradict what those files say are HIGH findings. Common examples 
 - Dependency management that contradicts the conventions in the guidelines
 Only flag a violation if the target repo's guidelines explicitly require a different convention.
 
+## Required PR-Description Sections (HIGH)
+Some repos require the PR **Description** (shown above) to contain a specific section. This is a
+guideline violation you MUST check even though it is not in the code diff and has no natural
+file:line. If `CONTRIBUTING.md` (or `AGENTS.md`) requires a review-brief section and the PR
+Description above does not contain that heading with real content, you MUST emit a HIGH Guidelines
+finding — do not stay silent.
+- For blueden specifically: `CONTRIBUTING.md` requires a `## Review guidance for Baloo` section in
+  every PR description. If the Description above is missing that heading (or it is present but empty),
+  emit a HIGH Guidelines finding titled "Missing '## Review guidance for Baloo' section",
+  recommending the author run the `pr-review-brief` skill and add it. Anchor it at the first changed
+  file, line 1, and state in the description that it is a PR-description omission.
+- Do not raise this when the target repo's guidelines do not require such a section.
+
 ## Dependency Reviews
 1. Check existing patterns (Glob other dep files)
 2. Consider deployment: Binary packages need wheels for target Python version

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -227,6 +227,15 @@ def test_exhaustive_reporting_in_system_prompt():
     assert "balanced" not in REVIEW_SYSTEM_PROMPT
 
 
+def test_required_pr_description_section_rule_in_system_prompt():
+    """System prompt requires flagging a PR description missing a required review-brief section."""
+    from baloo.agent.prompts import REVIEW_SYSTEM_PROMPT
+
+    assert "Required PR-Description Sections" in REVIEW_SYSTEM_PROMPT
+    assert "## Review guidance for Baloo" in REVIEW_SYSTEM_PROMPT
+    assert "pr-review-brief" in REVIEW_SYSTEM_PROMPT
+
+
 def test_exhaustive_reporting_in_code_review_prompt():
     """Full code review prompt includes completeness check step."""
     pr_context = {


### PR DESCRIPTION
## Why

blueden's CONTRIBUTING.md requires every PR description to contain a `## Review guidance for Baloo` section, but PRs (e.g. #2147) open without it and Baloo stays silent. Baloo already reads CONTRIBUTING.md/AGENTS.md (`prompts.py:72`) and receives the PR Description (`prompts.py:386`) — but its guideline checks are diff/file:line-oriented and never inspect the description for a required section.

## What

Add a 'Required PR-Description Sections' rule to `REVIEW_SYSTEM_PROMPT`: if the repo requires a review-brief section and the PR Description lacks it, emit a HIGH Guidelines finding recommending the `pr-review-brief` skill. + a unit test asserting the rule is in the prompt.

**Severity note:** HIGH (not CRITICAL) — the repo's own taxonomy (`prompts.py:21`) reserves CRITICAL for confirmed exploitable vulns / catastrophic data loss and classes guideline violations as HIGH.

Closes DEN-3316

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change to review instructions plus a string-presence test; no auth, data, or execution path changes.
> 
> **Overview**
> Extends Baloo’s **review system prompt** so guideline checks cover the PR **Description**, not only diff/file:line issues.
> 
> Adds a **Required PR-Description Sections** rule: when `CONTRIBUTING.md` / `AGENTS.md` require a review-brief heading and the description lacks it (or it’s empty), the agent must emit a **HIGH** **Guidelines** finding—anchored at the first changed file, line 1—with blueden-specific guidance for `## Review guidance for Baloo` and the `pr-review-brief` skill. Repos without that requirement are explicitly excluded.
> 
> A new unit test in `tests/test_prompts.py` asserts those strings are present in `REVIEW_SYSTEM_PROMPT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a8476316184fed5704db8213d3a5c6cf6fcff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->