### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "baloo"
-version = "2.2.1"
+version = "2.3.0"
 description = "AI-powered GitHub code review agent using PI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "baloo"
-version = "2.2.1"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Bumps the package version to 2.3.0 ahead of the `v2.3.0` release. `pyproject.toml` and the matching `uv.lock` entry only — no behaviour change.

The release itself is cut after this merges: a GitHub release on tag `v2.3.0` triggers `deploy.yml`, which builds and pushes `ghcr.io/bluebear-io/baloo-bear:2.3.0` and `:latest` with `BALOO_VERSION` baked in.

Minor rather than patch: 2.2.1 → 2.3.0 covers two new features (Databricks AI Gateway provider #228, startup misconfiguration surfacing #230) alongside the fixes.
