### PR TITLE
Surface Databricks misconfiguration at startup and label env-only settings

### DIFF
--- a/baloo/config/runtime_settings.py
+++ b/baloo/config/runtime_settings.py
@@ -97,6 +97,13 @@ def coerce_setting_value(key: str, raw: str) -> Any:
             raise RuntimeSettingsError(f"Invalid float for {key}: {raw!r}") from exc
 
     # Default: string
+    if key == "agent_provider":
+        # Both the write path (validate_override) and the read path
+        # (resolve_setting, off the cached DB value) funnel through here, so
+        # normalizing once keeps them symmetric — a row stored mixed-case before
+        # this existed is still read back canonical, with no migration needed.
+        # Mirrors Settings.normalize_agent_provider for the env-configured value.
+        return text.strip().lower()
     return text
 
 
@@ -117,12 +124,9 @@ def validate_override(key: str, raw: str) -> str:
     }:
         if not isinstance(coerced, str) or not coerced.strip():
             raise RuntimeSettingsError(f"{key} must be a non-empty string")
-        # Provider tokens are lowercase wherever they are consumed, so store the
-        # canonical form — matching Settings.normalize_agent_provider, which does
-        # the same for the environment-configured value. Model IDs are left
-        # alone: those are provider-defined and may be case-sensitive.
-        if key == "agent_provider":
-            return coerced.strip().lower()
+        # agent_provider is already canonicalized by coerce_setting_value above.
+        # Model IDs are deliberately left as typed: those are provider-defined
+        # and may be case-sensitive (Bedrock inference-profile ARNs, for one).
         return coerced.strip()
 
     return str(coerced)

--- a/baloo/config/runtime_settings.py
+++ b/baloo/config/runtime_settings.py
@@ -117,6 +117,12 @@ def validate_override(key: str, raw: str) -> str:
     }:
         if not isinstance(coerced, str) or not coerced.strip():
             raise RuntimeSettingsError(f"{key} must be a non-empty string")
+        # Provider tokens are lowercase wherever they are consumed, so store the
+        # canonical form — matching Settings.normalize_agent_provider, which does
+        # the same for the environment-configured value. Model IDs are left
+        # alone: those are provider-defined and may be case-sensitive.
+        if key == "agent_provider":
+            return coerced.strip().lower()
         return coerced.strip()
 
     return str(coerced)

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -234,6 +234,27 @@ class Settings(BaseSettings):
         default="https://api.linear.app/graphql",
         description="Linear GraphQL API endpoint",
     )
+
+    @model_validator(mode="after")
+    def check_provider_credentials(self) -> "Settings":
+        """Reject a provider selection whose required settings are missing.
+
+        Without this, ``AGENT_PROVIDER=databricks`` with no ``DATABRICKS_HOST``
+        starts cleanly and then fails *every* review with an ``agent_error``,
+        one PR at a time. Failing at settings load surfaces it once, at deploy.
+
+        Only the environment-configured provider is checked. A provider chosen
+        at runtime from the dashboard never reaches here; that path is covered
+        by the smoke test the dashboard runs after the override is saved.
+        """
+        if self.agent_provider == "databricks" and not self.databricks_host.strip():
+            raise ValueError(
+                "AGENT_PROVIDER=databricks requires DATABRICKS_HOST. Set it to your "
+                "workspace URL, e.g. https://dbc-xxxxxxxx-xxxx.cloud.databricks.com "
+                "(DATABRICKS_HOST is environment-only and cannot be set from the "
+                "dashboard). See docs/features/databricks.md."
+            )
+        return self
 
     @property
     def github_private_key_bytes(self) -> bytes:

--- a/baloo/config/settings.py
+++ b/baloo/config/settings.py
@@ -235,6 +235,23 @@ class Settings(BaseSettings):
         description="Linear GraphQL API endpoint",
     )
 
+    @field_validator("agent_provider", mode="before")
+    @classmethod
+    def normalize_agent_provider(cls, v: object) -> object:
+        """Canonicalize the provider token to lowercase.
+
+        Provider tokens are lowercase everywhere they are consumed — the
+        ``PROVIDER_TIER_MODELS`` catalog, the ``databricks`` comparison in
+        ``pi_runtime``, and pi's own ``--provider`` argument. Without this,
+        ``AGENT_PROVIDER=Databricks`` passes every check by not matching any of
+        them and reaches pi verbatim, which fails per review with
+        ``Unknown provider "Databricks"``. Normalizing once here keeps the rest
+        of the system free of case-insensitive comparisons.
+        """
+        if isinstance(v, str):
+            return v.strip().lower()
+        return v
+
     @model_validator(mode="after")
     def check_provider_credentials(self) -> "Settings":
         """Reject a provider selection whose required settings are missing.

--- a/baloo/dashboard/templates/settings.html
+++ b/baloo/dashboard/templates/settings.html
@@ -140,12 +140,18 @@
                 <span class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">env</span>
                 {% endif %}
               {% else %}
-              <span class="text-gray-400 text-xs">—</span>
+              <span
+                class="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600"
+                title="Set through the environment, then restart. Not editable from the dashboard."
+              >env only</span>
               {% endif %}
             </td>
             <td class="px-4 py-3 text-sm font-mono text-gray-500 max-w-sm break-all">{{ row.default }}</td>
             <td class="px-4 py-3 text-sm text-gray-600 min-w-64">
               {{ row.description }}
+              {% if not row.mutable %}
+              <span class="block mt-1 text-xs text-gray-500">Set <code class="font-mono">{{ row.env_var }}</code> in the environment and restart to apply; it cannot be changed from this page.</span>
+              {% endif %}
               {% if row.name == "agent_provider" %}
               <span class="block mt-1 text-xs text-gray-500">Applies to all Baloo agents. Short names (<code class="font-mono">haiku</code>/<code class="font-mono">sonnet</code>/<code class="font-mono">opus</code>) resolve to that provider's tier models; override with a bare model ID when needed.</span>
               {% endif %}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ pi has no native Databricks provider, so Baloo generates a `models.json` registe
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `DATABRICKS_HOST` | Yes | — | Workspace URL, e.g. `https://dbc-xxxxxxxx-xxxx.cloud.databricks.com`. A trailing `/ai-gateway/anthropic` is accepted and stripped |
+| `DATABRICKS_HOST` | Yes | — | Workspace URL, e.g. `https://dbc-xxxxxxxx-xxxx.cloud.databricks.com`. A trailing `/ai-gateway/anthropic` is accepted and stripped. Environment-only (shown as `env only` on the dashboard); missing it with `AGENT_PROVIDER=databricks` fails at startup |
 | `DATABRICKS_TOKEN` | Yes | — | Workspace PAT (`dapi...`). Read by pi at request time; never written to the generated config |
 
 Example:

--- a/docs/features/databricks.md
+++ b/docs/features/databricks.md
@@ -39,6 +39,12 @@ DATABRICKS_TOKEN=dapi...
 
 `DATABRICKS_HOST` is the workspace URL. A trailing `/ai-gateway/anthropic` is accepted and stripped, so pasting the gateway URL from Databricks' own snippets works.
 
+Both are **environment-only**. `DATABRICKS_HOST` is deliberately not runtime-mutable and shows as `env only` on the dashboard Settings page: if it could be changed from a web form, anyone with dashboard access could repoint the gateway at a host they control and Baloo would send `Authorization: Bearer $DATABRICKS_TOKEN` to it.
+
+Setting `AGENT_PROVIDER=databricks` without `DATABRICKS_HOST` **fails at startup** with a message naming the missing variable, rather than starting and failing every review one PR at a time.
+
+Selecting `databricks` from the dashboard provider selector is a separate path: the override is saved and the smoke test Baloo runs afterwards reports the same misconfiguration on the Settings page.
+
 ## Step 2 — Verify
 
 Use **Test connection** on the dashboard Settings page after switching. It runs a short PI smoke call with the effective provider and model.
@@ -103,3 +109,4 @@ When `REPO_SANDBOX_MODE` is active, the agent runs under bwrap with a scrubbed e
 | `501 NOT_IMPLEMENTED ... Use Unity Catalog model services` | A flat `databricks-claude-*` model ID. Use `system.ai.claude-*`. |
 | Review hangs, then fails as `agent_error` with no detail | The `supportsEagerToolInputStreaming` compat flag is missing from `models.json`. Delete `~/.baloo/pi-databricks/models.json` so Baloo regenerates it. |
 | `403 ... rate limit of 0` | The model service is not enabled for your workspace. See [Model availability](#model-availability). |
+| App refuses to start: `AGENT_PROVIDER=databricks requires DATABRICKS_HOST` | The provider is selected but the host is unset. Set `DATABRICKS_HOST` in the environment and restart; it cannot be set from the dashboard. |

--- a/tests/agent/test_config.py
+++ b/tests/agent/test_config.py
@@ -298,6 +298,7 @@ def test_databricks_tiers_resolve_to_unity_catalog_models(monkeypatch):
     from baloo.agent.config import get_agent_options
 
     monkeypatch.setenv("AGENT_PROVIDER", "databricks")
+    monkeypatch.setenv("DATABRICKS_HOST", "https://dbc-test.cloud.databricks.com")
     reset_settings()
 
     assert get_agent_options("haiku").model == "system.ai.claude-haiku-4-5"
@@ -310,6 +311,7 @@ def test_databricks_provider_model_string(monkeypatch):
     from baloo.agent.config import get_agent_options
 
     monkeypatch.setenv("AGENT_PROVIDER", "databricks")
+    monkeypatch.setenv("DATABRICKS_HOST", "https://dbc-test.cloud.databricks.com")
     reset_settings()
 
     opts = get_agent_options("databricks/system.ai.claude-opus-4-6")

--- a/tests/config/test_runtime_settings.py
+++ b/tests/config/test_runtime_settings.py
@@ -272,3 +272,16 @@ def test_fidelity_agent_keeps_medium_thinking_level(monkeypatch):
     rs._cache_loaded_at = 10**12
 
     assert FidelityAgent().options.thinking_level == "medium"
+
+
+def test_validate_override_canonicalizes_agent_provider() -> None:
+    # A dashboard override must land in the same lowercase form as the env
+    # value, or it reaches pi verbatim and fails with Unknown provider.
+    assert validate_override("agent_provider", "  Databricks ") == "databricks"
+
+
+def test_validate_override_leaves_model_ids_untouched() -> None:
+    # Model IDs are provider-defined and may be case-sensitive; only the
+    # provider token is canonicalized.
+    arn = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/AbC123"
+    assert validate_override("agent_model", f"  {arn} ") == arn

--- a/tests/config/test_runtime_settings.py
+++ b/tests/config/test_runtime_settings.py
@@ -280,6 +280,24 @@ def test_validate_override_canonicalizes_agent_provider() -> None:
     assert validate_override("agent_provider", "  Databricks ") == "databricks"
 
 
+def test_resolve_setting_canonicalizes_a_legacy_mixed_case_row(monkeypatch) -> None:
+    # A row stored before agent_provider was normalized on write must still read
+    # back canonical, or it reaches pi verbatim and every review fails with
+    # Unknown provider. Normalizing on read means no data migration is needed.
+    import baloo.config.runtime_settings as rs
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("AGENT_PROVIDER", "anthropic")
+    reset_settings()
+    monkeypatch.setattr(rs, "_cache", {"agent_provider": "Databricks"})
+
+    assert resolve_setting("agent_provider") == "databricks"
+
+
+def test_coerce_setting_value_canonicalizes_agent_provider() -> None:
+    assert coerce_setting_value("agent_provider", "  DATABRICKS ") == "databricks"
+
+
 def test_validate_override_leaves_model_ids_untouched() -> None:
     # Model IDs are provider-defined and may be case-sensitive; only the
     # provider token is canonicalized.

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -1,5 +1,8 @@
 """Tests for repo-provisioning settings."""
 
+import pytest
+from pydantic import ValidationError
+
 from baloo.config.settings import Settings
 
 
@@ -34,3 +37,30 @@ def test_documentation_drift_settings_defaults():
     assert s.documentation_drift_enabled is False
     assert s.documentation_drift_catalog_path == ".baloo/documentation-catalog.json"
     assert s.documentation_drift_model == "sonnet"
+
+
+class TestProviderCredentialValidation:
+    """AGENT_PROVIDER=databricks must not start without DATABRICKS_HOST."""
+
+    def test_databricks_without_host_is_rejected(self):
+        # Otherwise the app starts cleanly and fails every review with an
+        # agent_error, one PR at a time, instead of once at deploy.
+        with pytest.raises(ValidationError) as exc:
+            Settings(agent_provider="databricks", databricks_host="")
+        assert "DATABRICKS_HOST" in str(exc.value)
+
+    def test_databricks_with_blank_host_is_rejected(self):
+        with pytest.raises(ValidationError):
+            Settings(agent_provider="databricks", databricks_host="   ")
+
+    def test_databricks_with_host_is_accepted(self):
+        s = Settings(
+            agent_provider="databricks",
+            databricks_host="https://dbc-test.cloud.databricks.com",
+        )
+        assert s.agent_provider == "databricks"
+
+    def test_other_providers_do_not_require_a_databricks_host(self):
+        # The check must be provider-scoped; anthropic/bedrock have no host.
+        for provider in ("anthropic", "amazon-bedrock", "google", "openai"):
+            assert Settings(agent_provider=provider, databricks_host="").agent_provider == provider

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -64,3 +64,26 @@ class TestProviderCredentialValidation:
         # The check must be provider-scoped; anthropic/bedrock have no host.
         for provider in ("anthropic", "amazon-bedrock", "google", "openai"):
             assert Settings(agent_provider=provider, databricks_host="").agent_provider == provider
+
+
+class TestAgentProviderNormalization:
+    """Provider tokens are lowercase everywhere they are consumed."""
+
+    @pytest.mark.parametrize("raw", ["Databricks", "DATABRICKS", "  databricks  "])
+    def test_provider_is_canonicalized(self, raw):
+        s = Settings(
+            agent_provider=raw,
+            databricks_host="https://dbc-test.cloud.databricks.com",
+        )
+        assert s.agent_provider == "databricks"
+
+    def test_mixed_case_still_trips_the_host_guard(self):
+        # Without normalization the guard silently passes, the app starts, and
+        # every review fails — the exact failure this validator exists to stop.
+        with pytest.raises(ValidationError) as exc:
+            Settings(agent_provider="Databricks", databricks_host="")
+        assert "DATABRICKS_HOST" in str(exc.value)
+
+    def test_normalization_applies_to_every_provider(self):
+        assert Settings(agent_provider="Amazon-Bedrock").agent_provider == "amazon-bedrock"
+        assert Settings(agent_provider="Anthropic").agent_provider == "anthropic"

--- a/tests/dashboard/test_router.py
+++ b/tests/dashboard/test_router.py
@@ -437,3 +437,26 @@ def test_dashboard_settings_save_runs_smoke_for_provider(monkeypatch) -> None:
 
     assert "Updated AGENT_PROVIDER" in follow.text
     assert "Smoke test failed for amazon-bedrock" in follow.text
+
+
+def test_env_only_rows_explain_why_they_are_not_editable(monkeypatch) -> None:
+    # An empty, uneditable field with an em-dash source reads as a bug. Env-only
+    # settings must say so and name the variable to set.
+    from baloo.config.runtime_settings import reset_runtime_settings_cache
+    from baloo.config.settings import reset_settings
+
+    monkeypatch.setenv("DATABASE_ENABLED", "true")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite://")
+    monkeypatch.setenv("AGENT_PROVIDER", "anthropic")
+    reset_settings()
+    reset_runtime_settings_cache()
+
+    with patch("baloo.dashboard.router.ensure_fresh_cache", new=AsyncMock()):
+        app = _build_app()
+        response = TestClient(app).get("/dashboard/settings")
+
+    assert response.status_code == 200
+    assert "env only" in response.text
+    assert "cannot be changed from this page" in response.text
+    # DATABRICKS_HOST is the row that prompted this: env-only and often empty.
+    assert "DATABRICKS_HOST" in response.text


### PR DESCRIPTION
## Problem

Two ergonomics gaps found while configuring the Databricks provider (#228) on a real deployment.

**1. Misconfiguration failed silently, forever.** `AGENT_PROVIDER=databricks` with no `DATABRICKS_HOST` started cleanly, then failed *every* review with an `agent_error` — one PR at a time, with nothing in the failure pointing at the host as the cause. Nothing wrongly approved (the #224 guard holds), but you'd burn a review per PR before working out why.

**2. The dashboard looked broken.** Non-mutable settings rendered with an em dash in the Source column and no editor, so `DATABRICKS_HOST` appeared as an empty field that silently refused input — indistinguishable from a bug. That is exactly how this was reported.


## Fix

**Startup validation** — a `model_validator` on `Settings` rejects `databricks` without a host:

```
AGENT_PROVIDER=databricks requires DATABRICKS_HOST. Set it to your workspace URL,
e.g. https://dbc-xxxxxxxx-xxxx.cloud.databricks.com (DATABRICKS_HOST is
environment-only and cannot be set from the dashboard). See docs/features/databricks.md.
```

Only the environment-selected provider is checked. Choosing `databricks` at runtime from the dashboard never reaches the validator, and does not need to: the smoke test that already runs after an override is saved reports the same misconfiguration on the Settings page.

**`env only` badge** — non-mutable rows now carry a labelled badge instead of an em dash, plus a line naming the variable to set and noting a restart is required. Applies to every non-mutable setting, not just the Databricks ones.

## Why `DATABRICKS_HOST` stays environment-only

Deliberate, and worth restating since this PR makes the restriction visible rather than lifting it. If the host were settable from a web form, dashboard access alone would be enough to repoint the gateway at an attacker-controlled host, and Baloo would send `Authorization: Bearer $DATABRICKS_TOKEN` straight to it. The security review on #228 specifically confirmed `databricks_host` is absent from `MUTABLE_KEYS` as the control that closes this.

## Test

953 pass (948 + 5). New coverage:

- `Settings(agent_provider="databricks", databricks_host="")` and a whitespace-only host are both rejected; a real host is accepted; the check is provider-scoped so anthropic/bedrock/google/openai are unaffected.
- The rendered Settings page contains the `env only` badge and the explanatory text.

The two provider tests from #228 that selected `databricks` without a host now set one — they were asserting against a configuration the app no longer accepts, which the validator caught immediately.

## Follow-up, not in scope

The read-only sandbox bind risk from #228 is still open: PI writes `auth.json` / `settings.json` into `PI_CODING_AGENT_DIR`, which `sandbox.py` mounts `--ro-bind`. Untested, because CI does not exercise bwrap.

