### PR TITLE
fix: retry webhook validation and always publish non-blocking reviews

### DIFF
--- a/baloo/github/auth.py
+++ b/baloo/github/auth.py
@@ -124,6 +124,8 @@ class GitHubAuth:
 
 async def verify_repo_belongs_to_installation(installation_id: int, repo_full_name: str) -> bool:
     """Return True if repo_full_name is accessible under the given installation token."""
+    import asyncio
+
     import httpx
 
     auth = GitHubAuth()
@@ -137,9 +139,25 @@ async def verify_repo_belongs_to_installation(installation_id: int, repo_full_na
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            f"https://api.github.com/repos/{repo_full_name}",
-            headers=headers,
-        )
-    return response.status_code == 200
+    # Transient TLS/network failures must not drop the webhook — GitHub never
+    # redelivers once a 5xx response has been sent, so a single network hiccup
+    # would permanently lose the event (e.g. a push that never gets reviewed).
+    last_exc: Exception | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"https://api.github.com/repos/{repo_full_name}",
+                    headers=headers,
+                )
+            return response.status_code == 200
+        except httpx.TransportError as exc:
+            last_exc = exc
+            if attempt < 3:
+                await asyncio.sleep(2 * attempt)
+    logger.warning(
+        "verify_repo_belongs_to_installation failed after 3 attempts for %s: %s",
+        repo_full_name,
+        last_exc,
+    )
+    return False

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -8,6 +8,7 @@ import re
 import time
 from collections import defaultdict
 from datetime import datetime, timezone
+from pathlib import Path
 
 from baloo.agent.config import get_agent_options
 from baloo.agent.pi_runtime import PIAgentBase
@@ -85,6 +86,10 @@ _REVIEW_SIDE_AGENT_METADATA_KEYS = (
     "thread_reverification",
     "sync_scope_decider",
 )
+
+# Empty working directory used for diff-only reviews so the agent's file tools
+# never wander through baloo's own source tree.
+_DIFF_ONLY_DIR = Path("/tmp/baloo-diff-only")
 
 
 def get_review_semaphore() -> asyncio.Semaphore:
@@ -1335,14 +1340,16 @@ async def process_pr_review(
                         repo_path,
                     )
                 else:
-                    # No checkout: the PI subprocess inherits baloo's own cwd
-                    # (/app in the container), so every PR-file read/grep/find
-                    # fails and the review is effectively diff-only. Surface why
-                    # — the master switch being off is otherwise totally silent.
+                    # No checkout: point the agent at an empty directory instead of
+                    # inheriting baloo's own cwd (/app in the container). Otherwise
+                    # the agent's read/grep/find tools would wander through baloo's
+                    # own source tree and can produce garbage output (e.g. no
+                    # structured JSON), failing the review.
+                    _DIFF_ONLY_DIR.mkdir(parents=True, exist_ok=True)
+                    agent.options.cwd = str(_DIFF_ONLY_DIR)
                     logger.warning(
                         "No PR checkout for %s#%s (repo_cache_enabled=%s) — agent "
-                        "file tools will run against baloo's own cwd, not the PR; "
-                        "reviewing diff-only",
+                        "file tools run in an empty dir; reviewing diff-only",
                         repo_full_name,
                         pr_number,
                         settings.repo_cache_enabled,
@@ -1723,6 +1730,33 @@ async def process_pr_review(
                     ),
                     diff=pr_context.diff,
                 )
+            # Comments-only review: non-blocking findings (MEDIUM/LOW) exist but
+            # auto-approve is off (approve=False, request_changes=False). Without
+            # this branch those findings would be saved to the DB but never posted
+            # to GitHub — the PR author never sees them.
+            elif not request_changes and has_new_feedback and posted_review_result is None:
+                logger.info("Posting comments-only review with non-blocking findings")
+                posted_result = await github_client.post_review(
+                    repo_full_name,
+                    pr_number,
+                    ReviewResult(
+                        summary=review_result.summary,
+                        comments=routed["review"],
+                        approve=False,
+                        request_changes=False,
+                    ),
+                    diff=pr_context.diff,
+                )
+                if isinstance(posted_result, PostedReviewResult):
+                    posted_review_result = posted_result
+                    if posted_result.dropped:
+                        logger.warning(
+                            "Dropped %d/%d non-blocking review finding(s) while posting %s#%s",
+                            len(posted_result.dropped),
+                            posted_result.attempted,
+                            repo_full_name,
+                            pr_number,
+                        )
             # Update progress comment with completion status
             review_duration = int(time.time() - review_start_time)
             if progress_comment_id:

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -769,6 +769,8 @@ class TestRepoProvisioningWiring:
     async def test_agent_cwd_unset_when_unavailable(self):
         from contextlib import asynccontextmanager
 
+        from baloo.review.orchestrator import _DIFF_ONLY_DIR
+
         gc = _make_github_client()
         agent = _make_agent()
         agent.options = MagicMock()
@@ -783,7 +785,9 @@ class TestRepoProvisioningWiring:
         with patch("baloo.review.orchestrator.provision_repo", fake_provision):
             await _run_review(gc, agent)
 
-        assert agent.options.cwd is None
+        # Diff-only fallback points the agent at an empty dir, never baloo's own
+        # source tree (/app), so its file tools can't wander into baloo code.
+        assert agent.options.cwd == str(_DIFF_ONLY_DIR)
 
 
 # ---------------------------------------------------------------------------
@@ -1160,3 +1164,48 @@ class TestGeneralFindingsPosting:
             else posted_blocking[0].kwargs.get("review_result")
         )
         assert result_arg.comments == []
+
+
+class TestCommentsOnlyReviewPosting:
+    """A review with only MEDIUM/LOW findings (auto-approve off) must still post."""
+
+    @pytest.mark.asyncio
+    async def test_medium_only_review_posts_comments_only_review(self):
+        comment = ReviewComment(
+            path="file.py",
+            line=10,
+            body="**Medium issue**\n\nThis code path leaks the resource handle",
+            severity=ReviewSeverity.MEDIUM,
+            category=FindingCategory.QUALITY,
+        )
+        # approve=False + request_changes=False = comments-only state (REVIEW_AUTO_APPROVE=false)
+        agent = _make_agent(comments=[comment], approve=False, request_changes=False)
+        gc = _make_github_client()
+
+        with patch("baloo.config.settings.settings.review_auto_approve", False):
+            await _run_review(gc, agent)
+
+        posted = [
+            call
+            for call in gc.post_review.call_args_list
+            if len(call.args) >= 3 or call.kwargs.get("review_result")
+        ]
+        assert posted, "Comments-only review must be posted when non-blocking findings exist"
+        result_arg = (
+            posted[0].args[2] if len(posted[0].args) >= 3 else posted[0].kwargs.get("review_result")
+        )
+        assert result_arg.request_changes is False
+        assert result_arg.approve is False
+
+    @pytest.mark.asyncio
+    async def test_no_findings_comments_only_state_posts_nothing(self):
+        # approve=False + request_changes=False with zero findings: nothing to post
+        agent = _make_agent(comments=[], approve=False, request_changes=False)
+        gc = _make_github_client()
+
+        with patch("baloo.config.settings.settings.review_auto_approve", False):
+            await _run_review(gc, agent)
+
+        assert gc.post_review.call_args_list == [], (
+            "No review should be posted when there are no findings to share"
+        )


### PR DESCRIPTION
## Summary

Two bugs that silently lose review results, plus a hardening fix for diff-only reviews. All three were observed in production against real PRs.

## Bugs fixed

### 1. Webhook validation has no retry → events permanently lost
`verify_repo_belongs_to_installation` (in `baloo/github/auth.py`) used a bare `httpx` GET with no retry. GitHub **never redelivers** a webhook once a 5xx response has been sent — it only retries connection failures/timeouts. So a single transient TLS/network hiccup (common on WSL/proxied hosts) permanently dropped the event: the push never triggered a review, and there was no way to recover it.

Fix: retry up to 3 times with 2s/4s backoff on `httpx.TransportError`.

### 2. Comments-only state never publishes → findings vanish
With `REVIEW_AUTO_APPROVE=false` and only MEDIUM/LOW findings, `DecisionEngine` returns `(approve=False, request_changes=False)` — a comments-only state. The publish block in `process_pr_review` only handled three cases:
- `request_changes` → request-changes review
- `request_changes and not has_new_feedback` → waiting on threads
- `not request_changes and approve` → approval review

None matched, so findings were **persisted to the DB but never posted to GitHub**. The PR author sees "Found N issues" in the progress comment but no actual findings anywhere.

Fix: add a fourth branch that posts a comments-only review (`COMMENT` event) when non-blocking findings exist.

### 3. Diff-only reviews run the agent in baloo's own cwd
When repo provisioning fails, the agent's cwd was left unset — the PI subprocess inherited baloo's own working directory (`/app` in the container). The agent's `read`/`grep`/`find` tools then wandered through baloo's source tree and could produce garbage output (e.g. no structured JSON), failing the review with `no_output`.

Fix: point the agent at an empty directory (`/tmp/baloo-diff-only`) for diff-only reviews.

## Tests

- New `TestCommentsOnlyReviewPosting` (review posts when non-blocking findings exist; nothing posted when there are no findings)
- Updated `test_agent_cwd_unset_when_unavailable` to assert the empty-dir cwd
- Full suite: 855 passed