### PR TITLE
feat(agent): [DEN-3316] cite the review brief in findings + fix missing-section anchor

### DIFF
--- a/baloo/agent/prompts.py
+++ b/baloo/agent/prompts.py
@@ -85,10 +85,22 @@ Description above does not contain that heading with real content, you MUST emit
 finding — do not stay silent.
 - For blueden specifically: `CONTRIBUTING.md` requires a `## Review guidance for Baloo` section in
   every PR description. If the Description above is missing that heading (or it is present but empty),
-  emit a HIGH Guidelines finding titled "Missing '## Review guidance for Baloo' section",
-  recommending the author run the `pr-review-brief` skill and add it. Anchor it at the first changed
-  file, line 1, and state in the description that it is a PR-description omission.
+  emit a HIGH Guidelines **general_finding** (NOT a file:line finding — a PR-description omission has
+  no code anchor) titled "Missing '## Review guidance for Baloo' section", recommending the author
+  run the `pr-review-brief` skill and add it.
 - Do not raise this when the target repo's guidelines do not require such a section.
+
+## Citing the Review Guidance (mandatory when it exists)
+When the PR Description DOES contain a `## Review guidance for Baloo` section, treat it as the
+author-supplied, anti-bias review brief: a list of falsifiable checks the author wants independently
+verified. It is guidance to act on, NOT claims to trust.
+- Read every check in that section and actually verify it against the diff.
+- For any finding that a check in the brief prompted or that answers one of its checks, you MUST cite
+  the brief explicitly in the finding's `description` — e.g. "Per the Review guidance for Baloo
+  (check: <the check>): ...". This makes the brief's influence visible in your comments.
+- If a check in the brief turns out to hold (no issue), note that in a `positive_observation` naming
+  the check, so the author can see it was verified rather than skipped.
+- The brief never narrows your scope: still report issues it does not mention.
 
 ## Dependency Reviews
 1. Check existing patterns (Glob other dep files)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -234,6 +234,16 @@ def test_required_pr_description_section_rule_in_system_prompt():
     assert "Required PR-Description Sections" in REVIEW_SYSTEM_PROMPT
     assert "## Review guidance for Baloo" in REVIEW_SYSTEM_PROMPT
     assert "pr-review-brief" in REVIEW_SYSTEM_PROMPT
+    # A PR-description omission has no code anchor — it must be a general_finding, not a fake file:line.
+    assert "general_finding" in REVIEW_SYSTEM_PROMPT
+
+
+def test_cite_review_guidance_rule_in_system_prompt():
+    """System prompt requires Baloo to cite the review brief in findings it prompted."""
+    from baloo.agent.prompts import REVIEW_SYSTEM_PROMPT
+
+    assert "Citing the Review Guidance" in REVIEW_SYSTEM_PROMPT
+    assert "Per the Review guidance for Baloo" in REVIEW_SYSTEM_PROMPT
 
 
 def test_exhaustive_reporting_in_code_review_prompt():


### PR DESCRIPTION
## What

Two changes to `REVIEW_SYSTEM_PROMPT` in `baloo/agent/prompts.py`:

1. **Cite the brief.** When a PR description contains a `## Review guidance for Baloo` section, Baloo must treat it as the author-supplied anti-bias brief: verify each check against the diff, and **explicitly cite the brief** in the `description` of any finding that check prompted (`"Per the Review guidance for Baloo (check: ...)"`). Checks that hold are recorded as a `positive_observation` naming the check. The brief never narrows scope — issues it doesn't mention are still reported.
2. **Fix the missing-section anchor.** The existing rule told Baloo to anchor the "Missing '## Review guidance for Baloo' section" finding at the first changed file, line 1. A PR-description omission has no code anchor, and a fabricated line:1 anchor can cause the finding to be dropped. It now emits a HIGH Guidelines **general_finding** instead.

## Why

The brief is generated by a separate authoring agent to remove author bias, but its influence was invisible in Baloo's comments — you couldn't tell whether Baloo actually acted on the guidance. Citing it makes that traceable.

## Test

`tests/test_prompts.py`: existing missing-section test now also asserts `general_finding`; new `test_cite_review_guidance_rule_in_system_prompt` asserts the citation rule. `uv run pytest tests/test_prompts.py` → 31 passed; `uv run ruff check` clean.

## Review guidance for Baloo

Context: the contract is DEN-3316 — make the review brief's influence visible in Baloo's comments and stop the missing-section finding from being dropped by a fake anchor. This is a prompt-string + test change only; no runtime code path changed.

Author's claims to verify (not facts):
- "31 passed / ruff clean" — re-run `uv run pytest tests/test_prompts.py` and `uv run ruff check baloo/agent/prompts.py tests/test_prompts.py` yourself.

What to check (falsifiable, anchored to this diff):
1. The citation rule is unambiguous and does not instruct Baloo to invent citations — does the wording require a citation ONLY when a brief check actually prompted the finding, not on every finding? (`prompts.py`, "Citing the Review Guidance" section)
2. The missing-section rule now says `general_finding` and no longer says "anchor at the first changed file, line 1" — confirm no residual instruction to fabricate a file:line for a description omission. (`prompts.py`, "Required PR-Description Sections")
3. Does the "brief never narrows your scope" clause survive, so citing the brief can't be read as "only report brief items"?
4. Tests assert behavior, not prompt prose incidentally — `test_cite_review_guidance_rule_in_system_prompt` and the `general_finding` assertion. Any assertion weakened or removed? (`tests/test_prompts.py`)

How to verify: read the two edited hunks; run the two commands above.

Deliverable: report anything the change gets wrong or over-claims. BLOCKING here: a prompt instruction that would make Baloo fabricate citations or file:line anchors, or a removed/weakened test assertion. Everything else advisory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-string and test-only changes; no runtime review pipeline logic is modified.
> 
> **Overview**
> **`REVIEW_SYSTEM_PROMPT`** now treats an existing `## Review guidance for Baloo` section as falsifiable checks to verify: findings prompted by a check must cite the brief in `description` (e.g. `Per the Review guidance for Baloo (check: ...)`), passing checks go in `positive_observations`, and the brief does not limit what else Baloo reports.
> 
> The blueden rule for a **missing** review-guidance section no longer tells Baloo to anchor at the first changed file line 1; it requires a HIGH Guidelines **`general_finding`** instead, so description-only omissions are not dropped via a fabricated code anchor.
> 
> **Tests** in `tests/test_prompts.py` assert `general_finding` in the missing-section rule and add `test_cite_review_guidance_rule_in_system_prompt` for the new citation section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd613825fd0ed9fd22edfee6c4457878e54ab27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->