### PR TITLE
Never approve a PR when the review agent failed

### DIFF
--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -939,6 +939,15 @@ Serialized payload:
                         # reason" and has no way to tell an expired key from a
                         # model they lack access to.
                         detail = _provider_error_detail(msg) or "\n".join(text_parts).strip()
+                        if not detail:
+                            # ponytail: dump the raw message so an unknown PI error
+                            # shape is still diagnosable; narrow it in
+                            # _provider_error_detail once we've seen the payload.
+                            logger.error(
+                                "%s: error stop reason with no extractable detail; raw message: %s",
+                                self.agent_name,
+                                json.dumps(msg, default=str)[:2000],
+                            )
                         result.error_message = (
                             f"Agent returned error stop reason: {detail}"
                             if detail

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -1541,6 +1541,21 @@ async def process_pr_review(
             if awaiting_threads and not request_changes and not decision_comments:
                 request_changes = True
 
+            # A failed agent returns zero findings, which is indistinguishable
+            # from a clean PR here — that is how Baloo kept approving PRs while
+            # it was actually down. Never green-light a review that did not run.
+            agent_had_error = bool(agent_metadata.get("agent_error"))
+            if agent_had_error:
+                logger.error(
+                    "Agent failed for %s#%s (category=%s, detail=%s) - suppressing approval",
+                    repo_full_name,
+                    pr_number,
+                    agent_metadata.get("error_category"),
+                    agent_metadata.get("error_detail"),
+                )
+                approve = False
+                request_changes = False
+
             decision_summary = DecisionEngine.get_decision_summary(approve, request_changes)
 
             summary_text = CommentFormatter.format_summary(
@@ -1728,7 +1743,14 @@ async def process_pr_review(
             # Update progress comment with completion status
             review_duration = int(time.time() - review_start_time)
             if progress_comment_id:
-                if has_new_feedback or (routed["review"] or follow_up_comments):
+                if agent_had_error:
+                    completion_msg = (
+                        f"⚠️ Baloo review failed after {review_duration}s "
+                        f"({agent_metadata.get('error_category') or 'agent_error'}). "
+                        "**This PR was not reviewed** - do not read the absence of "
+                        "findings as an approval."
+                    )
+                elif has_new_feedback or (routed["review"] or follow_up_comments):
                     # Review posted findings - update with summary
                     counts = count_by_severity(decision_comments)
                     completion_msg = (
@@ -1845,9 +1867,6 @@ async def process_pr_review(
                     documentation_metadata,
                 )
 
-                # Detect agent soft-failures: agent caught an error
-                # internally and returned 0 findings
-                agent_had_error = review_metadata.get("agent_error", False)
                 error_category = review_metadata.get("error_category")
                 error_detail = review_metadata.get("error_detail")
 

--- a/docs/features/review-agent.md
+++ b/docs/features/review-agent.md
@@ -50,6 +50,15 @@ When the PR description contains a `## Review guidance for Baloo` section, Baloo
 
 Authors: see [How to Get the Most Out of Baloo](../how-to-get-the-most.md) for how to write falsifiable, diff-anchored checks.
 
+## Failure Handling
+
+When the agent terminates with an error stop reason or returns no structured
+output, Baloo sets `agent_error` in the review metadata, logs the raw PI message
+(so unknown error shapes stay diagnosable), records the review as `agent_error`
+in the database, and suppresses the approval decision — the PR gets a ⚠️ comment
+saying it was not reviewed, never an approval. See
+[severity-routing](severity-routing.md#approval-decision-logic).
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/docs/features/severity-routing.md
+++ b/docs/features/severity-routing.md
@@ -49,8 +49,14 @@ The agent assigns severity based on these guidelines:
 ## Approval Decision Logic
 
 ```
+Agent returned an error  →  Comment only (⚠️ warning posted; PR is NOT approved)
 CRITICAL or HIGH found (inline or general)  →  Request Changes
 No blocking issues + high fidelity score  →  Approve
 No blocking issues + auto-approve enabled  →  Approve
 Otherwise  →  Comment only (no approval or rejection)
 ```
+
+A failed agent run is never treated as a clean slate. A failing agent returns
+zero findings, which would otherwise satisfy the auto-approve branch above, so
+`agent_error` short-circuits the decision: Baloo approves nothing and edits its
+progress comment to say the PR was not reviewed.

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -1160,3 +1160,30 @@ class TestGeneralFindingsPosting:
             else posted_blocking[0].kwargs.get("review_result")
         )
         assert result_arg.comments == []
+
+
+# ---------------------------------------------------------------------------
+# Agent failure must never look like an approval
+# ---------------------------------------------------------------------------
+
+
+class TestAgentErrorSuppressesApproval:
+    @pytest.mark.asyncio
+    async def test_agent_error_posts_no_approval_and_flags_failure(self):
+        gc = _make_github_client()
+        agent = _make_agent(
+            comments=[],
+            approve=True,
+            request_changes=False,
+            metadata={"agent_error": True, "error_category": "no_output"},
+        )
+
+        with patch("baloo.config.settings.settings.review_auto_approve", True):
+            await _run_review(gc, agent, notify_progress=True)
+
+        for call in gc.post_review.call_args_list:
+            result_arg = call.args[2] if len(call.args) >= 3 else call.kwargs.get("review_result")
+            assert not (result_arg and result_arg.approve), "Must not approve a failed review"
+
+        body = gc.edit_comment.call_args.args[2]
+        assert "failed" in body and "not reviewed" in body


### PR DESCRIPTION
## Problem

Baloo was down for three days and kept posting `✅ No critical or high severity issues found. Safe to merge!` plus an approval on every PR — 11-second "reviews" that never ran.

When the PI agent fails, `BalooAgent.review_pr` sets `metadata["agent_error"]` and returns zero comments. The orchestrator recomputed the decision from findings alone (`DecisionEngine.make_decision([])` → `review_auto_approve` → `True`) and ignored the error flag entirely. Zero findings from a dead agent is indistinguishable from a clean PR.

The DB row was already marked `agent_error` the whole time. Only the GitHub side lied.

## Fix

- `orchestrator.py` — when `agent_error` is set, force `approve = request_changes = False` and log the category/detail at ERROR.
- Progress comment now reads `⚠️ Baloo review failed after Ns (no_output). **This PR was not reviewed** ...` instead of `No issues found!`.
- `pi_runtime.py` — dump the raw PI message when an error stop reason has no extractable detail, so an unknown error shape is still diagnosable.

## Test

One test in `tests/review/test_orchestrator.py`: agent error + `review_auto_approve=True` must post no approving review and must flag the failure in the progress comment. Verified it fails without the guard. Full suite: 916 passed.

## Not in scope

No alerting — there is no Slack/Sentry hook in this repo, and `review_status="agent_error"` already lands in the DB and dashboard counters. Worth a separate change if we want a page instead of a PR comment.