### PR TITLE
Salvage reviews at the turn cap and record real input tokens

### DIFF
--- a/baloo/agent/logger.py
+++ b/baloo/agent/logger.py
@@ -112,14 +112,26 @@ class ReviewLogger:
         )
 
     async def agent_completed(
-        self, tokens_in: int, tokens_out: int, cost: float, duration: float
+        self,
+        tokens_in: int,
+        tokens_out: int,
+        cost: float,
+        duration: float,
+        cache_read: int = 0,
+        cache_write: int = 0,
     ) -> None:
+        # Providers report almost all prompt volume as cache read/write and only
+        # the uncached delta as `input`, so tokens_in alone reads as ~1 per
+        # message. Record the split; the message shows the true input total.
+        total_in = tokens_in + cache_read + cache_write
         await self._log(
             "agent_completed",
-            f"Agent completed ({tokens_in} in / {tokens_out} out, ${cost:.4f}, {duration:.1f}s)",
+            f"Agent completed ({total_in} in / {tokens_out} out, ${cost:.4f}, {duration:.1f}s)",
             metadata={
                 "tokens_in": tokens_in,
                 "tokens_out": tokens_out,
+                "cache_read_tokens": cache_read,
+                "cache_write_tokens": cache_write,
                 "cost": cost,
                 "duration": duration,
             },

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -722,11 +722,27 @@ class PIAgentBase:
                 error_category="agent_error",
             )
         else:
+            if structured_output is None:
+                # A run that yields nothing is a real loss for every agent, but
+                # only BalooAgent's failure reaches reviews.review_status — the
+                # fidelity and documentation agents just log to stderr and
+                # return None. Record it here so aborts are countable per agent.
+                await review_logger.agent_error(
+                    error_message=(
+                        f"No structured output after {result.num_turns} turn(s), "
+                        f"${result.cost_usd:.4f} spent"
+                    ),
+                    error_category=(
+                        "max_turns_reached" if result.max_turns_reached else "no_output"
+                    ),
+                )
             await review_logger.agent_completed(
                 tokens_in=metadata.get("input_tokens", 0),
                 tokens_out=metadata.get("output_tokens", 0),
                 cost=metadata.get("cost_usd", 0),
                 duration=metadata.get("duration_seconds", 0),
+                cache_read=metadata.get("cache_read_tokens", 0),
+                cache_write=metadata.get("cache_write_tokens", 0),
             )
 
         return structured_output, metadata
@@ -738,6 +754,18 @@ class PIAgentBase:
     _JSON_RETRY_SYSTEM_PROMPT = (
         "You repair malformed JSON. "
         "Return only valid JSON with the same meaning and fields as the input."
+    )
+
+    # Turns held back so the agent can be told to wrap up and still have room to
+    # answer. Without it the cap arrives unannounced mid-exploration, PI is sent
+    # abort, and the entire run is discarded with zero findings — the turn-30
+    # wall seen in production. Raising max_turns only moves that wall.
+    _WRAPUP_RESERVE = 3
+
+    _WRAPUP_STEER = (
+        "You have {remaining} turn(s) left before this session is cut off. "
+        "Stop investigating now and return your final JSON response using only what "
+        "you have already found. A partial review is useful; no review is not."
     )
 
     _JSON_RETRY_PROMPT_TEMPLATE = """The malformed response is serialized below as a JSON object
@@ -880,6 +908,10 @@ Serialized payload:
         all_assistant_texts: list[str] = []
         turn_count = 0
         turn_tools: list[str] = []
+        # Steer the agent to finalize before the cap. A 1- or 2-turn decider has
+        # no room for the nudge, so it is pre-marked as sent and never fires.
+        wrapup_at = self.options.max_turns - self._WRAPUP_RESERVE
+        wrapup_sent = wrapup_at < 1
         # toolCallId -> (tool_name, target) captured at tool_execution_start so we
         # can attribute the outcome reported at tool_execution_end.
         pending_tools: dict[str, tuple[str, str | None]] = {}
@@ -909,6 +941,23 @@ Serialized payload:
                         tokens_out=result.output_tokens,
                     )
                 turn_tools = []
+                if not wrapup_sent and turn_count >= wrapup_at:
+                    wrapup_sent = True
+                    remaining = self.options.max_turns - turn_count
+                    logger.info(
+                        "%s: turn %d of %d — steering agent to wrap up",
+                        self.agent_name,
+                        turn_count,
+                        self.options.max_turns,
+                    )
+                    assert proc.stdin is not None
+                    proc.stdin.write(
+                        self._make_command(
+                            "steer",
+                            message=self._WRAPUP_STEER.format(remaining=remaining),
+                        ).encode("utf-8")
+                    )
+                    await proc.stdin.drain()
                 if turn_count >= self.options.max_turns:
                     result.max_turns_reached = True
                     if last_assistant_text:

--- a/baloo/agent/pi_runtime.py
+++ b/baloo/agent/pi_runtime.py
@@ -727,14 +727,23 @@ class PIAgentBase:
                 # only BalooAgent's failure reaches reviews.review_status — the
                 # fidelity and documentation agents just log to stderr and
                 # return None. Record it here so aborts are countable per agent.
+                #
+                # Text present means the agent did answer and the answer was
+                # malformed — a JSON-quality problem, not the turn cap silencing
+                # it mid-exploration. Keep the two apart so a count of
+                # max_turns_reached means only "cut off with nothing".
+                if result.assistant_text:
+                    category = "json_parse_failed"
+                    detail = f"{len(result.assistant_text)} chars of unparseable text"
+                else:
+                    category = "max_turns_reached" if result.max_turns_reached else "no_output"
+                    detail = "no assistant text"
                 await review_logger.agent_error(
                     error_message=(
-                        f"No structured output after {result.num_turns} turn(s), "
-                        f"${result.cost_usd:.4f} spent"
+                        f"No structured output after {result.num_turns} turn(s) "
+                        f"({detail}), ${result.cost_usd:.4f} spent"
                     ),
-                    error_category=(
-                        "max_turns_reached" if result.max_turns_reached else "no_output"
-                    ),
+                    error_category=category,
                 )
             await review_logger.agent_completed(
                 tokens_in=metadata.get("input_tokens", 0),

--- a/baloo/review/orchestrator.py
+++ b/baloo/review/orchestrator.py
@@ -1845,11 +1845,17 @@ async def process_pr_review(
                 )
 
                 # Aggregate costs and tokens
-                total_input_tokens = _total_review_tokens(
-                    "input_tokens",
-                    review_metadata,
-                    fidelity_metadata,
-                    documentation_metadata,
+                # Cache reads/writes ARE input tokens — providers just bill them
+                # separately and report `input` as the uncached delta only. Summing
+                # only "input_tokens" made reviews.tokens_input read ~1 per message.
+                total_input_tokens = sum(
+                    _total_review_tokens(
+                        key,
+                        review_metadata,
+                        fidelity_metadata,
+                        documentation_metadata,
+                    )
+                    for key in ("input_tokens", "cache_read_tokens", "cache_write_tokens")
                 )
                 total_output_tokens = _total_review_tokens(
                     "output_tokens",

--- a/tests/agent/test_logger.py
+++ b/tests/agent/test_logger.py
@@ -161,3 +161,45 @@ async def test_default_agent_label_is_review():
     row = mock_session.add.call_args[0][0]
     meta = json.loads(row.metadata_json)
     assert meta["agent"] == "review"
+
+
+class TestCacheTokenAccounting:
+    """Providers report nearly all prompt volume as cache read/write and only
+    the uncached delta as `input`, so tokens_in alone reads as ~1 per message.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_completed_records_cache_split(self):
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+
+        logger = ReviewLogger(review_id=42, session=mock_session)
+        await logger.agent_completed(
+            tokens_in=31,
+            tokens_out=8363,
+            cost=1.0573,
+            duration=171.2,
+            cache_read=240_000,
+            cache_write=27_000,
+        )
+
+        log_row = mock_session.add.call_args[0][0]
+        meta = json.loads(log_row.metadata_json)
+        assert meta["tokens_in"] == 31
+        assert meta["cache_read_tokens"] == 240_000
+        assert meta["cache_write_tokens"] == 27_000
+        # The human-readable line must show real input, not the uncached delta.
+        assert "267031 in" in log_row.message
+
+    @pytest.mark.asyncio
+    async def test_agent_completed_without_cache_is_unchanged(self):
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+
+        logger = ReviewLogger(review_id=42, session=mock_session)
+        await logger.agent_completed(tokens_in=1000, tokens_out=500, cost=0.05, duration=12.3)
+
+        log_row = mock_session.add.call_args[0][0]
+        assert "1000 in" in log_row.message
+        meta = json.loads(log_row.metadata_json)
+        assert meta["cache_read_tokens"] == 0

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -1159,3 +1159,153 @@ class TestDatabricksWiring:
     def test_unsandboxed_spawn_still_inherits(self):
         agent = PIAgentBase(PIAgentOptions(provider="anthropic", model="m"))
         assert agent._subprocess_env(sandbox_active=False) is None
+
+
+class TestWrapUpSteer:
+    """The agent must be told to finalize before the turn cap cuts it off.
+
+    Production hit a wall at exactly max_turns: the run was aborted mid-
+    exploration with no assistant text, so nothing could be parsed and the
+    whole review was discarded with zero findings.
+    """
+
+    async def _drive(self, *, max_turns: int, turns: int, with_text: bool = False, logger=None):
+        """Run an agent that emits `turns` tool-only turns. Returns stdin writes."""
+        agent = PIAgentBase(PIAgentOptions(max_turns=max_turns, name="BalooAgent"))
+
+        content = [{"type": "text", "text": '{"findings": []}'}] if with_text else []
+        events = [
+            json.dumps(
+                {"type": "response", "command": "set_thinking_level", "success": True}
+            ).encode()
+            + b"\n",
+            json.dumps({"type": "response", "command": "prompt", "success": True}).encode() + b"\n",
+        ]
+        for _ in range(turns):
+            events += [
+                json.dumps({"type": "turn_start"}).encode() + b"\n",
+                json.dumps(
+                    {
+                        "type": "message_end",
+                        "message": {
+                            "role": "assistant",
+                            "content": content,
+                            "model": "test",
+                            "usage": {"input": 1, "output": 5, "cost": {"total": 0.001}},
+                        },
+                    }
+                ).encode()
+                + b"\n",
+                json.dumps({"type": "turn_end"}).encode() + b"\n",
+            ]
+        events.append(json.dumps({"type": "agent_end"}).encode() + b"\n")
+
+        with patch("baloo.agent.pi_runtime.asyncio.create_subprocess_exec") as mock_exec:
+            proc = AsyncMock()
+            proc.returncode = None
+            proc.stdin = AsyncMock()
+            proc.stdin.write = MagicMock()
+            proc.stdin.drain = AsyncMock()
+            proc.stdout = AsyncMock(spec=asyncio.StreamReader)
+
+            event_iter = iter(events)
+
+            async def fake_readline():
+                try:
+                    return next(event_iter)
+                except StopIteration:
+                    return b""
+
+            proc.stdout.readline = fake_readline
+            proc.stderr = AsyncMock()
+            proc.kill = MagicMock()
+            proc.wait = AsyncMock()
+            mock_exec.return_value = proc
+
+            with patch.object(
+                PIAgentBase, "_retry_json", AsyncMock(return_value=(None, None, None))
+            ):
+                await agent.run_query("Review", review_logger=logger)
+
+            return [json.loads(c[0][0].decode()) for c in proc.stdin.write.call_args_list]
+
+    @pytest.mark.asyncio
+    async def test_steer_sent_before_cap_and_before_abort(self):
+        """A 30-turn agent is steered to wrap up at turn 27, then aborted at 30."""
+        cmds = await self._drive(max_turns=30, turns=30)
+        types = [c["type"] for c in cmds]
+
+        assert "steer" in types, "no wrap-up steer was sent before the cap"
+        assert types.index("steer") < types.index("abort")
+
+        steer = cmds[types.index("steer")]
+        assert "3 turn(s) left" in steer["message"]
+        assert "final JSON" in steer["message"]
+
+    @pytest.mark.asyncio
+    async def test_steer_not_repeated(self):
+        cmds = await self._drive(max_turns=30, turns=30)
+        assert [c["type"] for c in cmds].count("steer") == 1
+
+    @pytest.mark.asyncio
+    async def test_no_steer_when_agent_finishes_early(self):
+        """The common case costs nothing: a run that ends well short of the cap
+        is never nudged."""
+        cmds = await self._drive(max_turns=30, turns=12, with_text=True)
+        assert "steer" not in [c["type"] for c in cmds]
+
+    @pytest.mark.asyncio
+    async def test_no_steer_for_short_deciders(self):
+        """A 1- or 2-turn decider has no room for a nudge — reaching its cap is
+        its normal, successful exit."""
+        for cap in (1, 2, 3):
+            cmds = await self._drive(max_turns=cap, turns=cap, with_text=True)
+            assert "steer" not in [c["type"] for c in cmds], f"steered a {cap}-turn agent"
+
+
+class TestEmptyRunIsLogged:
+    """Only BalooAgent's failure reaches reviews.review_status. The fidelity and
+    documentation agents return None and log to stderr, so their aborts were
+    invisible in the database — they must land in review_logs.
+    """
+
+    def _logger(self):
+        log = AsyncMock()
+        log.agent_error = AsyncMock()
+        log.agent_completed = AsyncMock()
+        return log
+
+    @pytest.mark.asyncio
+    async def test_capped_run_with_no_output_logs_agent_error(self):
+        log = self._logger()
+        await TestWrapUpSteer()._drive(max_turns=30, turns=30, logger=log)
+
+        log.agent_error.assert_awaited_once()
+        assert log.agent_error.await_args.kwargs["error_category"] == "max_turns_reached"
+        assert "30 turn(s)" in log.agent_error.await_args.kwargs["error_message"]
+        # Cost accounting must still be recorded for a run that produced nothing.
+        log.agent_completed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_short_run_with_no_output_logs_no_output(self):
+        log = self._logger()
+        await TestWrapUpSteer()._drive(max_turns=30, turns=4, logger=log)
+
+        log.agent_error.assert_awaited_once()
+        assert log.agent_error.await_args.kwargs["error_category"] == "no_output"
+
+    @pytest.mark.asyncio
+    async def test_successful_run_logs_no_error(self):
+        log = self._logger()
+        await TestWrapUpSteer()._drive(max_turns=30, turns=4, with_text=True, logger=log)
+
+        log.agent_error.assert_not_awaited()
+        log.agent_completed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_completed_receives_cache_tokens(self):
+        log = self._logger()
+        await TestWrapUpSteer()._drive(max_turns=30, turns=4, with_text=True, logger=log)
+
+        kwargs = log.agent_completed.await_args.kwargs
+        assert "cache_read" in kwargs and "cache_write" in kwargs

--- a/tests/agent/test_runtime.py
+++ b/tests/agent/test_runtime.py
@@ -1169,11 +1169,20 @@ class TestWrapUpSteer:
     whole review was discarded with zero findings.
     """
 
-    async def _drive(self, *, max_turns: int, turns: int, with_text: bool = False, logger=None):
+    async def _drive(
+        self,
+        *,
+        max_turns: int,
+        turns: int,
+        with_text: bool = False,
+        parseable: bool = True,
+        logger=None,
+    ):
         """Run an agent that emits `turns` tool-only turns. Returns stdin writes."""
         agent = PIAgentBase(PIAgentOptions(max_turns=max_turns, name="BalooAgent"))
 
-        content = [{"type": "text", "text": '{"findings": []}'}] if with_text else []
+        text = '{"findings": []}' if parseable else "Let me check the parser next."
+        content = [{"type": "text", "text": text}] if with_text else []
         events = [
             json.dumps(
                 {"type": "response", "command": "set_thinking_level", "success": True}
@@ -1301,6 +1310,21 @@ class TestEmptyRunIsLogged:
 
         log.agent_error.assert_not_awaited()
         log.agent_completed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unparseable_text_is_not_counted_as_an_abort(self):
+        """Text present means the agent answered and the answer was malformed —
+        a JSON-quality problem, not the cap silencing it. A count of
+        max_turns_reached must mean only "cut off with nothing"."""
+        log = self._logger()
+        await TestWrapUpSteer()._drive(
+            max_turns=30, turns=30, with_text=True, parseable=False, logger=log
+        )
+
+        log.agent_error.assert_awaited_once()
+        kwargs = log.agent_error.await_args.kwargs
+        assert kwargs["error_category"] == "json_parse_failed"
+        assert "unparseable text" in kwargs["error_message"]
 
     @pytest.mark.asyncio
     async def test_agent_completed_receives_cache_tokens(self):

--- a/tests/github/test_webhook_handler.py
+++ b/tests/github/test_webhook_handler.py
@@ -99,6 +99,19 @@ def test_total_review_tokens_include_side_agent_tokens():
     assert total == 205
 
 
+def test_total_review_tokens_covers_cache_keys():
+    """The orchestrator sums input_tokens + cache_read + cache_write into
+    reviews.tokens_input — summing only input_tokens recorded ~1 per message."""
+    for key in ("cache_read_tokens", "cache_write_tokens"):
+        total = _total_review_tokens(
+            key,
+            {key: 100, "fp_verification": {key: 10}},
+            {key: 30},
+            {key: 40},
+        )
+        assert total == 180, key
+
+
 @pytest.mark.asyncio
 async def test_review_summary_uses_actionable_findings_after_resolved_thread_skip():
     """Review body counts should reflect deduped actionable findings, not raw agent output."""


### PR DESCRIPTION
## Why

Diagnosed from the production DB and `docker logs baloo-agent` on 2026-09-09. Last 2 days: **16 of 169 reviews failed, every one persisting 0 findings.** 14 `max_turns_reached`, 2 `no_output`.

Turn histogram since the current deploy:

```
turn 25 →  8 runs   turn 28 →  6 runs
turn 26 → 10 runs   turn 29 →  4 runs
turn 27 →  6 runs   turn 30 → 97 runs, 37 errors   ← the wall
```

Smooth decay to 4 runs at turn 29, then 97 pile up at exactly 30. That is censoring, not a mode. `SHORT_NAME_TIERS` already records this exact diagnosis at turn **20** — the cap was raised 20→30 to fix it. Turn 20 is now clean (8 runs, 0 errors). The wall just moved.

Not thrashing, either: duplicate-tool-call ratio is **1.44 for failed runs and 1.44 for successful ones**. Failed runs just do more work (58.8 tool calls vs ~34) and get guillotined.

## What

**1. Steer the agent to finalize before the cap.** At `max_turns - 3` it gets a PI `steer` — "you have 3 turns left, return your final JSON with what you have" — instead of meeting the cap unannounced. `steer` is PI's own mechanism for this (`rpc-types.d.ts`: *"Delivered after the current assistant turn finishes executing its tool calls, before the next LLM call"*), verified against `pi-coding-agent@0.73.1`. No new command, no session restart, no extra subprocess. The `abort` at `max_turns` stays as the hard backstop.

Costs nothing in the common case: a run finishing at turn 12 of 30 is never nudged. Agents with a cap of 3 or fewer turns (scope decider, FP verifier, thread agent) have no room and are skipped entirely.

**2. Log `agent_error` whenever a run yields no structured output.** Only BalooAgent's failure reaches `reviews.review_status`; FidelityAgent and DocumentationDriftAgent return `None` and log to stderr, so their aborts never showed up in the database — **16 recorded `agent_error` against 30 real aborts in 48h.** FidelityAgent is in fact the worst offender, not BalooAgent:

| agent | runs | cost | avg turns | hit cap | produced nothing |
|---|---|---|---|---|---|
| BalooAgent | 155 | \$114.08 | 12.0 | 18 | 14 |
| **FidelityAgent** | **59** | **\$92.75** | **20.3** | **24 (41%)** | **16** |
| DocumentationDriftAgent | 140 | \$49.87 | 6.6 | 0 | 0 |

Without this, whether change 1 worked is unmeasurable.

**3. Count cache reads/writes as the input tokens they are.** Providers report nearly all prompt volume as cache read/write and only the uncached delta as `input`, so `reviews.tokens_input` recorded ~1 per message — **31 for a 30-turn run** — and the dashboard's "Input tokens" was meaningless. `cost_usd` was always correct; `_estimate_cost` prices the cache fields properly. The per-agent split now also lands in `review_logs.metadata_json`. No schema change, no migration.

## Verification

978 passed. The 7 new positive tests fail with the source changes stashed and pass with them; 4 further tests assert absence (no steer for short deciders, no steer for an early finish, no error on a successful run) and hold either way. ruff and black clean.

## Not in this PR

Raising the cap again — that is what moved the wall from 20 to 30. If the next histogram still piles up at turn 30, the follow-up is a salvage pass behind the nudge, not a bigger number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bYcyiimsvzZWTuM2biAgb