### PR TITLE
Notify on the dashboard when a newer release is available

### DIFF
--- a/baloo/dashboard/router.py
+++ b/baloo/dashboard/router.py
@@ -28,6 +28,7 @@ from baloo.config.runtime_settings import (
 from baloo.config.settings import Settings, get_settings
 from baloo.dashboard.auth import verify_credentials
 from baloo.dashboard.queries import DashboardService
+from baloo.dashboard.upgrade import check_for_upgrade, current_version
 
 router = APIRouter(
     prefix="/dashboard",
@@ -35,6 +36,7 @@ router = APIRouter(
 )
 
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+templates.env.globals["current_version"] = current_version()
 
 # One-shot flash payloads for PRG redirects. Location only carries a server-
 # generated token so user-controlled form values never flow into the URL
@@ -433,6 +435,15 @@ def _models_in_use() -> list[dict[str, str]]:
             "source": setting_source("agent_model"),
         },
     ]
+
+
+@router.get("/upgrade-banner", response_class=HTMLResponse)
+async def upgrade_banner(request: Request):
+    return templates.TemplateResponse(
+        request=request,
+        name="partials/upgrade_banner.html",
+        context={"upgrade": await check_for_upgrade()},
+    )
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/baloo/dashboard/static/baloo.css
+++ b/baloo/dashboard/static/baloo.css
@@ -234,6 +234,15 @@ a {
   font-size: var(--text-sm);
 }
 
+.footer {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: var(--space-5);
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
 /* Cards */
 .card {
   background: var(--surface);

--- a/baloo/dashboard/templates/base.html
+++ b/baloo/dashboard/templates/base.html
@@ -33,6 +33,8 @@
   </header>
 
   <main class="main">
+    <div hx-get="/dashboard/upgrade-banner" hx-trigger="load" hx-swap="outerHTML"></div>
+
     {% block page_head %}
     {% if page_title %}
     <div class="page-head">
@@ -47,6 +49,11 @@
 
     {% block content %}{% endblock %}
   </main>
+
+  <footer class="footer">
+    Baloo v{{ current_version }} &middot; built by
+    <a href="https://bluebear.io" target="_blank" rel="noopener">BlueBear</a>
+  </footer>
 
   <script src="/dashboard-static/chart.umd.js"></script>
   <script src="/dashboard-static/charts.js"></script>

--- a/baloo/dashboard/templates/partials/upgrade_banner.html
+++ b/baloo/dashboard/templates/partials/upgrade_banner.html
@@ -1,0 +1,6 @@
+{% if upgrade %}
+<div class="alert alert--warn" style="margin-bottom: var(--space-5)">
+  Baloo-Bear <strong>{{ upgrade.version }}</strong> is available &mdash; you are on {{ current_version }}.
+  <a href="{{ upgrade.url }}" target="_blank" rel="noopener">Release notes</a>
+</div>
+{% endif %}

--- a/baloo/dashboard/upgrade.py
+++ b/baloo/dashboard/upgrade.py
@@ -42,6 +42,9 @@ def current_version() -> str:
 
 async def check_for_upgrade() -> dict[str, str] | None:
     """Return {'version', 'url'} when a newer release exists, else None."""
+    # ponytail: no lock around the fetch. A cache miss served to N concurrent
+    # requests costs N GitHub calls once per TTL, well inside the 60/hr
+    # unauthenticated budget; add an asyncio.Lock if the check ever needs auth.
     global _cache
     cached_at, cached = _cache
     if time.monotonic() - cached_at < CACHE_TTL_SECONDS:
@@ -60,7 +63,8 @@ async def check_for_upgrade() -> dict[str, str] | None:
         if current and newest and newest > current:
             latest = {"version": release["tag_name"], "url": release["html_url"]}
     except Exception as exc:  # network, rate limit, malformed payload
-        logger.debug(f"Upgrade check failed: {exc}")
+        # Cached like a real result, so this warns at most once per TTL.
+        logger.warning(f"Upgrade check failed: {exc}")
 
     _cache = (time.monotonic(), latest)
     return latest

--- a/baloo/dashboard/upgrade.py
+++ b/baloo/dashboard/upgrade.py
@@ -1,0 +1,66 @@
+"""Check GitHub for a newer official Baloo release."""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from pathlib import Path
+
+import httpx
+
+from baloo.version import VERSION
+
+logger = logging.getLogger(__name__)
+
+# /releases/latest returns the newest published, non-prerelease, non-draft
+# release, so main-branch builds and pre-releases never trigger the banner.
+LATEST_RELEASE_URL = "https://api.github.com/repos/bluebear-io/baloo-bear/releases/latest"
+CACHE_TTL_SECONDS = 3600
+
+_cache: tuple[float, dict[str, str] | None] = (0.0, None)
+
+
+def _parse(version: str) -> tuple[int, ...] | None:
+    """Turn '2.2.1' or 'v2.2.1-rc1' into (2, 2, 1); None if it isn't a version."""
+    match = re.match(r"v?(\d+(?:\.\d+)*)", version.strip())
+    return tuple(int(p) for p in match.group(1).split(".")) if match else None
+
+
+def current_version() -> str:
+    """Running version: the build-time env var, falling back to pyproject."""
+    if _parse(VERSION):
+        return VERSION
+    # ponytail: regex over pyproject beats tomllib, which is 3.11+ only.
+    try:
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        match = re.search(r'^version = "([^"]+)"', pyproject.read_text(), re.M)
+    except OSError:
+        return VERSION
+    return match.group(1) if match else VERSION
+
+
+async def check_for_upgrade() -> dict[str, str] | None:
+    """Return {'version', 'url'} when a newer release exists, else None."""
+    global _cache
+    cached_at, cached = _cache
+    if time.monotonic() - cached_at < CACHE_TTL_SECONDS:
+        return cached
+
+    latest = None
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                LATEST_RELEASE_URL, headers={"Accept": "application/vnd.github+json"}
+            )
+            response.raise_for_status()
+            release = response.json()
+        current = _parse(current_version())
+        newest = _parse(release.get("tag_name", ""))
+        if current and newest and newest > current:
+            latest = {"version": release["tag_name"], "url": release["html_url"]}
+    except Exception as exc:  # network, rate limit, malformed payload
+        logger.debug(f"Upgrade check failed: {exc}")
+
+    _cache = (time.monotonic(), latest)
+    return latest

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -9,8 +9,17 @@ Baloo includes an optional review history dashboard backed by PostgreSQL. It pro
 - **Cost tracking** — Token usage and dollar cost per review and in aggregate
 - **Fidelity scores** — When fidelity analysis is enabled
 - **Settings** — Effective runtime configuration; allowlisted agent knobs can be edited when the database is enabled
+- **Upgrade notice** — A banner when a newer Baloo-Bear release is available
 
 The dashboard follows the viewer's light/dark preference and has a theme toggle in the header. All CSS and JavaScript are served from the application itself — no CDN — so it renders correctly offline and behind a firewall.
+
+## Upgrade Notifications
+
+Every page checks the [GitHub releases API](https://github.com/bluebear-io/baloo-bear/releases) and shows a banner when a newer version is available, linking to its release notes. The footer shows the version you are running.
+
+Only published, non-prerelease releases count, so builds tracking `main` never raise the banner — nor does a build running ahead of the latest release. The check is loaded after the page renders, cached for an hour, and requires no token; if GitHub is unreachable the banner is simply omitted and the failure is logged as a warning.
+
+The running version comes from `BALOO_VERSION`, set at image build time from the release tag. Deployments that build from a source checkout fall back to the version in `pyproject.toml`.
 
 ## Requirements
 

--- a/tests/dashboard/test_upgrade.py
+++ b/tests/dashboard/test_upgrade.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from baloo.dashboard import upgrade
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    upgrade._cache = (0.0, None)
+    yield
+    upgrade._cache = (0.0, None)
+
+
+def _mock_release(monkeypatch, payload: dict) -> None:
+    class _Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, headers=None):
+            return _Response()
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: _Client())
+
+
+@pytest.mark.asyncio
+async def test_newer_release_is_reported(monkeypatch):
+    monkeypatch.setattr(upgrade, "VERSION", "2.2.1")
+    _mock_release(monkeypatch, {"tag_name": "v2.3.0", "html_url": "https://example.invalid/v2.3.0"})
+
+    assert await upgrade.check_for_upgrade() == {
+        "version": "v2.3.0",
+        "url": "https://example.invalid/v2.3.0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_same_or_older_release_is_ignored(monkeypatch):
+    monkeypatch.setattr(upgrade, "VERSION", "2.3.0")
+    _mock_release(monkeypatch, {"tag_name": "v2.3.0", "html_url": "https://example.invalid/v2.3.0"})
+
+    assert await upgrade.check_for_upgrade() is None
+
+
+@pytest.mark.asyncio
+async def test_network_failure_is_swallowed(monkeypatch):
+    def _boom(**kwargs):
+        raise httpx.ConnectError("no network")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _boom)
+
+    assert await upgrade.check_for_upgrade() is None
+
+
+def test_current_version_falls_back_to_pyproject(monkeypatch):
+    monkeypatch.setattr(upgrade, "VERSION", "dev")
+    assert upgrade._parse(upgrade.current_version()) is not None


### PR DESCRIPTION
Stacked on #231 — the design-system markup here only exists on `feat/dashboard-redesign`. Review that one first; this retargets to `main` automatically once it merges.

## What

- **Upgrade banner** on every dashboard page when the running version is behind the latest release. Uses the existing `.alert .alert--warn` component, htmx-lazy so page renders never block on GitHub.
- **Footer** with the running version and a `bluebear.io` linkback (one new `.footer` rule in `baloo.css`, tokens only, so it themes with the light/dark toggle).

## Only official releases, never main

The check hits `/releases/latest`, which by definition returns the newest **published, non-draft, non-prerelease** release — so main-branch builds and RCs can never trigger the banner. Versions are compared as int tuples, so a build running *ahead* of the latest release (main) stays quiet too.

## Version resolution

1. `BALOO_VERSION` — set at Docker build from the release tag (`deploy.yml`).
2. `pyproject.toml` fallback — for the `git pull + compose build` host and local dev, where `BALOO_VERSION` is `dev`. Regex rather than `tomllib`, which is 3.11+ and we support 3.10.

## Failure behaviour

Network errors, rate limits and malformed payloads are swallowed to "no banner" and cached for the hour like a normal result, so an offline deployment does not retry on every page load. Unauthenticated GitHub is 60 req/hr/IP; this is at most 1/hr/worker.

## Testing

`tests/dashboard/test_upgrade.py` covers newer / same-or-older / network-failure / pyproject-fallback. Full dashboard suite passes (57), ruff + black clean. Also verified live against the real API — running as 2.0.0 renders the v2.3.0 banner; running as 2.3.0 renders nothing.

## Not included

No settings toggle to disable the check and no persisted cache — worth adding if an air-gapped deploy or multi-worker rate limiting actually bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9x9qs3YQYLHjAyEKkrS2L