### PR TITLE
Add DB-backed runtime settings overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Install the GitHub App on your repositories. Open a PR — Baloo will review it 
 ```text
 baloo/
 ├── agent/       # PI runtime, prompts, structured output parsing
-├── config/      # Environment-based settings
+├── config/      # Settings (env + DB runtime overlay)
 ├── db/          # PostgreSQL models + migrations (optional)
 ├── dashboard/   # Review history UI (optional)
 ├── documentation/ # Documentation drift analysis (optional)
@@ -152,7 +152,7 @@ baloo/
 
 ## Configuration
 
-All settings are environment variables. Key ones:
+Settings are configured via environment variables; allowlisted agent knobs can also be overridden at runtime when `DATABASE_ENABLED=true`. Key variables:
 
 | Variable                      | Default                   | Description                                                                              |
 | ----------------------------- | ------------------------- | ---------------------------------------------------------------------------------------- |

--- a/baloo/agent/client.py
+++ b/baloo/agent/client.py
@@ -164,13 +164,12 @@ class BalooAgent(PIAgentBase):
 
     async def _run_with_fallback(self, query: str, review_logger: Any = None):
         """Run query with automatic fallback to secondary model on failure."""
-        from baloo.config.settings import get_settings
+        from baloo.config.runtime_settings import resolve_setting
 
         try:
             return await self.run_query(query, review_logger=review_logger)
         except Exception as primary_err:
-            settings = get_settings()
-            fallback = settings.agent_fallback_model
+            fallback = resolve_setting("agent_fallback_model")
             if not fallback or "/" not in fallback:
                 raise  # No valid fallback configured
 

--- a/baloo/agent/config.py
+++ b/baloo/agent/config.py
@@ -4,6 +4,7 @@ import logging
 
 from baloo.agent.pi_runtime import PIAgentOptions
 from baloo.agent.prompts import AST_TOOLS_PROMPT_SECTION, REVIEW_SYSTEM_PROMPT
+from baloo.config.runtime_settings import resolve_setting
 from baloo.config.settings import settings
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
     Returns:
         PIAgentOptions configured for read-only code review
     """
-    level = thinking_level or settings.pi_thinking_level
+    level = thinking_level or resolve_setting("pi_thinking_level")
     system_prompt = _build_system_prompt()
 
     # 1. Short name lookup
@@ -86,8 +87,8 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
             max_turns=20,
         )
 
-    # 4. Default from settings — resolve short names first
-    default_model = settings.agent_model
+    # 4. Default from settings (env + DB overlay) — resolve short names first
+    default_model = resolve_setting("agent_model")
     if default_model in MODEL_REGISTRY:
         provider, model_id, max_turns = MODEL_REGISTRY[default_model]
         return PIAgentOptions(
@@ -100,7 +101,7 @@ def get_agent_options(model: str = None, thinking_level: str | None = None) -> P
 
     return PIAgentOptions(
         model=default_model,
-        provider=settings.agent_provider,
+        provider=resolve_setting("agent_provider"),
         system_prompt=system_prompt,
         thinking_level=level,
         max_turns=20,

--- a/baloo/agent/provider_smoke.py
+++ b/baloo/agent/provider_smoke.py
@@ -1,0 +1,122 @@
+"""Smoke-test the effective LLM provider/model via a one-shot PI call.
+
+Used by the dashboard so an admin can confirm credentials and provider wiring
+after changing runtime settings, without running a full PR review.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from baloo.agent.config import get_agent_options
+from baloo.agent.pi_runtime import PIAgentBase
+
+logger = logging.getLogger(__name__)
+
+SMOKE_TIMEOUT_SECONDS = 30.0
+
+# Keys whose save/clear should auto-run a primary-provider smoke check.
+SMOKE_TRIGGER_KEYS = frozenset({"agent_provider", "agent_model"})
+
+_SMOKE_SYSTEM_PROMPT = (
+    "You are a connectivity probe for Baloo. " "Respond with only the requested JSON object."
+)
+_SMOKE_PROMPT = 'Reply with ONLY this JSON object and nothing else: {"status":"ok"}'
+
+
+@dataclass(frozen=True)
+class SmokeResult:
+    """Outcome of a provider connectivity smoke test."""
+
+    ok: bool
+    provider: str
+    model: str
+    duration_seconds: float
+    message: str
+    error: str | None = None
+
+    @property
+    def model_ref(self) -> str:
+        return f"{self.provider}/{self.model}"
+
+
+async def smoke_test_provider(
+    *,
+    model: str | None = None,
+    timeout_seconds: float = SMOKE_TIMEOUT_SECONDS,
+) -> SmokeResult:
+    """Spawn PI with the effective (or overridden) provider/model and probe it.
+
+    Uses ``--no-tools``, thinking off, and a 1-turn JSON ping so the check
+    validates auth + endpoint wiring without touching a repo worktree.
+    """
+    options = get_agent_options(model)
+    options.system_prompt = _SMOKE_SYSTEM_PROMPT
+    options.thinking_level = "off"
+    options.max_turns = 1
+    options.no_tools = True
+    options.name = "ProviderSmoke"
+    # Never sandbox a connectivity probe — no cwd / no repo isolation needed.
+    options.cwd = None
+
+    provider = options.provider
+    model_id = options.model
+    start = time.monotonic()
+
+    agent = PIAgentBase(options)
+    try:
+        _structured, metadata = await asyncio.wait_for(
+            agent.run_query(_SMOKE_PROMPT),
+            timeout=timeout_seconds,
+        )
+    except TimeoutError:
+        elapsed = time.monotonic() - start
+        msg = f"Smoke test timed out after {timeout_seconds:.0f}s for " f"{provider}/{model_id}"
+        logger.warning(msg)
+        return SmokeResult(
+            ok=False,
+            provider=provider,
+            model=model_id,
+            duration_seconds=elapsed,
+            message=msg,
+            error="timeout",
+        )
+    except Exception as exc:
+        elapsed = time.monotonic() - start
+        err = str(exc)[:500]
+        msg = f"Smoke test failed for {provider}/{model_id}: {err}"
+        logger.warning(msg)
+        return SmokeResult(
+            ok=False,
+            provider=provider,
+            model=model_id,
+            duration_seconds=elapsed,
+            message=msg,
+            error=err,
+        )
+
+    elapsed = time.monotonic() - start
+    if metadata.get("is_error"):
+        err = "PI agent reported an error (check server logs for details)"
+        msg = f"Smoke test failed for {provider}/{model_id}: {err}"
+        return SmokeResult(
+            ok=False,
+            provider=provider,
+            model=model_id,
+            duration_seconds=elapsed,
+            message=msg,
+            error=err,
+        )
+
+    msg = f"Smoke test passed for {provider}/{model_id} " f"in {elapsed:.1f}s"
+    logger.info(msg)
+    return SmokeResult(
+        ok=True,
+        provider=provider,
+        model=model_id,
+        duration_seconds=elapsed,
+        message=msg,
+    )

--- a/baloo/agent/thread_agent.py
+++ b/baloo/agent/thread_agent.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from baloo.agent.config import get_agent_options
 from baloo.agent.pi_runtime import PIAgentBase
 from baloo.agent.thread_prompts import THREAD_AGENT_SYSTEM_PROMPT, build_thread_prompt
-from baloo.config.settings import get_settings
 from baloo.github.models import DiscussionComment
 
 logger = logging.getLogger(__name__)
@@ -42,8 +41,9 @@ class ThreadAgent:
     """
 
     def __init__(self, model: str | None = None):
-        settings = get_settings()
-        self.model = model or settings.thread_agent_model
+        from baloo.config.runtime_settings import resolve_setting
+
+        self.model = model or resolve_setting("thread_agent_model")
 
     async def classify(
         self,

--- a/baloo/config/runtime_settings.py
+++ b/baloo/config/runtime_settings.py
@@ -1,0 +1,317 @@
+"""DB-backed runtime settings overlay on top of env/Pydantic Settings.
+
+Env-backed ``Settings`` remains the immutable bootstrap layer. Allowlisted keys
+may be overridden in the ``runtime_settings`` table and are served from an
+in-memory cache (30s TTL for multi-replica convergence). Secrets and infra
+settings are never overridable.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, get_args, get_origin
+
+from baloo.config.settings import Settings, get_settings
+
+logger = logging.getLogger(__name__)
+
+MUTABLE_KEYS = frozenset(
+    {
+        "agent_provider",
+        "agent_model",
+        "agent_fallback_model",
+        "pi_thinking_level",
+        "fp_verification_model",
+        "thread_agent_model",
+        "documentation_drift_model",
+    }
+)
+
+CACHE_TTL_SECONDS = 30
+
+# Process-local overlay: key -> raw string value from DB.
+_cache: dict[str, str] | None = None
+_cache_loaded_at: float | None = None
+
+
+class RuntimeSettingsError(ValueError):
+    """Raised when a runtime override is invalid or not allowed."""
+
+
+def reset_runtime_settings_cache() -> None:
+    """Clear the overlay cache (for tests)."""
+    global _cache, _cache_loaded_at
+    _cache = None
+    _cache_loaded_at = None
+
+
+def _cache_is_fresh() -> bool:
+    if _cache is None or _cache_loaded_at is None:
+        return False
+    return (time.monotonic() - _cache_loaded_at) < CACHE_TTL_SECONDS
+
+
+def _field_annotation(key: str) -> Any:
+    field = Settings.model_fields.get(key)
+    if field is None:
+        raise RuntimeSettingsError(f"Unknown setting: {key}")
+    return field.annotation
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    origin = get_origin(annotation)
+    if origin is None:
+        return annotation
+    args = [a for a in get_args(annotation) if a is not type(None)]
+    if len(args) == 1:
+        return args[0]
+    return annotation
+
+
+def coerce_setting_value(key: str, raw: str) -> Any:
+    """Coerce a stored/submitted string to the Settings field type."""
+    if key not in Settings.model_fields:
+        raise RuntimeSettingsError(f"Unknown setting: {key}")
+
+    annotation = _unwrap_optional(_field_annotation(key))
+    text = raw if isinstance(raw, str) else str(raw)
+
+    if annotation is bool or annotation is bool | None:
+        lowered = text.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        raise RuntimeSettingsError(f"Invalid boolean for {key}: {raw!r}")
+
+    if annotation is int:
+        try:
+            return int(text.strip())
+        except ValueError as exc:
+            raise RuntimeSettingsError(f"Invalid integer for {key}: {raw!r}") from exc
+
+    if annotation is float:
+        try:
+            return float(text.strip())
+        except ValueError as exc:
+            raise RuntimeSettingsError(f"Invalid float for {key}: {raw!r}") from exc
+
+    # Default: string
+    return text
+
+
+def validate_override(key: str, raw: str) -> str:
+    """Validate an override and return the canonical string to store."""
+    if key not in MUTABLE_KEYS:
+        raise RuntimeSettingsError(f"Setting is not mutable at runtime: {key}")
+
+    coerced = coerce_setting_value(key, raw)
+
+    if key in {
+        "agent_provider",
+        "agent_model",
+        "fp_verification_model",
+        "thread_agent_model",
+        "documentation_drift_model",
+        "pi_thinking_level",
+    }:
+        if not isinstance(coerced, str) or not coerced.strip():
+            raise RuntimeSettingsError(f"{key} must be a non-empty string")
+        return coerced.strip()
+
+    if key == "agent_fallback_model":
+        # Empty string disables fallback (matches Settings semantics).
+        if not isinstance(coerced, str):
+            raise RuntimeSettingsError(f"{key} must be a string")
+        return coerced.strip()
+
+    return str(coerced)
+
+
+def resolve_setting(key: str) -> Any:
+    """Return DB override if present and allowlisted; otherwise env Settings value.
+
+    Sync read of the process-local cache only. Call ``ensure_fresh_cache()`` from
+    async paths (startup, dashboard, review start) so multi-replica TTL refresh
+    stays current.
+    """
+    settings = get_settings()
+    env_value = getattr(settings, key)
+
+    if key not in MUTABLE_KEYS:
+        return env_value
+
+    if not settings.database_enabled:
+        return env_value
+
+    if _cache is None:
+        return env_value
+
+    if key in _cache:
+        try:
+            return coerce_setting_value(key, _cache[key])
+        except RuntimeSettingsError:
+            logger.warning("Invalid cached override for %s; falling back to env", key)
+            return env_value
+
+    return env_value
+
+
+def setting_source(key: str) -> str:
+    """Return ``db`` if an overlay is active for ``key``, else ``env``."""
+    settings = get_settings()
+    if (
+        key in MUTABLE_KEYS
+        and settings.database_enabled
+        and _cache is not None
+        and key in _cache
+    ):
+        return "db"
+    return "env"
+
+
+def get_override_map() -> dict[str, str]:
+    """Return a copy of the current overlay cache (empty if unloaded)."""
+    return dict(_cache or {})
+
+
+async def refresh_cache() -> None:
+    """Load allowlisted overrides for this installation into the process cache."""
+    global _cache, _cache_loaded_at
+
+    settings = get_settings()
+    if not settings.database_enabled or not settings.database_url:
+        _cache = {}
+        _cache_loaded_at = time.monotonic()
+        return
+
+    from sqlalchemy import select
+
+    from baloo.db.engine import get_session_factory
+    from baloo.db.models import RuntimeSetting
+
+    installation_id = settings.installation_id
+    try:
+        factory = get_session_factory(settings.database_url)
+        async with factory() as session:
+            stmt = select(RuntimeSetting)
+            if installation_id:
+                stmt = stmt.where(RuntimeSetting.installation_id == installation_id)
+            else:
+                stmt = stmt.where(RuntimeSetting.installation_id.is_(None))
+            rows = (await session.execute(stmt)).scalars().all()
+    except Exception as exc:
+        # Table may not exist yet mid-migration, or DB briefly unavailable.
+        logger.warning("Failed to load runtime settings cache: %s", exc)
+        if _cache is None:
+            _cache = {}
+            _cache_loaded_at = time.monotonic()
+        return
+
+    loaded: dict[str, str] = {}
+    for row in rows:
+        if row.key in MUTABLE_KEYS:
+            loaded[row.key] = row.value
+
+    _cache = loaded
+    _cache_loaded_at = time.monotonic()
+    logger.info("Loaded %d runtime setting override(s)", len(loaded))
+
+
+async def ensure_fresh_cache() -> None:
+    """Refresh the overlay cache when missing or past TTL."""
+    if not _cache_is_fresh():
+        await refresh_cache()
+
+
+def _tenant_filter(stmt, model, installation_id: str | None):
+    if installation_id:
+        return stmt.where(model.installation_id == installation_id)
+    return stmt.where(model.installation_id.is_(None))
+
+
+async def set_override(key: str, value: str, *, updated_by: str | None = None) -> str:
+    """Upsert a runtime override. Returns the stored string value."""
+    global _cache, _cache_loaded_at
+
+    stored = validate_override(key, value)
+    settings = get_settings()
+    if not settings.database_enabled or not settings.database_url:
+        raise RuntimeSettingsError("Database must be enabled to set runtime overrides")
+
+    from datetime import datetime, timezone
+
+    from sqlalchemy import select
+
+    from baloo.db.engine import get_session_factory
+    from baloo.db.models import RuntimeSetting
+
+    installation_id = settings.installation_id
+    now = datetime.now(timezone.utc)
+    factory = get_session_factory(settings.database_url)
+
+    async with factory() as session:
+        async with session.begin():
+            stmt = select(RuntimeSetting).where(RuntimeSetting.key == key)
+            stmt = _tenant_filter(stmt, RuntimeSetting, installation_id)
+            existing = (await session.execute(stmt)).scalar_one_or_none()
+            if existing:
+                existing.value = stored
+                existing.updated_at = now
+                existing.updated_by = updated_by
+            else:
+                session.add(
+                    RuntimeSetting(
+                        key=key,
+                        value=stored,
+                        installation_id=installation_id,
+                        updated_at=now,
+                        updated_by=updated_by,
+                    )
+                )
+
+    if _cache is None:
+        _cache = {}
+    _cache[key] = stored
+    _cache_loaded_at = time.monotonic()
+    logger.info("Runtime override set: %s=%r (by %s)", key, stored, updated_by or "unknown")
+    return stored
+
+
+async def clear_override(key: str) -> bool:
+    """Delete a runtime override. Returns True if a row was removed."""
+    global _cache, _cache_loaded_at
+
+    if key not in MUTABLE_KEYS:
+        raise RuntimeSettingsError(f"Setting is not mutable at runtime: {key}")
+
+    settings = get_settings()
+    if not settings.database_enabled or not settings.database_url:
+        raise RuntimeSettingsError("Database must be enabled to clear runtime overrides")
+
+    from sqlalchemy import delete
+
+    from baloo.db.engine import get_session_factory
+    from baloo.db.models import RuntimeSetting
+
+    installation_id = settings.installation_id
+    factory = get_session_factory(settings.database_url)
+
+    async with factory() as session:
+        async with session.begin():
+            stmt = delete(RuntimeSetting).where(RuntimeSetting.key == key)
+            if installation_id:
+                stmt = stmt.where(RuntimeSetting.installation_id == installation_id)
+            else:
+                stmt = stmt.where(RuntimeSetting.installation_id.is_(None))
+            result = await session.execute(stmt)
+            removed = (result.rowcount or 0) > 0
+
+    if _cache is not None and key in _cache:
+        del _cache[key]
+        _cache_loaded_at = time.monotonic()
+
+    if removed:
+        logger.info("Runtime override cleared: %s", key)
+    return removed

--- a/baloo/config/runtime_settings.py
+++ b/baloo/config/runtime_settings.py
@@ -238,6 +238,7 @@ async def set_override(key: str, value: str, *, updated_by: str | None = None) -
     from datetime import datetime, timezone
 
     from sqlalchemy import select
+    from sqlalchemy.exc import IntegrityError
 
     from baloo.db.engine import get_session_factory
     from baloo.db.models import RuntimeSetting
@@ -246,16 +247,20 @@ async def set_override(key: str, value: str, *, updated_by: str | None = None) -
     now = datetime.now(timezone.utc)
     factory = get_session_factory(settings.database_url)
 
-    async with factory() as session:
-        async with session.begin():
-            stmt = select(RuntimeSetting).where(RuntimeSetting.key == key)
-            stmt = _tenant_filter(stmt, RuntimeSetting, installation_id)
-            existing = (await session.execute(stmt)).scalar_one_or_none()
-            if existing:
-                existing.value = stored
-                existing.updated_at = now
-                existing.updated_by = updated_by
-            else:
+    async def _write(insert_allowed: bool) -> bool:
+        """Update in place, or insert when absent. Returns True when written."""
+        async with factory() as session:
+            async with session.begin():
+                stmt = select(RuntimeSetting).where(RuntimeSetting.key == key)
+                stmt = _tenant_filter(stmt, RuntimeSetting, installation_id)
+                existing = (await session.execute(stmt)).scalar_one_or_none()
+                if existing:
+                    existing.value = stored
+                    existing.updated_at = now
+                    existing.updated_by = updated_by
+                    return True
+                if not insert_allowed:
+                    return False
                 session.add(
                     RuntimeSetting(
                         key=key,
@@ -265,6 +270,16 @@ async def set_override(key: str, value: str, *, updated_by: str | None = None) -
                         updated_by=updated_by,
                     )
                 )
+                return True
+
+    try:
+        await _write(insert_allowed=True)
+    except IntegrityError:
+        # A concurrent writer inserted the same (key, installation_id) between
+        # our SELECT and INSERT; the partial unique index rejected the race
+        # loser. Re-read and update the row the winner created.
+        if not await _write(insert_allowed=False):
+            raise
 
     if _cache is None:
         _cache = {}

--- a/baloo/config/runtime_settings.py
+++ b/baloo/config/runtime_settings.py
@@ -161,12 +161,7 @@ def resolve_setting(key: str) -> Any:
 def setting_source(key: str) -> str:
     """Return ``db`` if an overlay is active for ``key``, else ``env``."""
     settings = get_settings()
-    if (
-        key in MUTABLE_KEYS
-        and settings.database_enabled
-        and _cache is not None
-        and key in _cache
-    ):
+    if key in MUTABLE_KEYS and settings.database_enabled and _cache is not None and key in _cache:
         return "db"
     return "env"
 

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -466,9 +466,11 @@ async def update_settings(
         if action == "clear":
             await clear_override(key)
             msg = f"Cleared override for {key.upper()}; using env default."
-        else:
+        elif action == "save":
             await set_override(key, value, updated_by=username)
             msg = f"Updated {key.upper()}."
+        else:
+            return _settings_redirect(error="Unknown action.")
     except RuntimeSettingsError as exc:
         return _settings_redirect(error=str(exc))
 

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import secrets
+import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -29,6 +31,12 @@ router = APIRouter(
 )
 
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+# One-shot flash payloads for PRG redirects. Location only carries a server-
+# generated token so user-controlled form values never flow into the URL
+# (CodeQL: URL redirection from remote source).
+_FLASH_TTL_SECONDS = 300
+_flash_store: dict[str, tuple[float, dict[str, Any]]] = {}
 
 SENSITIVE_SETTINGS = {
     "anthropic_api_key",
@@ -383,10 +391,7 @@ async def outcomes(
 async def settings_page(request: Request):
     await ensure_fresh_cache()
     settings = get_settings()
-    message = request.query_params.get("message")
-    error = request.query_params.get("error")
-    smoke_ok = request.query_params.get("smoke_ok")
-    smoke_message = request.query_params.get("smoke_message")
+    flash = _pop_flash(request.query_params.get("flash"))
     return templates.TemplateResponse(
         request=request,
         name="settings.html",
@@ -394,33 +399,47 @@ async def settings_page(request: Request):
             "settings_rows": _settings_rows(),
             "models_in_use": _models_in_use(),
             "database_enabled": settings.database_enabled and bool(settings.database_url),
-            "message": message,
-            "error": error,
-            "smoke_ok": smoke_ok,
-            "smoke_message": smoke_message,
+            "message": flash.get("message") if flash else None,
+            "error": flash.get("error") if flash else None,
+            "smoke_ok": flash.get("smoke_ok") if flash else None,
+            "smoke_message": flash.get("smoke_message") if flash else None,
         },
     )
 
 
-def _settings_redirect(
-    *,
-    message: str | None = None,
-    error: str | None = None,
-    smoke_ok: bool | None = None,
-    smoke_message: str | None = None,
-) -> RedirectResponse:
-    params: list[tuple[str, str]] = []
-    if message:
-        params.append(("message", message))
-    if error:
-        params.append(("error", error))
-    if smoke_message:
-        params.append(("smoke_message", smoke_message))
-        if smoke_ok is not None:
-            params.append(("smoke_ok", "1" if smoke_ok else "0"))
-    query = urlencode(params)
+def _purge_expired_flash() -> None:
+    now = time.monotonic()
+    expired = [token for token, (expires, _) in _flash_store.items() if expires <= now]
+    for token in expired:
+        _flash_store.pop(token, None)
+
+
+def _put_flash(payload: dict[str, Any]) -> str:
+    """Store a one-shot flash payload; return an opaque token for the redirect."""
+    _purge_expired_flash()
+    token = secrets.token_urlsafe(16)
+    _flash_store[token] = (time.monotonic() + _FLASH_TTL_SECONDS, payload)
+    return token
+
+
+def _pop_flash(token: str | None) -> dict[str, Any] | None:
+    if not token:
+        return None
+    _purge_expired_flash()
+    entry = _flash_store.pop(token, None)
+    if entry is None:
+        return None
+    return entry[1]
+
+
+def _settings_redirect(**flash: Any) -> RedirectResponse:
+    """Redirect to settings with a server-generated flash token only."""
+    payload = {key: value for key, value in flash.items() if value is not None}
+    if not payload:
+        return RedirectResponse(url="/dashboard/settings", status_code=303)
+    token = _put_flash(payload)
     return RedirectResponse(
-        url=f"/dashboard/settings?{query}" if query else "/dashboard/settings",
+        url=f"/dashboard/settings?flash={token}",
         status_code=303,
     )
 
@@ -439,7 +458,7 @@ async def update_settings(
         result = await smoke_test_provider()
         return _settings_redirect(
             message="Ran provider smoke test.",
-            smoke_ok=result.ok,
+            smoke_ok="1" if result.ok else "0",
             smoke_message=result.message,
         )
 
@@ -453,15 +472,10 @@ async def update_settings(
     except RuntimeSettingsError as exc:
         return _settings_redirect(error=str(exc))
 
-    smoke_ok = None
-    smoke_message = None
+    flash: dict[str, Any] = {"message": msg}
     if key in SMOKE_TRIGGER_KEYS:
         result = await smoke_test_provider()
-        smoke_ok = result.ok
-        smoke_message = result.message
+        flash["smoke_ok"] = "1" if result.ok else "0"
+        flash["smoke_message"] = result.message
 
-    return _settings_redirect(
-        message=msg,
-        smoke_ok=smoke_ok,
-        smoke_message=smoke_message,
-    )
+    return _settings_redirect(**flash)

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -215,6 +215,82 @@ def _settings_rows() -> list[dict[str, Any]]:
     return rows
 
 
+def _resolve_model_ref(configured: str) -> str:
+    """Resolve a short name or provider/model string to ``provider/model_id``."""
+    from baloo.agent.config import get_agent_options
+
+    if not configured:
+        return "(disabled)"
+    options = get_agent_options(configured)
+    return f"{options.provider}/{options.model}"
+
+
+def _models_in_use() -> list[dict[str, str]]:
+    """Summarize each agent role and the model it will actually call."""
+    from baloo.agent.config import get_agent_options
+
+    primary = get_agent_options()
+    primary_ref = f"{primary.provider}/{primary.model}"
+    primary_configured = str(resolve_setting("agent_model"))
+
+    fallback_configured = str(resolve_setting("agent_fallback_model") or "")
+    fp_configured = str(resolve_setting("fp_verification_model"))
+    thread_configured = str(resolve_setting("thread_agent_model"))
+    docs_configured = str(resolve_setting("documentation_drift_model"))
+
+    return [
+        {
+            "role": "Primary review",
+            "setting": "AGENT_MODEL",
+            "configured": primary_configured,
+            "resolved": primary_ref,
+            "source": setting_source("agent_model"),
+        },
+        {
+            "role": "Fallback",
+            "setting": "AGENT_FALLBACK_MODEL",
+            "configured": fallback_configured or "(empty)",
+            "resolved": _resolve_model_ref(fallback_configured),
+            "source": setting_source("agent_fallback_model"),
+        },
+        {
+            "role": "FP verification",
+            "setting": "FP_VERIFICATION_MODEL",
+            "configured": fp_configured,
+            "resolved": _resolve_model_ref(fp_configured),
+            "source": setting_source("fp_verification_model"),
+        },
+        {
+            "role": "Thread agent",
+            "setting": "THREAD_AGENT_MODEL",
+            "configured": thread_configured,
+            "resolved": _resolve_model_ref(thread_configured),
+            "source": setting_source("thread_agent_model"),
+        },
+        {
+            "role": "Fidelity analysis",
+            "setting": "AGENT_MODEL",
+            "configured": primary_configured,
+            "resolved": primary_ref,
+            "source": setting_source("agent_model"),
+        },
+        {
+            "role": "Documentation drift",
+            "setting": "DOCUMENTATION_DRIFT_MODEL",
+            "configured": docs_configured,
+            "resolved": _resolve_model_ref(docs_configured),
+            "source": setting_source("documentation_drift_model"),
+        },
+        {
+            "role": "Sync scope decider",
+            "setting": "AGENT_MODEL",
+            "configured": primary_configured,
+            "resolved": primary_ref,
+            "source": setting_source("agent_model"),
+        },
+    ]
+
+
 @router.get("/", response_class=HTMLResponse)
 async def overview(request: Request):
     stats = await DashboardService.get_overview_stats()
@@ -316,6 +392,7 @@ async def settings_page(request: Request):
         name="settings.html",
         context={
             "settings_rows": _settings_rows(),
+            "models_in_use": _models_in_use(),
             "database_enabled": settings.database_enabled and bool(settings.database_url),
             "message": message,
             "error": error,

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, quote_plus, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -309,6 +309,8 @@ async def settings_page(request: Request):
     settings = get_settings()
     message = request.query_params.get("message")
     error = request.query_params.get("error")
+    smoke_ok = request.query_params.get("smoke_ok")
+    smoke_message = request.query_params.get("smoke_message")
     return templates.TemplateResponse(
         request=request,
         name="settings.html",
@@ -317,7 +319,32 @@ async def settings_page(request: Request):
             "database_enabled": settings.database_enabled and bool(settings.database_url),
             "message": message,
             "error": error,
+            "smoke_ok": smoke_ok,
+            "smoke_message": smoke_message,
         },
+    )
+
+
+def _settings_redirect(
+    *,
+    message: str | None = None,
+    error: str | None = None,
+    smoke_ok: bool | None = None,
+    smoke_message: str | None = None,
+) -> RedirectResponse:
+    params: list[tuple[str, str]] = []
+    if message:
+        params.append(("message", message))
+    if error:
+        params.append(("error", error))
+    if smoke_message:
+        params.append(("smoke_message", smoke_message))
+        if smoke_ok is not None:
+            params.append(("smoke_ok", "1" if smoke_ok else "0"))
+    query = urlencode(params)
+    return RedirectResponse(
+        url=f"/dashboard/settings?{query}" if query else "/dashboard/settings",
+        status_code=303,
     )
 
 
@@ -328,7 +355,17 @@ async def update_settings(
     action: str = Form("save"),
     username: str = Depends(verify_credentials),
 ):
-    """Set or clear an allowlisted runtime override."""
+    """Set or clear an allowlisted runtime override, or run a provider smoke test."""
+    from baloo.agent.provider_smoke import SMOKE_TRIGGER_KEYS, smoke_test_provider
+
+    if action == "test_connection":
+        result = await smoke_test_provider()
+        return _settings_redirect(
+            message="Ran provider smoke test.",
+            smoke_ok=result.ok,
+            smoke_message=result.message,
+        )
+
     try:
         if action == "clear":
             await clear_override(key)
@@ -336,12 +373,18 @@ async def update_settings(
         else:
             await set_override(key, value, updated_by=username)
             msg = f"Updated {key.upper()}."
-        return RedirectResponse(
-            url=f"/dashboard/settings?message={quote_plus(msg)}",
-            status_code=303,
-        )
     except RuntimeSettingsError as exc:
-        return RedirectResponse(
-            url=f"/dashboard/settings?error={quote_plus(str(exc))}",
-            status_code=303,
-        )
+        return _settings_redirect(error=str(exc))
+
+    smoke_ok = None
+    smoke_message = None
+    if key in SMOKE_TRIGGER_KEYS:
+        result = await smoke_test_provider()
+        smoke_ok = result.ok
+        smoke_message = result.message
+
+    return _settings_redirect(
+        message=msg,
+        smoke_ok=smoke_ok,
+        smoke_message=smoke_message,
+    )

--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, quote_plus, urlencode, urlsplit, urlunsplit
 
-from fastapi import APIRouter, Depends, Query, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
+from baloo.config.runtime_settings import (
+    MUTABLE_KEYS,
+    RuntimeSettingsError,
+    clear_override,
+    ensure_fresh_cache,
+    resolve_setting,
+    set_override,
+    setting_source,
+)
 from baloo.config.settings import Settings, get_settings
 from baloo.dashboard.auth import verify_credentials
 from baloo.dashboard.queries import DashboardService
@@ -177,20 +186,30 @@ def _setting_category(name: str) -> str:
     return "Other"
 
 
-def _settings_rows() -> list[dict[str, str]]:
+def _settings_rows() -> list[dict[str, Any]]:
     settings = get_settings()
     rows = []
     for name, field in Settings.model_fields.items():
-        value = getattr(settings, name)
+        env_value = getattr(settings, name)
+        mutable = name in MUTABLE_KEYS
+        if mutable:
+            effective = resolve_setting(name)
+            source = setting_source(name)
+        else:
+            effective = env_value
+            source = "env"
         default = field.default
         rows.append(
             {
                 "category": _setting_category(name),
                 "env_var": name.upper(),
                 "name": name,
-                "value": _format_setting_value(name, value),
+                "value": _format_setting_value(name, effective),
+                "raw_value": "" if effective is None else str(effective),
                 "default": _format_setting_value(name, default),
                 "description": field.description or "",
+                "mutable": mutable,
+                "source": source,
             }
         )
     return rows
@@ -286,8 +305,43 @@ async def outcomes(
 
 @router.get("/settings", response_class=HTMLResponse)
 async def settings_page(request: Request):
+    await ensure_fresh_cache()
+    settings = get_settings()
+    message = request.query_params.get("message")
+    error = request.query_params.get("error")
     return templates.TemplateResponse(
         request=request,
         name="settings.html",
-        context={"settings_rows": _settings_rows()},
+        context={
+            "settings_rows": _settings_rows(),
+            "database_enabled": settings.database_enabled and bool(settings.database_url),
+            "message": message,
+            "error": error,
+        },
     )
+
+
+@router.post("/settings")
+async def update_settings(
+    key: str = Form(...),
+    value: str = Form(""),
+    action: str = Form("save"),
+    username: str = Depends(verify_credentials),
+):
+    """Set or clear an allowlisted runtime override."""
+    try:
+        if action == "clear":
+            await clear_override(key)
+            msg = f"Cleared override for {key.upper()}; using env default."
+        else:
+            await set_override(key, value, updated_by=username)
+            msg = f"Updated {key.upper()}."
+        return RedirectResponse(
+            url=f"/dashboard/settings?message={quote_plus(msg)}",
+            status_code=303,
+        )
+    except RuntimeSettingsError as exc:
+        return RedirectResponse(
+            url=f"/dashboard/settings?error={quote_plus(str(exc))}",
+            status_code=303,
+        )

--- a/baloo/dashboard/templates/settings.html
+++ b/baloo/dashboard/templates/settings.html
@@ -7,9 +7,19 @@
 <div class="flex items-start justify-between mb-6">
   <div>
     <h1 class="text-2xl font-bold text-gray-900">Settings</h1>
-    <p class="mt-1 text-sm text-gray-500">Effective runtime configuration loaded for this Baloo instance.</p>
+    <p class="mt-1 text-sm text-gray-500">Effective runtime configuration for this Baloo instance. Allowlisted agent knobs can be overridden in the database without redeploying.</p>
   </div>
 </div>
+
+{% if message %}
+<div class="mb-4 rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">{{ message }}</div>
+{% endif %}
+{% if error %}
+<div class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">{{ error }}</div>
+{% endif %}
+{% if not database_enabled %}
+<div class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">Runtime overrides require the database. Set <code class="font-mono">DATABASE_ENABLED=true</code> and <code class="font-mono">DATABASE_URL</code>.</div>
+{% endif %}
 
 {% set ns = namespace(category="") %}
 {% for row in settings_rows %}
@@ -31,6 +41,7 @@
           <tr>
             <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Variable</th>
             <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Value</th>
+            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Source</th>
             <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Default</th>
             <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Description</th>
           </tr>
@@ -39,7 +50,36 @@
   {% endif %}
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-3 text-sm font-mono text-gray-900 whitespace-nowrap">{{ row.env_var }}</td>
-            <td class="px-4 py-3 text-sm font-mono text-gray-700 max-w-md break-all">{{ row.value }}</td>
+            <td class="px-4 py-3 text-sm text-gray-700 max-w-md">
+              {% if row.mutable and database_enabled %}
+              <form method="post" action="/dashboard/settings" class="flex flex-wrap items-center gap-2">
+                <input type="hidden" name="key" value="{{ row.name }}" />
+                <input
+                  type="text"
+                  name="value"
+                  value="{{ row.raw_value }}"
+                  class="font-mono text-sm border border-gray-300 rounded px-2 py-1 min-w-48 max-w-md"
+                />
+                <button type="submit" name="action" value="save" class="text-xs bg-gray-900 text-white px-2 py-1 rounded hover:bg-gray-700">Save</button>
+                {% if row.source == "db" %}
+                <button type="submit" name="action" value="clear" class="text-xs border border-gray-300 text-gray-700 px-2 py-1 rounded hover:bg-gray-100">Revert to env</button>
+                {% endif %}
+              </form>
+              {% else %}
+              <span class="font-mono break-all">{{ row.value }}</span>
+              {% endif %}
+            </td>
+            <td class="px-4 py-3 text-sm whitespace-nowrap">
+              {% if row.mutable %}
+                {% if row.source == "db" %}
+                <span class="inline-flex items-center rounded bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">db</span>
+                {% else %}
+                <span class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">env</span>
+                {% endif %}
+              {% else %}
+              <span class="text-gray-400 text-xs">—</span>
+              {% endif %}
+            </td>
             <td class="px-4 py-3 text-sm font-mono text-gray-500 max-w-sm break-all">{{ row.default }}</td>
             <td class="px-4 py-3 text-sm text-gray-600 min-w-64">{{ row.description }}</td>
           </tr>

--- a/baloo/dashboard/templates/settings.html
+++ b/baloo/dashboard/templates/settings.html
@@ -4,11 +4,18 @@
 {% block title %}Settings - Baloo Dashboard{% endblock %}
 
 {% block content %}
-<div class="flex items-start justify-between mb-6">
+<div class="flex items-start justify-between mb-6 gap-4 flex-wrap">
   <div>
     <h1 class="text-2xl font-bold text-gray-900">Settings</h1>
     <p class="mt-1 text-sm text-gray-500">Effective runtime configuration for this Baloo instance. Allowlisted agent knobs can be overridden in the database without redeploying.</p>
   </div>
+  <form method="post" action="/dashboard/settings">
+    <input type="hidden" name="key" value="agent_model" />
+    <input type="hidden" name="value" value="" />
+    <button type="submit" name="action" value="test_connection" class="text-sm bg-white border border-gray-300 text-gray-800 px-3 py-2 rounded hover:bg-gray-50">
+      Test connection
+    </button>
+  </form>
 </div>
 
 {% if message %}
@@ -16,6 +23,13 @@
 {% endif %}
 {% if error %}
 <div class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">{{ error }}</div>
+{% endif %}
+{% if smoke_message %}
+  {% if smoke_ok == "1" %}
+  <div class="mb-4 rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">{{ smoke_message }}</div>
+  {% else %}
+  <div class="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">{{ smoke_message }}</div>
+  {% endif %}
 {% endif %}
 {% if not database_enabled %}
 <div class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">Runtime overrides require the database. Set <code class="font-mono">DATABASE_ENABLED=true</code> and <code class="font-mono">DATABASE_URL</code>.</div>

--- a/baloo/dashboard/templates/settings.html
+++ b/baloo/dashboard/templates/settings.html
@@ -35,6 +35,43 @@
 <div class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">Runtime overrides require the database. Set <code class="font-mono">DATABASE_ENABLED=true</code> and <code class="font-mono">DATABASE_URL</code>.</div>
 {% endif %}
 
+<div class="bg-white rounded-lg shadow overflow-hidden mb-8">
+  <div class="px-5 py-4 border-b border-gray-200">
+    <h2 class="text-lg font-semibold text-gray-900">Models in use</h2>
+    <p class="mt-1 text-sm text-gray-500">Each Baloo agent role and the model it will call with the current effective settings (short names like <code class="font-mono">haiku</code> are resolved to provider/model).</p>
+  </div>
+  <div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Role</th>
+          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Setting</th>
+          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Configured</th>
+          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Resolved</th>
+          <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Source</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200">
+        {% for row in models_in_use %}
+        <tr class="hover:bg-gray-50">
+          <td class="px-4 py-3 text-sm text-gray-900 whitespace-nowrap">{{ row.role }}</td>
+          <td class="px-4 py-3 text-sm font-mono text-gray-700 whitespace-nowrap">{{ row.setting }}</td>
+          <td class="px-4 py-3 text-sm font-mono text-gray-700 whitespace-nowrap">{{ row.configured }}</td>
+          <td class="px-4 py-3 text-sm font-mono text-gray-900 whitespace-nowrap">{{ row.resolved }}</td>
+          <td class="px-4 py-3 text-sm whitespace-nowrap">
+            {% if row.source == "db" %}
+            <span class="inline-flex items-center rounded bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">db</span>
+            {% else %}
+            <span class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">env</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
 {% set ns = namespace(category="") %}
 {% for row in settings_rows %}
   {% if row.category != ns.category %}

--- a/baloo/db/migrations/versions/008_add_runtime_settings.py
+++ b/baloo/db/migrations/versions/008_add_runtime_settings.py
@@ -1,0 +1,73 @@
+"""Add runtime_settings table for DB-backed config overrides.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-08-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "008"
+down_revision: str = "007"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    tables = set(inspector.get_table_names())
+
+    if "runtime_settings" not in tables:
+        op.create_table(
+            "runtime_settings",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("key", sa.String(length=100), nullable=False),
+            sa.Column("value", sa.Text(), nullable=False),
+            sa.Column("installation_id", sa.String(length=255), nullable=True),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_by", sa.String(length=255), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index(
+            "ix_runtime_settings_installation_id",
+            "runtime_settings",
+            ["installation_id"],
+        )
+        op.create_index(
+            "uq_runtime_settings_null_tenant",
+            "runtime_settings",
+            ["key"],
+            unique=True,
+            postgresql_where=sa.text("installation_id IS NULL"),
+            sqlite_where=sa.text("installation_id IS NULL"),
+        )
+        op.create_index(
+            "uq_runtime_settings_with_tenant",
+            "runtime_settings",
+            ["key", "installation_id"],
+            unique=True,
+            postgresql_where=sa.text("installation_id IS NOT NULL"),
+            sqlite_where=sa.text("installation_id IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    tables = set(inspector.get_table_names())
+    if "runtime_settings" not in tables:
+        return
+
+    indexes = {idx["name"] for idx in inspector.get_indexes("runtime_settings")}
+    for name in (
+        "uq_runtime_settings_with_tenant",
+        "uq_runtime_settings_null_tenant",
+        "ix_runtime_settings_installation_id",
+    ):
+        if name in indexes:
+            op.drop_index(name, table_name="runtime_settings")
+    op.drop_table("runtime_settings")

--- a/baloo/db/models.py
+++ b/baloo/db/models.py
@@ -190,3 +190,38 @@ class FeedbackSignal(Base):
             sqlite_where=text("installation_id IS NOT NULL"),
         ),
     )
+
+
+class RuntimeSetting(Base):
+    """DB-backed runtime overrides for allowlisted settings (env remains fallback)."""
+
+    __tablename__ = "runtime_settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    key: Mapped[str] = mapped_column(String(100), nullable=False)
+    value: Mapped[str] = mapped_column(Text, nullable=False)
+    installation_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uq_runtime_settings_null_tenant",
+            "key",
+            unique=True,
+            postgresql_where=text("installation_id IS NULL"),
+            sqlite_where=text("installation_id IS NULL"),
+        ),
+        Index(
+            "uq_runtime_settings_with_tenant",
+            "key",
+            "installation_id",
+            unique=True,
+            postgresql_where=text("installation_id IS NOT NULL"),
+            sqlite_where=text("installation_id IS NOT NULL"),
+        ),
+    )

--- a/baloo/fidelity/fidelity_analyzer.py
+++ b/baloo/fidelity/fidelity_analyzer.py
@@ -20,6 +20,9 @@ class FidelityAgent(PIAgentBase):
     def __init__(self):
         options = get_agent_options()
         options.system_prompt = FIDELITY_SYSTEM_PROMPT
+        # Fidelity comparison needs deliberate reasoning; keep it independent of
+        # the global PI_THINKING_LEVEL an admin may tune for primary reviews.
+        options.thinking_level = "medium"
         options.name = "FidelityAgent"
         super().__init__(options)
 

--- a/baloo/fidelity/fidelity_analyzer.py
+++ b/baloo/fidelity/fidelity_analyzer.py
@@ -2,7 +2,8 @@
 
 import logging
 
-from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions
+from baloo.agent.config import get_agent_options
+from baloo.agent.pi_runtime import PIAgentBase
 from baloo.fidelity.models import (
     FidelityOutput,
     FidelityResult,
@@ -17,13 +18,9 @@ class FidelityAgent(PIAgentBase):
     """Agent for fidelity analysis comparing PR changes to design spec."""
 
     def __init__(self):
-        options = PIAgentOptions(
-            model="claude-sonnet-4-6",
-            provider="anthropic",
-            system_prompt=FIDELITY_SYSTEM_PROMPT,
-            thinking_level="medium",
-            max_turns=20,
-        )
+        options = get_agent_options()
+        options.system_prompt = FIDELITY_SYSTEM_PROMPT
+        options.name = "FidelityAgent"
         super().__init__(options)
 
     async def analyze(

--- a/baloo/github/webhook_handler.py
+++ b/baloo/github/webhook_handler.py
@@ -105,6 +105,9 @@ async def lifespan(app: FastAPI):
     if settings.database_enabled and settings.database_url:
         logger.info("Database enabled, initializing...")
         await init_db(settings.database_url)
+        from baloo.config.runtime_settings import refresh_cache
+
+        await refresh_cache()
     elif settings.database_enabled:
         logger.warning(
             "DATABASE_ENABLED=true but DATABASE_URL is not set — "

--- a/baloo/processor/fp_verifier.py
+++ b/baloo/processor/fp_verifier.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from baloo.agent.config import get_agent_options
 from baloo.agent.pi_runtime import PIAgentBase, PIAgentOptions
+from baloo.config.runtime_settings import resolve_setting
 from baloo.config.settings import get_settings
 from baloo.github.models import PRContext, ReviewComment
 from baloo.processor.fp_prompts import (
@@ -95,8 +96,10 @@ class FPVerifier:
         model: str | None = None,
         max_concurrent: int | None = None,
     ):
+        from baloo.config.runtime_settings import resolve_setting
+
         settings = get_settings()
-        self.model = model or settings.fp_verification_model
+        self.model = model or resolve_setting("fp_verification_model")
         self.max_concurrent = max_concurrent or settings.fp_verification_max_concurrent
         self.audit_log_path = settings.fp_audit_log_path
 
@@ -343,7 +346,7 @@ class FPVerifier:
             "verdict": verdict,
             "reason": reason,
             "model": model,
-            "review_model": get_settings().agent_model,
+            "review_model": resolve_setting("agent_model"),
             "cost_usd": cost_usd,
         }
 

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from baloo.agent.config import get_agent_options
 from baloo.agent.pi_runtime import PIAgentBase
 from baloo.agent.repo_provision import provision_repo
+from baloo.config.runtime_settings import ensure_fresh_cache, resolve_setting
 from baloo.config.settings import settings
 from baloo.db.service import DuplicateReviewError, ReviewCompleteDTO, ReviewService
 from baloo.db.tenant import apply_tenant_filter
@@ -941,7 +942,7 @@ async def _run_documentation_drift_analysis(
                 work_item=work_item,
                 catalog_path=settings.documentation_drift_catalog_path,
                 repo_path=repo_path,
-                model=settings.documentation_drift_model,
+                model=resolve_setting("documentation_drift_model"),
                 review_logger=documentation_logger,
             )
         finally:
@@ -1158,6 +1159,7 @@ async def process_pr_review(
     github_client: GitHubAPIClient | None = None
 
     try:
+        await ensure_fresh_cache()
         async with semaphore:
             active_count = max(0, sum(1 for t in active_reviews.values() if not t.done()) - 1)
             logger.info(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-All Baloo settings are environment variables. Set them in `.env`, pass them via `docker-compose.yml`, or export them directly.
+All Baloo settings are environment variables by default. Set them in `.env`, pass them via `docker-compose.yml`, or export them directly. When the database is enabled, a small allowlist of agent settings can also be overridden at runtime (see [Runtime Overrides](#runtime-overrides-db)).
 
 ## GitHub App
 
@@ -89,6 +89,18 @@ All Baloo settings are environment variables. Set them in `.env`, pass them via 
 | `DASHBOARD_USERNAME` | — | Dashboard basic auth username |
 | `DASHBOARD_PASSWORD` | — | Dashboard basic auth password |
 | `LOG_RETENTION_DAYS` | `30` | Days to retain execution logs (0 to disable cleanup) |
+
+## Runtime Overrides (DB)
+
+When `DATABASE_ENABLED=true`, Baloo can override a small allowlist of settings at runtime without restarting the process. Overrides are stored in the `runtime_settings` table (scoped by `INSTALLATION_ID` when set) and layered over env defaults:
+
+**Precedence:** DB overlay → environment variable → field default
+
+**Mutable keys:** `AGENT_PROVIDER`, `AGENT_MODEL`, `AGENT_FALLBACK_MODEL`, `PI_THINKING_LEVEL`, `FP_VERIFICATION_MODEL`, `THREAD_AGENT_MODEL`, `DOCUMENTATION_DRIFT_MODEL`
+
+Secrets, database connection settings, GitHub credentials, and host/port are never overridable via the DB. Edit overrides on the dashboard Settings page (`/dashboard/settings`), or they converge across replicas within ~30 seconds via cache TTL refresh.
+
+If the database is disabled, behavior is unchanged: env vars only.
 
 ## Thread Agent
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,8 @@ When `DATABASE_ENABLED=true`, Baloo can override a small allowlist of settings a
 
 Secrets, database connection settings, GitHub credentials, and host/port are never overridable via the DB. Edit overrides on the dashboard Settings page (`/dashboard/settings`), or they converge across replicas within ~30 seconds via cache TTL refresh.
 
+After changing `AGENT_PROVIDER` or `AGENT_MODEL` (or clicking **Test connection**), Baloo runs a short PI smoke call with the effective provider/model to confirm credentials and endpoint wiring. A failure is shown on the Settings page; the override is still saved so you can fix auth and retry.
+
 If the database is disabled, behavior is unchanged: env vars only.
 
 ## Thread Agent

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -35,6 +35,8 @@ The dashboard includes a **Settings** page at `/dashboard/settings` showing the 
 
 Allowlisted agent settings (`AGENT_PROVIDER`, `AGENT_MODEL`, `AGENT_FALLBACK_MODEL`, `PI_THINKING_LEVEL`, and secondary model knobs) can be overridden at runtime when `DATABASE_ENABLED=true`. Overridden rows show a `db` source badge and a **Revert to env** control. All other settings remain read-only and always come from environment variables.
 
+Use **Test connection** to run a one-shot PI smoke call against the effective provider/model (no tools, ~30s timeout). Saving or clearing `AGENT_PROVIDER` / `AGENT_MODEL` also auto-runs that smoke check and shows pass/fail on the page. Overrides are kept even if the smoke fails so you can inspect credentials and retry.
+
 Secrets are never exposed: sensitive settings (API keys, private keys, passwords, webhook secrets) render as `Configured (redacted)` or `Not configured`, and `DATABASE_URL` is shown with its credentials stripped. Secrets cannot be stored as runtime overrides.
 
 ## Configuration

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -35,6 +35,8 @@ The dashboard includes a **Settings** page at `/dashboard/settings` showing the 
 
 Allowlisted agent settings (`AGENT_PROVIDER`, `AGENT_MODEL`, `AGENT_FALLBACK_MODEL`, `PI_THINKING_LEVEL`, and secondary model knobs) can be overridden at runtime when `DATABASE_ENABLED=true`. Overridden rows show a `db` source badge and a **Revert to env** control. All other settings remain read-only and always come from environment variables.
 
+The page opens with a **Models in use** summary: each agent role (primary review, fallback, FP verification, thread agent, fidelity, documentation drift, sync scope) with its configured value and resolved `provider/model` (so defaults like `haiku` for FP/thread are visible without scrolling).
+
 Use **Test connection** to run a one-shot PI smoke call against the effective provider/model (no tools, ~30s timeout). Saving or clearing `AGENT_PROVIDER` / `AGENT_MODEL` also auto-runs that smoke check and shows pass/fail on the page. Overrides are kept even if the smoke fails so you can inspect credentials and retry.
 
 Secrets are never exposed: sensitive settings (API keys, private keys, passwords, webhook secrets) render as `Configured (redacted)` or `Not configured`, and `DATABASE_URL` is shown with its credentials stripped. Secrets cannot be stored as runtime overrides.

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -8,7 +8,7 @@ Baloo includes an optional review history dashboard backed by PostgreSQL. It pro
 - **Findings** — Individual findings per review with severity, category, file, and line
 - **Cost tracking** — Token usage and dollar cost per review and in aggregate
 - **Fidelity scores** — When fidelity analysis is enabled
-- **Settings** — A read-only view of the instance's effective runtime configuration
+- **Settings** — Effective runtime configuration; allowlisted agent knobs can be edited when the database is enabled
 
 ## Requirements
 
@@ -31,9 +31,11 @@ http://localhost:8000/dashboard/
 
 ## Settings Page
 
-The dashboard includes a read-only **Settings** page at `/dashboard/settings` showing the effective runtime configuration loaded for this Baloo instance, grouped by category (GitHub App, Agent, Review Behavior, Repo Provisioning, etc.). Each row lists the environment variable, its current value, its default, and a description.
+The dashboard includes a **Settings** page at `/dashboard/settings` showing the effective runtime configuration for this Baloo instance, grouped by category (GitHub App, Agent, Review Behavior, Repo Provisioning, etc.). Each row lists the environment variable, its current value, its default, and a description.
 
-Secrets are never exposed: sensitive settings (API keys, private keys, passwords, webhook secrets) render as `Configured (redacted)` or `Not configured`, and `DATABASE_URL` is shown with its credentials stripped. The page is for inspection only — it cannot change configuration.
+Allowlisted agent settings (`AGENT_PROVIDER`, `AGENT_MODEL`, `AGENT_FALLBACK_MODEL`, `PI_THINKING_LEVEL`, and secondary model knobs) can be overridden at runtime when `DATABASE_ENABLED=true`. Overridden rows show a `db` source badge and a **Revert to env** control. All other settings remain read-only and always come from environment variables.
+
+Secrets are never exposed: sensitive settings (API keys, private keys, passwords, webhook secrets) render as `Configured (redacted)` or `Not configured`, and `DATABASE_URL` is shown with its credentials stripped. Secrets cannot be stored as runtime overrides.
 
 ## Configuration
 

--- a/docs/features/fidelity.md
+++ b/docs/features/fidelity.md
@@ -17,7 +17,7 @@ This is especially useful for teams that use ticket-linked plan files as part of
 1. **Extract ticket ID** — Baloo looks for a ticket ID in the PR branch name, title, or description (e.g., `PROJ-123` from branch `feat/PROJ-123-add-auth`)
 2. **Fetch ticket** — When `LINEAR_API_KEY` is set, the linked ticket is fetched from Linear and becomes the ticket layer of the spec
 3. **Fetch plan file** — Looks for a plan document at a configurable path (default: `docs/plans/{ticket_id}.md`) in the PR branch; this is the plan layer
-4. **Analyze** — An LLM compares the two-layer spec (ticket and/or plan) against the PR diff
+4. **Analyze** — An LLM compares the two-layer spec (ticket and/or plan) against the PR diff, using the same model as the primary review agent (`AGENT_MODEL`)
 5. **Score** — Produces a fidelity score (0–100) and a breakdown of matched/missing/extra items
 6. **Report** — Posts the fidelity report as a separate PR comment
 
@@ -97,6 +97,13 @@ This means a high-fidelity PR with only MEDIUM issues can still be auto-approved
 | `TICKET_ID_PREFIX` | `PROJ` | Prefix for ticket extraction (e.g., `PROJ` matches `PROJ-123`) |
 | `LINEAR_API_KEY` | *(empty)* | Linear API key; enables ticket fetching when set |
 | `LINEAR_API_URL` | `https://api.linear.app/graphql` | Linear GraphQL endpoint |
+| `AGENT_MODEL` | *(see [Models](models.md))* | Model used for fidelity analysis — shared with the primary review agent |
+
+Fidelity analysis runs on the effective `AGENT_MODEL`, including any runtime override set from the
+dashboard (see [Runtime Overrides](../configuration.md#runtime-overrides-db)). Choosing a premium
+model for reviews therefore also applies to fidelity. The thinking level is always `medium` for
+fidelity regardless of `PI_THINKING_LEVEL`, so tuning that for reviews cannot degrade fidelity
+results.
 
 ## No Spec? No Report
 

--- a/docs/features/models.md
+++ b/docs/features/models.md
@@ -34,6 +34,8 @@ AGENT_MODEL=anthropic/claude-sonnet-4-6
 AGENT_MODEL=opus
 ```
 
+When `DATABASE_ENABLED=true`, `AGENT_MODEL`, `AGENT_FALLBACK_MODEL`, and `PI_THINKING_LEVEL` can also be changed at runtime from the dashboard Settings page without restarting. See [Runtime Overrides](../configuration.md#runtime-overrides-db).
+
 ## Automatic Fallback
 
 If the primary model fails (rate limit, timeout, availability), Baloo automatically retries with a fallback model:

--- a/tests/agent/test_provider_smoke.py
+++ b/tests/agent/test_provider_smoke.py
@@ -1,0 +1,132 @@
+"""Tests for provider connectivity smoke checks."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from baloo.agent.pi_runtime import PIAgentOptions
+from baloo.agent.provider_smoke import SmokeResult, smoke_test_provider
+
+
+def _options(**kwargs) -> PIAgentOptions:
+    defaults = {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "system_prompt": "",
+        "thinking_level": "medium",
+        "max_turns": 20,
+        "no_tools": False,
+        "name": None,
+        "cwd": None,
+    }
+    defaults.update(kwargs)
+    return PIAgentOptions(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_provider_success():
+    metadata = {
+        "is_error": False,
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "cost_usd": 0.0,
+    }
+    with patch(
+        "baloo.agent.provider_smoke.get_agent_options",
+        return_value=_options(model="claude-haiku-4-5-20251001"),
+    ):
+        with patch(
+            "baloo.agent.provider_smoke.PIAgentBase.run_query",
+            new=AsyncMock(return_value=({"status": "ok"}, metadata)),
+        ) as run_query:
+            result = await smoke_test_provider()
+
+    assert result.ok is True
+    assert result.provider == "anthropic"
+    assert result.model == "claude-haiku-4-5-20251001"
+    assert "passed" in result.message.lower()
+    run_query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_provider_configures_no_tools_probe():
+    captured: dict = {}
+
+    def capture_options(model=None):
+        opts = _options()
+        captured["opts"] = opts
+        return opts
+
+    with patch("baloo.agent.provider_smoke.get_agent_options", side_effect=capture_options):
+        with patch(
+            "baloo.agent.provider_smoke.PIAgentBase.run_query",
+            new=AsyncMock(return_value=({"status": "ok"}, {"is_error": False})),
+        ):
+            await smoke_test_provider()
+
+    assert captured["opts"].no_tools is True
+    assert captured["opts"].thinking_level == "off"
+    assert captured["opts"].max_turns == 1
+    assert captured["opts"].cwd is None
+    assert captured["opts"].name == "ProviderSmoke"
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_provider_agent_error():
+    with patch(
+        "baloo.agent.provider_smoke.get_agent_options",
+        return_value=_options(provider="amazon-bedrock", model="us.anthropic.x"),
+    ):
+        with patch(
+            "baloo.agent.provider_smoke.PIAgentBase.run_query",
+            new=AsyncMock(return_value=(None, {"is_error": True})),
+        ):
+            result = await smoke_test_provider()
+
+    assert result.ok is False
+    assert "failed" in result.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_provider_timeout():
+    with patch(
+        "baloo.agent.provider_smoke.get_agent_options",
+        return_value=_options(),
+    ):
+        with patch(
+            "baloo.agent.provider_smoke.PIAgentBase.run_query",
+            new=AsyncMock(side_effect=TimeoutError()),
+        ):
+            result = await smoke_test_provider(timeout_seconds=0.01)
+
+    assert result.ok is False
+    assert result.error == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_smoke_test_provider_exception():
+    with patch(
+        "baloo.agent.provider_smoke.get_agent_options",
+        return_value=_options(),
+    ):
+        with patch(
+            "baloo.agent.provider_smoke.PIAgentBase.run_query",
+            new=AsyncMock(side_effect=RuntimeError("auth failed")),
+        ):
+            result = await smoke_test_provider()
+
+    assert result.ok is False
+    assert "auth failed" in (result.error or "")
+
+
+def test_smoke_result_model_ref():
+    result = SmokeResult(
+        ok=True,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        duration_seconds=1.2,
+        message="ok",
+    )
+    assert result.model_ref == "anthropic/claude-sonnet-4-6"

--- a/tests/config/test_runtime_settings.py
+++ b/tests/config/test_runtime_settings.py
@@ -166,6 +166,62 @@ async def test_set_override_rejects_non_mutable(runtime_db):
         await set_override("database_url", "postgresql://x", updated_by="x")
 
 
+@pytest.mark.asyncio
+async def test_set_override_updates_existing_row(runtime_db):
+    await set_override("agent_model", "opus", updated_by="alice")
+    await set_override("agent_model", "sonnet", updated_by="bob")
+
+    async with runtime_db() as session:
+        rows = (await session.execute(select(RuntimeSetting))).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].value == "sonnet"
+    assert rows[0].updated_by == "bob"
+    assert resolve_setting("agent_model") == "sonnet"
+
+
+@pytest.mark.asyncio
+async def test_set_override_recovers_from_concurrent_insert(runtime_db):
+    """A racing writer inserts first; our INSERT loses the unique index and retries as update."""
+    import baloo.config.runtime_settings as rs
+
+    async with runtime_db() as session:
+        async with session.begin():
+            session.add(
+                RuntimeSetting(
+                    key="agent_model",
+                    value="haiku",
+                    installation_id=None,
+                    updated_at=datetime.now(timezone.utc),
+                    updated_by="racer",
+                )
+            )
+
+    real_filter = rs._tenant_filter
+    calls = {"n": 0}
+
+    def flaky_filter(stmt, model, installation_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # First lookup misses the row the racing writer just committed,
+            # so set_override attempts an INSERT and hits the unique index.
+            return stmt.where(model.key == "__never_matches__")
+        return real_filter(stmt, model, installation_id)
+
+    with patch.object(rs, "_tenant_filter", flaky_filter):
+        await set_override("agent_model", "opus", updated_by="admin")
+
+    assert calls["n"] >= 2
+
+    async with runtime_db() as session:
+        rows = (await session.execute(select(RuntimeSetting))).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].value == "opus"
+    assert rows[0].updated_by == "admin"
+    assert resolve_setting("agent_model") == "opus"
+
+
 def test_get_agent_options_picks_up_overlay(monkeypatch):
     monkeypatch.setenv("DATABASE_ENABLED", "true")
     monkeypatch.setenv("AGENT_MODEL", "haiku")
@@ -199,3 +255,19 @@ def test_fidelity_agent_uses_get_agent_options(monkeypatch):
     agent = FidelityAgent()
     assert agent.options.model == "claude-sonnet-4-6"
     assert "fidelity" in agent.options.system_prompt.lower() or agent.options.system_prompt
+
+
+def test_fidelity_agent_keeps_medium_thinking_level(monkeypatch):
+    """Global PI_THINKING_LEVEL changes must not degrade fidelity analysis."""
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("PI_THINKING_LEVEL", "off")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    import baloo.config.runtime_settings as rs
+    from baloo.fidelity.fidelity_analyzer import FidelityAgent
+
+    rs._cache = {"pi_thinking_level": "off"}
+    rs._cache_loaded_at = 10**12
+
+    assert FidelityAgent().options.thinking_level == "medium"

--- a/tests/config/test_runtime_settings.py
+++ b/tests/config/test_runtime_settings.py
@@ -1,0 +1,201 @@
+"""Tests for DB-backed runtime settings overlay."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from baloo.config.runtime_settings import (
+    MUTABLE_KEYS,
+    RuntimeSettingsError,
+    clear_override,
+    coerce_setting_value,
+    refresh_cache,
+    reset_runtime_settings_cache,
+    resolve_setting,
+    set_override,
+    setting_source,
+    validate_override,
+)
+from baloo.config.settings import reset_settings
+from baloo.db.engine import reset_engine
+from baloo.db.models import Base, RuntimeSetting
+
+
+@pytest.fixture
+async def runtime_db(monkeypatch):
+    """In-memory SQLite DB wired into runtime settings + settings singleton."""
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    monkeypatch.setenv("AGENT_PROVIDER", "anthropic")
+    monkeypatch.setenv("AGENT_MODEL", "sonnet")
+    monkeypatch.delenv("INSTALLATION_ID", raising=False)
+    reset_settings()
+    reset_runtime_settings_cache()
+    reset_engine()
+
+    with patch("baloo.db.engine.get_session_factory", return_value=factory):
+        yield factory
+    reset_runtime_settings_cache()
+    reset_engine()
+    await engine.dispose()
+
+
+def test_mutable_keys_cover_agent_knobs():
+    assert "agent_provider" in MUTABLE_KEYS
+    assert "agent_model" in MUTABLE_KEYS
+    assert "agent_fallback_model" in MUTABLE_KEYS
+    assert "anthropic_api_key" not in MUTABLE_KEYS
+    assert "database_url" not in MUTABLE_KEYS
+
+
+def test_validate_override_rejects_secrets():
+    with pytest.raises(RuntimeSettingsError, match="not mutable"):
+        validate_override("anthropic_api_key", "sk-secret")
+
+
+def test_validate_override_rejects_empty_provider():
+    with pytest.raises(RuntimeSettingsError, match="non-empty"):
+        validate_override("agent_provider", "  ")
+
+
+def test_coerce_string_passthrough():
+    assert coerce_setting_value("agent_model", "opus") == "opus"
+
+
+def test_resolve_falls_back_to_env_when_cache_empty(monkeypatch):
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MODEL", "haiku")
+    reset_settings()
+    reset_runtime_settings_cache()
+    assert resolve_setting("agent_model") == "haiku"
+    assert setting_source("agent_model") == "env"
+
+
+def test_resolve_uses_cache_overlay(monkeypatch):
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MODEL", "haiku")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    import baloo.config.runtime_settings as rs
+
+    rs._cache = {"agent_model": "opus"}
+    rs._cache_loaded_at = 10**12  # fresh
+    assert resolve_setting("agent_model") == "opus"
+    assert setting_source("agent_model") == "db"
+
+
+def test_resolve_ignores_overlay_when_db_disabled(monkeypatch):
+    monkeypatch.setenv("DATABASE_ENABLED", "false")
+    monkeypatch.setenv("AGENT_MODEL", "haiku")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    import baloo.config.runtime_settings as rs
+
+    rs._cache = {"agent_model": "opus"}
+    rs._cache_loaded_at = 10**12
+    assert resolve_setting("agent_model") == "haiku"
+    assert setting_source("agent_model") == "env"
+
+
+@pytest.mark.asyncio
+async def test_set_and_clear_override_roundtrip(runtime_db):
+    await set_override("agent_provider", "amazon-bedrock", updated_by="tester")
+    assert resolve_setting("agent_provider") == "amazon-bedrock"
+    assert setting_source("agent_provider") == "db"
+
+    async with runtime_db() as session:
+        row = (await session.execute(select(RuntimeSetting))).scalar_one()
+        assert row.key == "agent_provider"
+        assert row.value == "amazon-bedrock"
+        assert row.updated_by == "tester"
+        assert row.installation_id is None
+
+    removed = await clear_override("agent_provider")
+    assert removed is True
+    assert resolve_setting("agent_provider") == "anthropic"
+    assert setting_source("agent_provider") == "env"
+
+
+@pytest.mark.asyncio
+async def test_set_override_scopes_by_installation_id(runtime_db, monkeypatch):
+    monkeypatch.setenv("INSTALLATION_ID", "inst-42")
+    reset_settings()
+
+    await set_override("agent_model", "opus", updated_by="alice")
+
+    async with runtime_db() as session:
+        row = (await session.execute(select(RuntimeSetting))).scalar_one()
+        assert row.installation_id == "inst-42"
+        assert row.key == "agent_model"
+
+
+@pytest.mark.asyncio
+async def test_refresh_cache_loads_rows(runtime_db):
+    async with runtime_db() as session:
+        async with session.begin():
+            session.add(
+                RuntimeSetting(
+                    key="pi_thinking_level",
+                    value="high",
+                    installation_id=None,
+                    updated_at=datetime.now(timezone.utc),
+                    updated_by="seed",
+                )
+            )
+
+    reset_runtime_settings_cache()
+    await refresh_cache()
+    assert resolve_setting("pi_thinking_level") == "high"
+
+
+@pytest.mark.asyncio
+async def test_set_override_rejects_non_mutable(runtime_db):
+    with pytest.raises(RuntimeSettingsError, match="not mutable"):
+        await set_override("database_url", "postgresql://x", updated_by="x")
+
+
+def test_get_agent_options_picks_up_overlay(monkeypatch):
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MODEL", "haiku")
+    monkeypatch.setenv("AGENT_PROVIDER", "anthropic")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    import baloo.config.runtime_settings as rs
+    from baloo.agent.config import get_agent_options
+
+    rs._cache = {"agent_model": "opus", "agent_provider": "anthropic"}
+    rs._cache_loaded_at = 10**12
+
+    options = get_agent_options()
+    assert options.model == "claude-opus-4-6"
+    assert options.provider == "anthropic"
+
+
+def test_fidelity_agent_uses_get_agent_options(monkeypatch):
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("AGENT_MODEL", "haiku")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    import baloo.config.runtime_settings as rs
+    from baloo.fidelity.fidelity_analyzer import FidelityAgent
+
+    rs._cache = {"agent_model": "sonnet"}
+    rs._cache_loaded_at = 10**12
+
+    agent = FidelityAgent()
+    assert agent.options.model == "claude-sonnet-4-6"
+    assert "fidelity" in agent.options.system_prompt.lower() or agent.options.system_prompt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,11 @@ os.environ.setdefault("FIDELITY_ENABLED", "true")
 @pytest.fixture(autouse=True)
 def reset_baloo_settings():
     """Reset cached settings between tests so env overrides stay deterministic."""
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
     from baloo.config.settings import reset_settings
 
     reset_settings()
+    reset_runtime_settings_cache()
     yield
     reset_settings()
+    reset_runtime_settings_cache()

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -127,3 +127,93 @@ def test_documentation_drift_settings_are_grouped() -> None:
         "documentation_drift_model",
     ):
         assert by_name[name] == "Documentation Drift"
+
+
+def test_settings_rows_mark_mutable_keys() -> None:
+    from baloo.config.runtime_settings import MUTABLE_KEYS
+    from baloo.dashboard.router import _settings_rows
+
+    by_name = {r["name"]: r for r in _settings_rows()}
+    for key in MUTABLE_KEYS:
+        assert by_name[key]["mutable"] is True
+    assert by_name["database_url"]["mutable"] is False
+
+
+def test_dashboard_settings_post_sets_override(monkeypatch) -> None:
+    from baloo.config.runtime_settings import reset_runtime_settings_cache, resolve_setting
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    monkeypatch.setenv("AGENT_PROVIDER", "anthropic")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    async def fake_set(key: str, value: str, *, updated_by: str | None = None) -> str:
+        import baloo.config.runtime_settings as rs
+
+        rs._cache = {**(rs._cache or {}), key: value}
+        rs._cache_loaded_at = 10**12
+        return value
+
+    with patch("baloo.dashboard.router.set_override", side_effect=fake_set):
+        with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+            app = _build_app()
+            client = TestClient(app)
+            response = client.post(
+                "/dashboard/settings",
+                data={"key": "agent_provider", "value": "amazon-bedrock", "action": "save"},
+                follow_redirects=False,
+            )
+
+    assert response.status_code == 303
+    assert "message=" in response.headers["location"]
+    assert resolve_setting("agent_provider") == "amazon-bedrock"
+
+
+def test_dashboard_settings_post_clear_override(monkeypatch) -> None:
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    with patch("baloo.dashboard.router.clear_override", new=AsyncMock(return_value=True)) as clear:
+        with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+            app = _build_app()
+            client = TestClient(app)
+            response = client.post(
+                "/dashboard/settings",
+                data={"key": "agent_model", "value": "", "action": "clear"},
+                follow_redirects=False,
+            )
+
+    assert response.status_code == 303
+    clear.assert_awaited_once_with("agent_model")
+
+
+def test_dashboard_settings_post_rejects_non_mutable(monkeypatch) -> None:
+    from baloo.config.runtime_settings import RuntimeSettingsError, reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    async def boom(*args, **kwargs):
+        raise RuntimeSettingsError("Setting is not mutable at runtime: database_url")
+
+    with patch("baloo.dashboard.router.set_override", side_effect=boom):
+        app = _build_app()
+        client = TestClient(app)
+        response = client.post(
+            "/dashboard/settings",
+            data={"key": "database_url", "value": "x", "action": "save"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 303
+    assert "error=" in response.headers["location"]

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -140,6 +140,7 @@ def test_settings_rows_mark_mutable_keys() -> None:
 
 
 def test_dashboard_settings_post_sets_override(monkeypatch) -> None:
+    from baloo.agent.provider_smoke import SmokeResult
     from baloo.config.runtime_settings import reset_runtime_settings_cache, resolve_setting
     from baloo.config.settings import reset_settings
 
@@ -156,15 +157,26 @@ def test_dashboard_settings_post_sets_override(monkeypatch) -> None:
         rs._cache_loaded_at = 10**12
         return value
 
+    smoke = SmokeResult(
+        ok=True,
+        provider="amazon-bedrock",
+        model="claude-sonnet-4-6",
+        duration_seconds=0.1,
+        message="Smoke test passed",
+    )
     with patch("baloo.dashboard.router.set_override", side_effect=fake_set):
         with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
-            app = _build_app()
-            client = TestClient(app)
-            response = client.post(
-                "/dashboard/settings",
-                data={"key": "agent_provider", "value": "amazon-bedrock", "action": "save"},
-                follow_redirects=False,
-            )
+            with patch(
+                "baloo.agent.provider_smoke.smoke_test_provider",
+                new=AsyncMock(return_value=smoke),
+            ):
+                app = _build_app()
+                client = TestClient(app)
+                response = client.post(
+                    "/dashboard/settings",
+                    data={"key": "agent_provider", "value": "amazon-bedrock", "action": "save"},
+                    follow_redirects=False,
+                )
 
     assert response.status_code == 303
     assert "message=" in response.headers["location"]
@@ -217,3 +229,83 @@ def test_dashboard_settings_post_rejects_non_mutable(monkeypatch) -> None:
 
     assert response.status_code == 303
     assert "error=" in response.headers["location"]
+
+
+def test_dashboard_settings_test_connection(monkeypatch) -> None:
+    from baloo.agent.provider_smoke import SmokeResult
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    smoke = SmokeResult(
+        ok=True,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        duration_seconds=0.5,
+        message="Smoke test passed for anthropic/claude-sonnet-4-6 in 0.5s",
+    )
+    with patch(
+        "baloo.agent.provider_smoke.smoke_test_provider",
+        new=AsyncMock(return_value=smoke),
+    ):
+        app = _build_app()
+        client = TestClient(app)
+        response = client.post(
+            "/dashboard/settings",
+            data={"key": "agent_model", "value": "", "action": "test_connection"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 303
+    location = response.headers["location"]
+    assert "smoke_ok=1" in location
+    assert "smoke_message=" in location
+
+
+def test_dashboard_settings_save_runs_smoke_for_provider(monkeypatch) -> None:
+    from baloo.agent.provider_smoke import SmokeResult
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    monkeypatch.setenv("AGENT_PROVIDER", "anthropic")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    async def fake_set(key: str, value: str, *, updated_by: str | None = None) -> str:
+        return value
+
+    smoke = SmokeResult(
+        ok=False,
+        provider="amazon-bedrock",
+        model="us.anthropic.x",
+        duration_seconds=1.0,
+        message="Smoke test failed for amazon-bedrock/us.anthropic.x: auth",
+        error="auth",
+    )
+    with patch("baloo.dashboard.router.set_override", side_effect=fake_set):
+        with patch(
+            "baloo.agent.provider_smoke.smoke_test_provider",
+            new=AsyncMock(return_value=smoke),
+        ):
+            app = _build_app()
+            client = TestClient(app)
+            response = client.post(
+                "/dashboard/settings",
+                data={
+                    "key": "agent_provider",
+                    "value": "amazon-bedrock",
+                    "action": "save",
+                },
+                follow_redirects=False,
+            )
+
+    assert response.status_code == 303
+    location = response.headers["location"]
+    assert "message=" in location
+    assert "smoke_ok=0" in location

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -326,6 +326,33 @@ def test_dashboard_settings_test_connection(monkeypatch) -> None:
     assert "Smoke test passed for anthropic/claude-sonnet-4-6" in follow.text
 
 
+def test_dashboard_settings_rejects_unknown_action(monkeypatch) -> None:
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    with patch("baloo.dashboard.router.set_override", new=AsyncMock()) as set_mock:
+        with patch("baloo.dashboard.router.clear_override", new=AsyncMock()) as clear_mock:
+            with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+                app = _build_app()
+                client = TestClient(app)
+                response = client.post(
+                    "/dashboard/settings",
+                    data={"key": "agent_model", "value": "opus", "action": "delete"},
+                    follow_redirects=False,
+                )
+                assert response.status_code == 303
+                follow = client.get(response.headers["location"])
+
+    set_mock.assert_not_awaited()
+    clear_mock.assert_not_awaited()
+    assert "Unknown action" in follow.text
+
+
 def test_dashboard_settings_save_runs_smoke_for_provider(monkeypatch) -> None:
     from baloo.agent.provider_smoke import SmokeResult
     from baloo.config.runtime_settings import reset_runtime_settings_cache

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -129,6 +129,50 @@ def test_documentation_drift_settings_are_grouped() -> None:
         assert by_name[name] == "Documentation Drift"
 
 
+def test_models_in_use_includes_haiku_roles(monkeypatch) -> None:
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+    from baloo.dashboard.router import _models_in_use
+
+    monkeypatch.setenv("AGENT_MODEL", "sonnet")
+    monkeypatch.setenv("FP_VERIFICATION_MODEL", "haiku")
+    monkeypatch.setenv("THREAD_AGENT_MODEL", "haiku")
+    monkeypatch.setenv("DOCUMENTATION_DRIFT_MODEL", "sonnet")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    by_role = {row["role"]: row for row in _models_in_use()}
+    assert by_role["Primary review"]["configured"] == "sonnet"
+    assert by_role["Primary review"]["resolved"] == "anthropic/claude-sonnet-4-6"
+    assert by_role["FP verification"]["configured"] == "haiku"
+    assert by_role["FP verification"]["resolved"] == "anthropic/claude-haiku-4-5-20251001"
+    assert by_role["Thread agent"]["configured"] == "haiku"
+    assert by_role["Fidelity analysis"]["resolved"] == by_role["Primary review"]["resolved"]
+    assert by_role["Documentation drift"]["configured"] == "sonnet"
+
+
+def test_dashboard_settings_shows_models_in_use(monkeypatch) -> None:
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("FP_VERIFICATION_MODEL", "haiku")
+    monkeypatch.setenv("THREAD_AGENT_MODEL", "haiku")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+        app = _build_app()
+        client = TestClient(app)
+        response = client.get("/dashboard/settings")
+
+    assert response.status_code == 200
+    assert "Models in use" in response.text
+    assert "FP verification" in response.text
+    assert "Thread agent" in response.text
+    assert "haiku" in response.text
+    assert "claude-haiku-4-5-20251001" in response.text
+
+
 def test_settings_rows_mark_mutable_keys() -> None:
     from baloo.config.runtime_settings import MUTABLE_KEYS
     from baloo.dashboard.router import _settings_rows

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -221,10 +221,18 @@ def test_dashboard_settings_post_sets_override(monkeypatch) -> None:
                     data={"key": "agent_provider", "value": "amazon-bedrock", "action": "save"},
                     follow_redirects=False,
                 )
+                assert response.status_code == 303
+                location = response.headers["location"]
+                assert location.startswith("/dashboard/settings?flash=")
+                # User-controlled values must not appear in the redirect URL.
+                assert "amazon-bedrock" not in location
+                assert "AGENT_PROVIDER" not in location
 
-    assert response.status_code == 303
-    assert "message=" in response.headers["location"]
+                follow = client.get(location)
+
     assert resolve_setting("agent_provider") == "amazon-bedrock"
+    assert "Updated AGENT_PROVIDER" in follow.text
+    assert "Smoke test passed" in follow.text
 
 
 def test_dashboard_settings_post_clear_override(monkeypatch) -> None:
@@ -247,6 +255,7 @@ def test_dashboard_settings_post_clear_override(monkeypatch) -> None:
             )
 
     assert response.status_code == 303
+    assert response.headers["location"].startswith("/dashboard/settings?flash=")
     clear.assert_awaited_once_with("agent_model")
 
 
@@ -263,16 +272,21 @@ def test_dashboard_settings_post_rejects_non_mutable(monkeypatch) -> None:
         raise RuntimeSettingsError("Setting is not mutable at runtime: database_url")
 
     with patch("baloo.dashboard.router.set_override", side_effect=boom):
-        app = _build_app()
-        client = TestClient(app)
-        response = client.post(
-            "/dashboard/settings",
-            data={"key": "database_url", "value": "x", "action": "save"},
-            follow_redirects=False,
-        )
+        with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+            app = _build_app()
+            client = TestClient(app)
+            response = client.post(
+                "/dashboard/settings",
+                data={"key": "database_url", "value": "x", "action": "save"},
+                follow_redirects=False,
+            )
+            assert response.status_code == 303
+            location = response.headers["location"]
+            assert location.startswith("/dashboard/settings?flash=")
+            assert "database_url" not in location
+            follow = client.get(location)
 
-    assert response.status_code == 303
-    assert "error=" in response.headers["location"]
+    assert "not mutable" in follow.text
 
 
 def test_dashboard_settings_test_connection(monkeypatch) -> None:
@@ -296,18 +310,20 @@ def test_dashboard_settings_test_connection(monkeypatch) -> None:
         "baloo.agent.provider_smoke.smoke_test_provider",
         new=AsyncMock(return_value=smoke),
     ):
-        app = _build_app()
-        client = TestClient(app)
-        response = client.post(
-            "/dashboard/settings",
-            data={"key": "agent_model", "value": "", "action": "test_connection"},
-            follow_redirects=False,
-        )
+        with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+            app = _build_app()
+            client = TestClient(app)
+            response = client.post(
+                "/dashboard/settings",
+                data={"key": "agent_model", "value": "", "action": "test_connection"},
+                follow_redirects=False,
+            )
+            assert response.status_code == 303
+            location = response.headers["location"]
+            assert location.startswith("/dashboard/settings?flash=")
+            follow = client.get(location)
 
-    assert response.status_code == 303
-    location = response.headers["location"]
-    assert "smoke_ok=1" in location
-    assert "smoke_message=" in location
+    assert "Smoke test passed for anthropic/claude-sonnet-4-6" in follow.text
 
 
 def test_dashboard_settings_save_runs_smoke_for_provider(monkeypatch) -> None:
@@ -337,19 +353,22 @@ def test_dashboard_settings_save_runs_smoke_for_provider(monkeypatch) -> None:
             "baloo.agent.provider_smoke.smoke_test_provider",
             new=AsyncMock(return_value=smoke),
         ):
-            app = _build_app()
-            client = TestClient(app)
-            response = client.post(
-                "/dashboard/settings",
-                data={
-                    "key": "agent_provider",
-                    "value": "amazon-bedrock",
-                    "action": "save",
-                },
-                follow_redirects=False,
-            )
+            with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+                app = _build_app()
+                client = TestClient(app)
+                response = client.post(
+                    "/dashboard/settings",
+                    data={
+                        "key": "agent_provider",
+                        "value": "amazon-bedrock",
+                        "action": "save",
+                    },
+                    follow_redirects=False,
+                )
+                assert response.status_code == 303
+                location = response.headers["location"]
+                assert location.startswith("/dashboard/settings?flash=")
+                follow = client.get(location)
 
-    assert response.status_code == 303
-    location = response.headers["location"]
-    assert "message=" in location
-    assert "smoke_ok=0" in location
+    assert "Updated AGENT_PROVIDER" in follow.text
+    assert "Smoke test failed for amazon-bedrock" in follow.text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds DB-backed runtime settings so agent provider/model (and related knobs) can change without redeploy. Implements the dynamic-config slice of #188; Bedrock/Databricks wiring remains a follow-up.

## Changes

- Add `runtime_settings` table + Alembic migration `008` (scoped by `installation_id`)
- Add `baloo/config/runtime_settings.py` overlay: allowlist, 30s cache TTL, `resolve_setting` / set / clear
- Wire agent defaults, fallback, FP/thread/doc-drift models, and fidelity through the overlay
- Make dashboard Settings editable for allowlisted keys (Save / Revert to env) with source badges
- Load overlay cache after DB init; refresh before each review and on the settings page
- Add **Models in use** summary (primary, fallback, FP/haiku, thread/haiku, fidelity, docs, sync scope) with configured + resolved `provider/model`
- Add PI provider smoke test: **Test connection** button + auto-run after saving/clearing `AGENT_PROVIDER` / `AGENT_MODEL`
- PRG flash uses a server-generated token only (no user input in redirect URL; addresses CodeQL)
- Docs for precedence, mutable keys, models summary, and smoke check; tests for overlay, scoping, dashboard writes, and smoke

## Testing

- [x] Tests added/updated
- [x] `uv run pytest` passes
- [x] `uv run ruff check baloo tests` clean
- [x] `uv run black --check baloo tests` clean

## Notes

- Requires `DATABASE_ENABLED=true`. Secrets and infra settings are never overridable.
- Precedence: DB overlay → env → field default.
- Smoke check uses `--no-tools`, thinking off, ~30s timeout; override is kept even if smoke fails so admins can fix auth and retry.
- Follow-ups from #188: Bedrock AWS sandbox allowlist; Databricks via pi `models.json` baseUrl.
- Rebased onto latest `main` (includes #193).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bb5127d-3ca0-4b8d-b6ed-983fe7440b4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bb5127d-3ca0-4b8d-b6ed-983fe7440b4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

