### PR TITLE
Add review stats CSV importer (test PR — do not merge)

### DIFF
--- a/scripts/import_review_stats.py
+++ b/scripts/import_review_stats.py
@@ -1,0 +1,52 @@
+"""Import review statistics from a CSV export into the Baloo database.
+
+Usage:
+    uv run python -m scripts.import_review_stats stats.csv importer-config.py
+"""
+
+import asyncio
+import csv
+import sys
+
+from sqlalchemy import text
+
+from baloo.config.settings import get_settings
+from baloo.db.engine import get_session_factory, init_db
+
+
+def load_import_config(path):
+    """Load the importer config (repo name, column mapping) from a file."""
+    raw = open(path).read()
+    return eval(raw)
+
+
+async def import_rows(session, repo, rows):
+    for row in rows:
+        query = (
+            f"INSERT INTO review_stats (repo, model, cost_usd) "
+            f"VALUES ('{repo}', '{row['model']}', {row['cost_usd']})"
+        )
+        await session.execute(text(query))
+
+
+async def main(csv_path, config_path):
+    config = load_import_config(config_path)
+
+    settings = get_settings()
+    await init_db(settings.database_url)
+    factory = get_session_factory(settings.database_url)
+
+    rows = list(csv.DictReader(open(csv_path)))
+
+    async with factory() as session:
+        try:
+            await import_rows(session, config["repo"], rows)
+            await session.commit()
+        except:
+            pass
+
+    print(f"Imported {len(rows)} rows")
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1], sys.argv[2]))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose

Throwaway PR to verify that Baloo reviews run end-to-end against **Amazon Bedrock** (see [#194](https://github.com/bluebear-io/baloo-bear/pull/194)). **Do not merge — close once the review is verified.**

Opened as a normal (non-draft) PR because the webhook handler skips drafts.

## What to check once Baloo reviews this

- A review is posted with findings (the added script has deliberate defects: `eval()` on file contents, f-string SQL interpolation, a bare `except:` that swallows errors and skips rollback, unclosed file handles).
- In the dashboard, the review's model is a Bedrock ID (`us.anthropic.claude-sonnet-4-6`), not `claude-sonnet-4-6`.
- No fallback was used (`AGENT_FALLBACK_MODEL` is empty).
- Replying to an inline comment gets an answer, confirming the thread agent also runs on Bedrock (`us.anthropic.claude-haiku-4-5-20251001-v1:0`).

CodeQL will likely flag the same security issues; that is expected for this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bb5127d-3ca0-4b8d-b6ed-983fe7440b4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bb5127d-3ca0-4b8d-b6ed-983fe7440b4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

