### PR TITLE
Fix blank dashboard charts

### DIFF
--- a/baloo/dashboard/templates/base.html
+++ b/baloo/dashboard/templates/base.html
@@ -13,6 +13,9 @@
   </script>
   <link rel="stylesheet" href="/dashboard-static/baloo.css">
   <script src="/dashboard-static/htmx.min.js" defer></script>
+  <!-- Loaded in <head> on purpose: page templates call BalooCharts from inline scripts inside the content block. -->
+  <script src="/dashboard-static/chart.umd.js"></script>
+  <script src="/dashboard-static/charts.js"></script>
 </head>
 <body>
   <header class="topbar">
@@ -55,8 +58,6 @@
     <a href="https://bluebear.io" target="_blank" rel="noopener">BlueBear</a>
   </footer>
 
-  <script src="/dashboard-static/chart.umd.js"></script>
-  <script src="/dashboard-static/charts.js"></script>
   <script>
     (function () {
       var root = document.documentElement;

--- a/tests/dashboard/test_render_smoke.py
+++ b/tests/dashboard/test_render_smoke.py
@@ -128,6 +128,11 @@ def test_route_renders(path: str, method: str, payload: dict) -> None:
 
     assert response.status_code == 200, response.text
     assert "<html" in response.text
+    # Inline page scripts call BalooCharts synchronously, so the bridge must be
+    # loaded earlier in the document or every chart silently stays blank.
+    call = response.text.find("BalooCharts.make")
+    if call != -1:
+        assert response.text.find("charts.js") < call, "charts.js loads after BalooCharts.make"
 
 
 def test_review_detail_renders() -> None:

--- a/tests/dashboard/test_render_smoke.py
+++ b/tests/dashboard/test_render_smoke.py
@@ -132,7 +132,7 @@ def test_route_renders(path: str, method: str, payload: dict) -> None:
     # loaded earlier in the document or every chart silently stays blank.
     call = response.text.find("BalooCharts.make")
     if call != -1:
-        assert response.text.find("charts.js") < call, "charts.js loads after BalooCharts.make"
+        assert response.text.index("charts.js") < call, "charts.js loads after BalooCharts.make"
 
 
 def test_review_detail_renders() -> None:


### PR DESCRIPTION
## Summary
- Every chart on Overview, Analytics and Outcomes rendered blank in production. Console: `ReferenceError: BalooCharts is not defined`.
- Page templates call `BalooCharts.make` from inline scripts inside the content block, but `base.html` loaded `chart.umd.js` and `charts.js` at the end of the body, after that block.
- Move the two script tags into `<head>` (neither touches the DOM at load) and extend the route smoke test to assert `charts.js` appears before any `BalooCharts.make` call.

## Test plan
- [x] `uv run pytest` — 1044 passed
- [x] New assertion fails on `main` for all three chart pages, passes with the fix
- [ ] After deploy, confirm charts render on `/dashboard/outcomes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHQgVe8FVeZdd5CJpyZK8c