### PR TITLE
Stop losing review findings to three silent failure paths

### DIFF
--- a/baloo/agent/config.py
+++ b/baloo/agent/config.py
@@ -17,10 +17,13 @@ SHORT_NAME_TIERS: dict[str, tuple[str, int]] = {
     # Economy — FP verification, thread replies, simple reviews
     "flash": ("economy", 10),
     "haiku": ("economy", 10),
-    # Standard — default code reviews
-    "standard": ("standard", 20),
-    "gemini-pro": ("standard", 20),
-    "sonnet": ("standard", 20),
+    # Standard — default code reviews. 30, not 20: at 20 the finished-run
+    # histogram decayed smoothly to ~11 runs at turn 19 and then spiked to 86
+    # at exactly 20, with a further 66 aborting there having produced no
+    # output — a wall, not a distribution.
+    "standard": ("standard", 30),
+    "gemini-pro": ("standard", 30),
+    "sonnet": ("standard", 30),
     # Premium — complex / security-sensitive reviews
     "premium": ("premium", 30),
     "gemini-3.1-pro": ("premium", 30),

--- a/baloo/documentation/models.py
+++ b/baloo/documentation/models.py
@@ -42,7 +42,9 @@ class DocumentationWorkItem(BaseModel):
 class DocumentationDriftFinding(BaseModel):
     doc_path: str
     verdict: Literal["required", "optional", "not_needed"]
-    rationale: str
+    # The prompt only asks for a rationale on stale docs, so the model routinely
+    # omits it on `not_needed` entries. Requiring it failed the whole result.
+    rationale: str = ""
     evidence: list[str] = Field(default_factory=list)
     suggested_update: str | None = None
 

--- a/baloo/documentation/report.py
+++ b/baloo/documentation/report.py
@@ -96,7 +96,8 @@ def _format_findings(findings: list[DocumentationDriftFinding]) -> list[str]:
         lines.append(f"- `{finding.doc_path}`")
         if finding.suggested_update:
             lines.append(f"  - {finding.suggested_update}")
-        lines.append(f"  - Rationale: {finding.rationale}")
+        if finding.rationale:
+            lines.append(f"  - Rationale: {finding.rationale}")
         if finding.evidence:
             evidence = ", ".join(f"`{item}`" for item in finding.evidence)
             lines.append(f"  - Evidence: {evidence}")

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -681,16 +681,13 @@ def _calculate_similarity(s1: str, s2: str) -> float:
     return sim
 
 
-def _build_db_findings(
-    comments: list[ReviewComment],
-    posted_review_result: PostedReviewResult | None,
-) -> list[dict]:
-    """Build the findings list for DB storage, excluding dropped comments."""
-    dropped_ids: set[int] = (
-        {id(d.comment) for d in posted_review_result.dropped}
-        if posted_review_result and posted_review_result.dropped
-        else set()
-    )
+def _build_db_findings(comments: list[ReviewComment]) -> list[dict]:
+    """Build the findings list for DB storage.
+
+    Findings GitHub refused to place inline (line not in the diff) are kept:
+    the review still blocked on them, so dropping them left the dashboard
+    showing a `changes_requested` review with zero findings and no reason.
+    """
     return [
         {
             "file_path": c.path,
@@ -700,7 +697,6 @@ def _build_db_findings(
             "body": c.body,
         }
         for c in comments
-        if id(c) not in dropped_ids
     ]
 
 
@@ -1896,7 +1892,7 @@ async def process_pr_review(
                     fidelity_score=(fidelity_result.fidelity_score if fidelity_result else None),
                     error_message=error_detail,
                     error_category=error_category,
-                    findings=_build_db_findings(decision_comments, posted_review_result),
+                    findings=_build_db_findings(decision_comments),
                 )
 
                 await ReviewService.complete_review(

--- a/tests/agent/test_config.py
+++ b/tests/agent/test_config.py
@@ -21,7 +21,7 @@ class TestGetAgentOptions:
         options = get_agent_options("sonnet")
         assert options.model == "claude-sonnet-4-6"
         assert options.provider == "anthropic"
-        assert options.max_turns == 20
+        assert options.max_turns == 30
 
     def test_get_options_with_opus_short_name(self):
         options = get_agent_options("opus")
@@ -45,7 +45,7 @@ class TestGetAgentOptions:
         options = get_agent_options("gemini-pro")
         assert options.model == "gemini-3.6-flash"
         assert options.provider == "google"
-        assert options.max_turns == 20
+        assert options.max_turns == 30
 
     def test_flash_on_anthropic_maps_to_economy_claude(self, monkeypatch):
         monkeypatch.setenv("AGENT_PROVIDER", "anthropic")
@@ -133,7 +133,7 @@ def test_standard_alias_resolves_to_sonnet():
     opts = get_agent_options("standard")
     assert opts.model == "claude-sonnet-4-6"
     assert opts.provider == "anthropic"
-    assert opts.max_turns == 20
+    assert opts.max_turns == 30
 
 
 def test_premium_alias_resolves_on_google(monkeypatch):
@@ -202,7 +202,7 @@ def test_bedrock_short_names_use_bedrock_tiers(monkeypatch):
     standard = get_agent_options("sonnet")
     assert standard.provider == "amazon-bedrock"
     assert standard.model == "us.anthropic.claude-sonnet-4-6"
-    assert standard.max_turns == 20
+    assert standard.max_turns == 30
 
     premium = get_agent_options("opus")
     assert premium.provider == "amazon-bedrock"
@@ -291,7 +291,7 @@ def test_resolve_short_name_helper():
     provider, model_id, max_turns = resolve_short_name("sonnet", "amazon-bedrock")
     assert provider == "amazon-bedrock"
     assert model_id == "us.anthropic.claude-sonnet-4-6"
-    assert max_turns == 20
+    assert max_turns == 30
 
 
 def test_databricks_tiers_resolve_to_unity_catalog_models(monkeypatch):

--- a/tests/documentation/test_models.py
+++ b/tests/documentation/test_models.py
@@ -126,3 +126,30 @@ def test_work_item_state_fields():
     assert item.has_docs_already_changed is True
     assert item.has_catalog_gaps is True
     assert item.needs_analysis is True
+
+
+def test_not_needed_finding_parses_without_a_rationale():
+    """The model omits `rationale` on `not_needed` entries; that must not fail.
+
+    Regression: 32 production drift runs died with
+    `not_needed.0.rationale Field required`, losing the whole result.
+    """
+    result = DocumentationDriftResult.model_validate(
+        {
+            "required_updates": [],
+            "optional_updates": [],
+            "not_needed": [{"doc_path": "docs/DATA_SOURCES.md", "verdict": "not_needed"}],
+        }
+    )
+
+    assert result.not_needed[0].rationale == ""
+
+
+def test_report_omits_the_rationale_line_when_empty():
+    from baloo.documentation.report import _format_findings
+
+    lines = _format_findings(
+        [DocumentationDriftFinding(doc_path="docs/x.md", verdict="not_needed")]
+    )
+
+    assert not any("Rationale" in line for line in lines)

--- a/tests/review/test_orchestrator.py
+++ b/tests/review/test_orchestrator.py
@@ -1187,3 +1187,29 @@ class TestAgentErrorSuppressesApproval:
 
         body = gc.edit_comment.call_args.args[2]
         assert "failed" in body and "not reviewed" in body
+
+
+def test_build_db_findings_keeps_findings_github_could_not_place_inline():
+    """A blocking finding GitHub refuses to place inline must still be persisted.
+
+    Regression: production review 7567 landed as `changes_requested` with zero
+    rows in `findings`, because the only finding was dropped for an invalid
+    diff line. The dashboard showed a blocked review with no reason.
+    """
+    from baloo.github.models import FindingCategory, ReviewComment, ReviewSeverity
+    from baloo.review.orchestrator import _build_db_findings
+
+    dropped = ReviewComment(
+        path="baloo/agent/config.py",
+        line=999,
+        body="Line is outside the diff hunk.",
+        severity=ReviewSeverity.HIGH,
+        category=FindingCategory.BUGS,
+    )
+    placed = ReviewComment(path="main.py", line=1, body="Placed fine.")
+
+    rows = _build_db_findings([dropped, placed])
+
+    assert [r["file_path"] for r in rows] == ["baloo/agent/config.py", "main.py"]
+    assert rows[0]["line_number"] == 999
+    assert rows[0]["severity"] == ReviewSeverity.HIGH


### PR DESCRIPTION
Three unrelated defects found while reading 11 days of production logs on the `baloo-agent` host. Each ends the same way: findings the agent produced never reach the user, and nothing surfaces as an error.

Unrelated enough to split if you'd rather review them separately — they're grouped because they came out of one log pass.

## 1. Drift results discarded over a missing rationale

`DocumentationDriftFinding` required `rationale`, but `prompts.py` only asks for one on stale docs, so the model routinely omits it on `not_needed` entries. Pydantic then rejected the **entire** result — `required_updates` included:

```
pydantic_core.ValidationError: 6 validation errors for DocumentationDriftResult
not_needed.0.rationale
  Field required [type=missing, ...]
```

**32 production runs** died this way. The field now defaults to `""`, which is what `coerce_finding_lists` already substitutes on its own construction path — the schema was inconsistent with itself. `report.py` skips the Rationale line when empty.

## 2. Blocking findings vanished from the dashboard

`_build_db_findings` excluded any comment GitHub refused to place inline. Production review **7567** (`baloo-bear#230`):

```
WARNING Dropped 1/1 review finding(s) with invalid diff lines
INFO    Review completed: 1 blocking, 0 non-blocking
```

…landed as `changes_requested` with **zero rows** in `findings`. A blocked PR with no stated reason, and a log line the DB contradicts.

The review blocked on that finding, so it's now persisted. The posted/dropped distinction already lives in the logs and in the completion comment (`⚠️ N finding(s) could not be placed inline`), so nothing is lost by keeping the row. The exclusion arrived via the `#61` orchestrator refactor rather than as a deliberate product decision.

## 3. Standard-tier reviews truncated at the turn cap

Finished-run histogram across 475 `BalooAgent` runs:

```
turns:  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 | 20
runs:  11 14 26 26 32 23 29 20 12 21 14 20 14 16 13 13  8 11 | 86
```

Smooth decay to ~11 at turn 19, then **86 at exactly 20** — plus 66 more that aborted there having produced no output. That's **152 of 475 runs (32%)** hitting a wall, not a distribution. Review 7567 used 19 turns on a 4-file scoped review.

Standard tier goes to 30. Economy stays at 10 — `FPVerifier` and `ThreadAgent` finish in one turn.

## Testing

`965 passed`, ruff and black clean. Three regression tests added, one per fix; the five `test_config.py` assertions pinning `max_turns == 20` are updated to 30.

## Not covered here

Found in the same pass, but host config rather than repo changes: `bwrap` fails its probe under Docker's default seccomp profile (sandbox silently off, secrets unscrubbed — `#206` addresses the policy side), and `AGENT_PROVIDER` currently lives only in the `runtime_settings` DB row with no compose fallback.