### PR TITLE
Fix documentation drift prompt context overflow

### DIFF
--- a/baloo/documentation/prompts.py
+++ b/baloo/documentation/prompts.py
@@ -7,6 +7,11 @@ import json
 from baloo.documentation.models import DocumentationWorkItem
 from baloo.github.models import PRContext
 
+# ponytail: flat char cap instead of token counting. The agent has the repo
+# checked out and can read any file it needs, so a clipped diff is enough
+# signal. Raise if drift analysis starts missing large PRs.
+MAX_DIFF_CHARS = 60_000
+
 DOCUMENTATION_DRIFT_SYSTEM_PROMPT = """You are Baloo's documentation drift reviewer.
 
 You run during pull request review. Your audience is the PR author. Your job is
@@ -38,13 +43,19 @@ def build_documentation_drift_prompt(
                 "additions": file.additions,
                 "deletions": file.deletions,
                 "changes": file.changes,
-                "patch": file.patch,
             }
             for file in pr_context.files_changed
         ],
         indent=2,
         sort_keys=True,
     )
+
+    diff = pr_context.diff or ""
+    if len(diff) > MAX_DIFF_CHARS:
+        diff = (
+            diff[:MAX_DIFF_CHARS]
+            + "\n\n[diff truncated - read the changed files in the repo checkout for full context]"
+        )
 
     return f"""Review this pull request for documentation drift.
 
@@ -103,6 +114,6 @@ Changed files:
 
 PR diff:
 ```diff
-{pr_context.diff}
+{diff}
 ```
 """

--- a/tests/documentation/test_prompts.py
+++ b/tests/documentation/test_prompts.py
@@ -4,7 +4,7 @@ from baloo.documentation.models import (
     DocumentationWorkItem,
     DocumentationWorkItemMatch,
 )
-from baloo.documentation.prompts import build_documentation_drift_prompt
+from baloo.documentation.prompts import MAX_DIFF_CHARS, build_documentation_drift_prompt
 from baloo.github.models import (
     FileChange,
     PRContext,
@@ -111,3 +111,17 @@ def test_prompt_forbids_file_edits():
 
     assert "Do not edit files" in prompt
     assert "Do not create branches" in prompt
+
+
+def test_prompt_truncates_oversized_diff():
+    pr_context = _pr_context()
+    pr_context.diff = "x" * (MAX_DIFF_CHARS + 5000)
+
+    prompt = build_documentation_drift_prompt(
+        pr_context=pr_context,
+        work_item=_work_item(),
+        catalog_path=".baloo/documentation-catalog.json",
+    )
+
+    assert "[diff truncated" in prompt
+    assert len(prompt) < MAX_DIFF_CHARS + 5000

--- a/tests/documentation/test_prompts.py
+++ b/tests/documentation/test_prompts.py
@@ -124,4 +124,23 @@ def test_prompt_truncates_oversized_diff():
     )
 
     assert "[diff truncated" in prompt
-    assert len(prompt) < MAX_DIFF_CHARS + 5000
+    # Pin the cap directly rather than bounding the whole prompt: a total-length
+    # assertion passes even with truncation removed if the template is small,
+    # and fails spuriously when the template grows.
+    assert "x" * MAX_DIFF_CHARS in prompt
+    assert "x" * (MAX_DIFF_CHARS + 1) not in prompt
+
+
+def test_prompt_keeps_undersized_diff_intact():
+    """The other half of the invariant: nothing under the cap gets clipped."""
+    pr_context = _pr_context()
+    pr_context.diff = "y" * 100
+
+    prompt = build_documentation_drift_prompt(
+        pr_context=pr_context,
+        work_item=_work_item(),
+        catalog_path=".baloo/documentation-catalog.json",
+    )
+
+    assert "[diff truncated" not in prompt
+    assert "y" * 100 in prompt


### PR DESCRIPTION
## Problem

Documentation drift analysis was failing on large PRs:

```
WARNING [baloo.documentation.analyzer] Documentation drift analysis failed: Prompt is too long - PR diff exceeds context window
RuntimeError: Prompt is too long - PR diff exceeds context window
```

`build_documentation_drift_prompt` embedded the PR diff **twice**, both unbounded:

1. Per-file `patch` inside the `Changed files` JSON block
2. The full `pr_context.diff` in the `PR diff` block

Every other prompt in the codebase caps the diff (e.g. `orchestrator.py` truncates at 12k chars); this one did not.

## Change

- Drop `patch` from the changed-files JSON — it is a pure duplicate of the diff block
- Cap the diff at `MAX_DIFF_CHARS = 60_000` with a truncation note telling the agent to read the changed files in the repo checkout for full context

The drift agent runs with the repo checked out and read/grep/find tools, so a clipped diff is enough signal to decide what to inspect.

## Test

`test_prompt_truncates_oversized_diff` — oversized diff is clipped and the truncation marker is present.